### PR TITLE
Beautiful cli docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY compiler/cli/build/bin/linuxX64/releaseExecutable/cli.kexe /app
 
 WORKDIR /app
 
-CMD /app/cli.kexe $(pwd)/types Java,Kotlin,Scala,TypeScript
+CMD /app/cli.kexe -l Java -l Kotlin -l Scala -l TypeScript $(pwd)/types

--- a/README.md
+++ b/README.md
@@ -21,17 +21,29 @@ Instructions on how to install different components
 
 ## Cli
 
-### Linux
+```
+Usage: wirespec options_list
+Arguments: 
+    input -> Input file { String }
+Options: 
+    --output, -o -> Output directory { String }
+    --languages, -l [Kotlin] -> Language type { Value should be one of [Java, Kotlin, Scala, TypeScript] }
+    --packageName, -p [community.flock.wirespec.generated] -> Package name { String }
+    --help, -h -> Usage info 
+```
+
+### Install
+#### Linux
 ```
 curl -L https://github.com/flock-community/wirespec/releases/latest/download/linuxX64.kexe -o wirespec
 ```
 
-### macOS
+#### macOS
 ```
 curl -L https://github.com/flock-community/wirespec/releases/latest/download/macosX64.kexe -o wirespec
 ```
 
-### macOS Arm
+#### macOS Arm
 ```
 curl -L https://github.com/flock-community/wirespec/releases/latest/download/macosArm64.kexe -o wirespec
 ```

--- a/compiler/cli/build.gradle.kts
+++ b/compiler/cli/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("multiplatform")
     kotlin("jvm") apply false
     id("com.github.johnrengelman.shadow")
+    id("com.goncalossilva.resources") version "0.3.2"
 }
 
 group = "${Settings.groupId}.compiler"
@@ -45,6 +46,14 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":compiler:core"))
+                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.5")
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test-junit"))
             }
         }
         val desktopMain by creating {

--- a/compiler/cli/src/commonMain/kotlin/community/flock/wirespec/compiler/cli/Main.kt
+++ b/compiler/cli/src/commonMain/kotlin/community/flock/wirespec/compiler/cli/Main.kt
@@ -46,12 +46,10 @@ private fun Logger.from(s: String): Language? = Language.valueOf(s).also {
 
 fun main(args: Array<String>) {
 
-    val l = Language.values().map { it.name }.mapNotNull(logger::from)
-
     val parser = ArgParser("wirespec")
     val input by parser.argument(ArgType.String, description = "Input file")
     val output by parser.option(ArgType.String, shortName = "o", description = "Output directory")
-    val languages by parser.option(ArgType.Choice(l, { Language.valueOf(it) ?: error("Language not found") }), shortName = "l", description = "Language type").default(Language.Jvm.Kotlin).multiple()
+    val languages by parser.option(ArgType.Choice(Language.values().map { it.name }.mapNotNull(logger::from), { Language.valueOf(it) ?: error("Language not found") }), shortName = "l", description = "Language type").default(Language.Jvm.Kotlin).multiple()
     val packageName by parser.option(ArgType.String, shortName = "p", description = "Package name").default(DEFAULT_PACKAGE_NAME)
 
     parser.parse(args)

--- a/compiler/cli/src/commonMain/kotlin/community/flock/wirespec/compiler/cli/Main.kt
+++ b/compiler/cli/src/commonMain/kotlin/community/flock/wirespec/compiler/cli/Main.kt
@@ -22,6 +22,7 @@ import community.flock.wirespec.compiler.core.emit.TypeScriptEmitter
 import community.flock.wirespec.compiler.core.emit.common.DEFAULT_PACKAGE_NAME
 import community.flock.wirespec.compiler.utils.Logger
 import community.flock.wirespec.compiler.utils.getEnvVar
+import community.flock.wirespec.compiler.utils.orNull
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
@@ -46,13 +47,21 @@ private fun Logger.from(s: String): Language? = Language.valueOf(s).also {
 
 fun main(args: Array<String>) {
 
+    val a = if (args.isEmpty()) {
+        (0..20)
+            .mapNotNull { args.orNull(it) }
+            .toTypedArray()
+    } else {
+        args
+    }
+
     val parser = ArgParser("wirespec")
     val input by parser.argument(ArgType.String, description = "Input file")
     val output by parser.option(ArgType.String, shortName = "o", description = "Output directory")
     val languages by parser.option(ArgType.Choice(Language.values().map { it.name }.mapNotNull(logger::from), { Language.valueOf(it) ?: error("Language not found") }), shortName = "l", description = "Language type").default(Language.Jvm.Kotlin).multiple()
     val packageName by parser.option(ArgType.String, shortName = "p", description = "Package name").default(DEFAULT_PACKAGE_NAME)
 
-    parser.parse(args)
+    parser.parse(a)
 
     compile(languages.toSet(), input, output, packageName)
 

--- a/compiler/cli/src/commonMain/kotlin/community/flock/wirespec/compiler/cli/Main.kt
+++ b/compiler/cli/src/commonMain/kotlin/community/flock/wirespec/compiler/cli/Main.kt
@@ -46,14 +46,13 @@ private fun Logger.from(s: String): Language? = Language.valueOf(s).also {
 }
 
 fun main(args: Array<String>) {
+    (0..20)
+        .mapNotNull { args.orNull(it) }
+        .toTypedArray()
+        .let{ cli(it) }
+}
 
-    val a = if (args.isEmpty()) {
-        (0..20)
-            .mapNotNull { args.orNull(it) }
-            .toTypedArray()
-    } else {
-        args
-    }
+fun cli(args: Array<String>) {
 
     val parser = ArgParser("wirespec")
     val input by parser.argument(ArgType.String, description = "Input file")
@@ -61,7 +60,7 @@ fun main(args: Array<String>) {
     val languages by parser.option(ArgType.Choice(Language.values().map { it.name }.mapNotNull(logger::from), { Language.valueOf(it) ?: error("Language not found") }), shortName = "l", description = "Language type").default(Language.Jvm.Kotlin).multiple()
     val packageName by parser.option(ArgType.String, shortName = "p", description = "Package name").default(DEFAULT_PACKAGE_NAME)
 
-    parser.parse(a)
+    parser.parse(args)
 
     compile(languages.toSet(), input, output, packageName)
 

--- a/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
+++ b/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
@@ -1,15 +1,21 @@
 package community.flock.wirespec.compiler.cli
 
-import community.flock.wirespec.compiler.cli.io.Directory
-import kotlin.random.Random
-import kotlin.test.Ignore
+import community.flock.wirespec.compiler.cli.io.Extension
+import community.flock.wirespec.compiler.cli.io.File
+import community.flock.wirespec.compiler.cli.io.FullFilePath
+import community.flock.wirespec.compiler.core.emit.common.DEFAULT_PACKAGE_NAME
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 
 class CliTest {
 
     fun outputDir() = "/tmp/${getRandomString(8)}"
     val inputDir = "src/commonTest/resources"
+
+    class TestFile(val directory: String, val fileName: String, val extension: Extension) : File(FullFilePath(directory, fileName, extension)) {
+        override fun copy(fileName: String) = TestFile(directory, fileName, extension)
+    }
 
     @Test
     fun testMainHelp() {
@@ -18,15 +24,45 @@ class CliTest {
 
     @Test
     fun testMainOutput() {
-        main(arrayOf(inputDir, "-o", outputDir()))
+        val packageDir = DEFAULT_PACKAGE_NAME.replace(".", "/")
+        val outputDir = outputDir()
+        main(arrayOf(inputDir, "-o", outputDir))
+
+        val kotlin = TestFile("$outputDir/$packageDir", "Bla", Extension.Kotlin).read()
+
+        val expected = """
+            package community.flock.wirespec.generated
+
+            data class Bla(
+              val yolo: String
+            )
+            
+        """.trimIndent()
+        assertEquals(expected, kotlin)
     }
 
     @Test
     fun testMainJavaPackage() {
-        main(arrayOf(inputDir, "-o", outputDir(), "-l",  "Kotlin", "-l",  "Java", "-p", "community.flock.next"))
+        val packageName = "community.flock.next"
+        val packageDir = packageName.replace(".", "/")
+        val outputDir = outputDir()
+        main(arrayOf(inputDir, "-o", outputDir, "-l", "Kotlin", "-l", "Java", "-p", "community.flock.next"))
+
+        val java = TestFile("$outputDir/$packageDir", "Bla", Extension.Java).read()
+
+        val expected = """
+            package community.flock.next;
+
+            public record Bla(
+              String yolo
+            ) {};
+            
+            
+        """.trimIndent()
+        assertEquals(expected, java)
     }
 
-    private fun getRandomString(length: Int) : String {
+    private fun getRandomString(length: Int): String {
         val allowedChars = ('A'..'Z') + ('a'..'z') + ('0'..'9')
         return (1..length)
             .map { allowedChars.random() }

--- a/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
+++ b/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
@@ -1,0 +1,36 @@
+package community.flock.wirespec.compiler.cli
+
+import community.flock.wirespec.compiler.cli.io.Directory
+import kotlin.random.Random
+import kotlin.test.Ignore
+import kotlin.test.Test
+
+
+class CliTest {
+
+    fun outputDir() = "/tmp/${getRandomString(8)}"
+    val inputDir = "src/commonTest/resources"
+
+    @Test
+    fun testMainHelp() {
+        main(arrayOf("--help"))
+    }
+
+    @Test
+    fun testMainOutput() {
+        main(arrayOf(inputDir, "-o", outputDir()))
+    }
+
+    @Test
+    fun testMainJavaPackage() {
+        main(arrayOf(inputDir, "-o", outputDir(), "-l",  "Kotlin", "-l",  "Java", "-p", "community.flock.next"))
+    }
+
+    private fun getRandomString(length: Int) : String {
+        val allowedChars = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+        return (1..length)
+            .map { allowedChars.random() }
+            .joinToString("")
+    }
+
+}

--- a/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
+++ b/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
@@ -5,6 +5,7 @@ import community.flock.wirespec.compiler.cli.io.File
 import community.flock.wirespec.compiler.cli.io.FullFilePath
 import community.flock.wirespec.compiler.core.emit.common.DEFAULT_PACKAGE_NAME
 import kotlin.test.Test
+import kotlin.test.Ignore
 import kotlin.test.assertEquals
 
 
@@ -18,6 +19,7 @@ class CliTest {
     }
 
     @Test
+    @Ignore
     fun testMainHelp() {
         main(arrayOf("--help"))
     }

--- a/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
+++ b/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 
 class CliTest {
 
-    fun outputDir() = "/tmp/${getRandomString(8)}"
+    fun outputDir() = "../../tmp/${getRandomString(8)}"
     val inputDir = "src/commonTest/resources"
 
     class TestFile(val directory: String, val fileName: String, val extension: Extension) : File(FullFilePath(directory, fileName, extension)) {

--- a/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
+++ b/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/MainTest.kt
@@ -20,15 +20,15 @@ class CliTest {
 
     @Test
     @Ignore
-    fun testMainHelp() {
-        main(arrayOf("--help"))
+    fun testCliHelp() {
+        cli(arrayOf("--help"))
     }
 
     @Test
-    fun testMainOutput() {
+    fun testCliOutput() {
         val packageDir = DEFAULT_PACKAGE_NAME.replace(".", "/")
         val outputDir = outputDir()
-        main(arrayOf(inputDir, "-o", outputDir))
+        cli(arrayOf(inputDir, "-o", outputDir))
 
         val kotlin = TestFile("$outputDir/$packageDir", "Bla", Extension.Kotlin).read()
 
@@ -44,11 +44,11 @@ class CliTest {
     }
 
     @Test
-    fun testMainJavaPackage() {
+    fun testCliJavaPackage() {
         val packageName = "community.flock.next"
         val packageDir = packageName.replace(".", "/")
         val outputDir = outputDir()
-        main(arrayOf(inputDir, "-o", outputDir, "-l", "Kotlin", "-l", "Java", "-p", "community.flock.next"))
+        cli(arrayOf(inputDir, "-o", outputDir, "-l", "Kotlin", "-l", "Java", "-p", "community.flock.next"))
 
         val java = TestFile("$outputDir/$packageDir", "Bla", Extension.Java).read()
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,7 @@
 
 artifactName="cli"
 version="0.0.0-SNAPSHOT"
-languages="Java,Kotlin,Scala,TypeScript"
+languages="-l Java -l Kotlin -l Scala -l TypeScript"
 
 buildNothing=false
 
@@ -19,7 +19,7 @@ fi
 
 if [[ $WIRESPEC_BUILD_ALL = true || $WIRESPEC_BUILD_MAC = true ]]; then
   echo "Test macOS artifact"
-  ./compiler/$artifactName/build/bin/$macosArch/releaseExecutable/$artifactName.kexe "$(pwd)"/types $languages
+  ./compiler/$artifactName/build/bin/$macosArch/releaseExecutable/$artifactName.kexe $languages "$(pwd)"/types
 fi
 
 if [[ $WIRESPEC_BUILD_ALL = true || $WIRESPEC_BUILD_LINUX = true || $buildNothing = true ]]; then
@@ -28,7 +28,7 @@ if [[ $WIRESPEC_BUILD_ALL = true || $WIRESPEC_BUILD_LINUX = true || $buildNothin
 fi
 
 echo "Test Node.js artifact"
-node build/js/packages/wirespec-$artifactName/kotlin/wirespec-$artifactName.js "$(pwd)"/types $languages
+node build/js/packages/wirespec-$artifactName/kotlin/wirespec-$artifactName.js $languages "$(pwd)"/types
 
 echo "Test JVM artifact"
-java -jar compiler/$artifactName/build/libs/$artifactName-$version-all.jar "$(pwd)"/types $languages
+java -jar compiler/$artifactName/build/libs/$artifactName-$version-all.jar $languages "$(pwd)"/types

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
when you run the cli without arguments you get the following documentation:

```
Usage: wirespec options_list
Arguments: 
    input -> Input file { String }
Options: 
    --output, -o -> Output directory { String }
    --languages, -l [Kotlin] -> Language type { Value should be one of [Java, Kotlin, Scala, TypeScript] }
    --packageName, -p [community.flock.wirespec.generated] -> Package name { String }
    --help, -h -> Usage info 
```