### PR TITLE
Add strict mode to the cli and change openapi into format

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,14 @@ Usage: wirespec options_list
 Arguments: 
     input -> Input file { String }
 Options: 
+    --debug, -d [false] -> Debug mode 
     --output, -o -> Output directory { String }
-    --languages, -l [Kotlin] -> Language type { Value should be one of [Java, Kotlin, Scala, TypeScript] }
+    --language, -l [Kotlin] -> Language type { Value should be one of [Java, Kotlin, Scala, TypeScript, Wirespec, OpenApiV2, OpenApiV3] }
+    --format, -f [Wirespec] -> Input format { Value should be one of [wirespec, openapiv2, openapiv3] }
     --packageName, -p [community.flock.wirespec.generated] -> Package name { String }
+    --strict, -s [true] -> Strict mode 
     --help, -h -> Usage info 
+
 ```
 
 ### Install
@@ -156,6 +160,9 @@ It is also possible to create your custom emitter and run with the plugin[here](
                         <configuration>
                             <input>${project.basedir}/src/main/wirespec</input>
                             <output>${project.build.directory}/generated-sources</output>
+                            <languages>
+                                <language>Kotlin</language>
+                            </languages>
                         </configuration>
                     </execution>
                     <execution>
@@ -166,6 +173,9 @@ It is also possible to create your custom emitter and run with the plugin[here](
                         <configuration>
                             <input>${project.basedir}/src/main/wirespec</input>
                             <output>${project.basedir}/src/main/frontend/generated</output>
+                            <languages>
+                                <language>TypeScript</language>
+                            </languages>
                         </configuration>
                     </execution>
                     <execution>

--- a/examples/spring-boot-openapi-maven-plugin/pom.xml
+++ b/examples/spring-boot-openapi-maven-plugin/pom.xml
@@ -85,7 +85,7 @@
                             <input>${project.basedir}/src/main/openapi/petstorev2.json</input>
                             <output>${project.build.directory}/generated-sources</output>
                             <packageName>community.flock.wirespec.generated.kotlin.v2</packageName>
-                            <openapi>v2</openapi>
+                            <format>OpenApiV2</format>
                             <languages>
                                 <language>Kotlin</language>
                             </languages>
@@ -101,7 +101,7 @@
                             <input>${project.basedir}/src/main/openapi/petstorev3.json</input>
                             <output>${project.build.directory}/generated-sources</output>
                             <packageName>community.flock.wirespec.generated.kotlin.v3</packageName>
-                            <openapi>v3</openapi>
+                            <format>OpenApiV3</format>
                             <languages>
                                 <language>Kotlin</language>
                             </languages>
@@ -117,7 +117,7 @@
                             <input>${project.basedir}/src/main/openapi/petstorev2.json</input>
                             <output>${project.build.directory}/generated-sources</output>
                             <packageName>community.flock.wirespec.generated.java.v2</packageName>
-                            <openapi>v2</openapi>
+                            <format>OpenApiV2</format>
                             <languages>
                                 <language>Java</language>
                             </languages>
@@ -133,7 +133,7 @@
                             <input>${project.basedir}/src/main/openapi/petstorev3.json</input>
                             <output>${project.build.directory}/generated-sources</output>
                             <packageName>community.flock.wirespec.generated.java.v3</packageName>
-                            <openapi>v3</openapi>
+                            <format>OpenApiV3</format>
                             <languages>
                                 <language>Java</language>
                             </languages>

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,7 +19,7 @@ fi
 if [[ $WIRESPEC_BUILD_ALL = true || $WIRESPEC_BUILD_MAC = true ]]; then
   echo "Test macOS artifact"
   ./src/compiler/$artifactName/build/bin/$macosArch/releaseExecutable/$artifactName.kexe -l Java -l Kotlin -l Scala -l TypeScript -l Wirespec -p "community.flock.wirespec.generated" "$(pwd)"/types
-  ./src/compiler/$artifactName/build/bin/$macosArch/releaseExecutable/$artifactName.kexe -l Java -l Kotlin -l Scala -l TypeScript -l Wirespec -p "community.flock.openapi.generated" -a v2 "$(pwd)"/types/petstore.json
+  ./src/compiler/$artifactName/build/bin/$macosArch/releaseExecutable/$artifactName.kexe -l Java -l Kotlin -l Scala -l TypeScript -l Wirespec -p "community.flock.openapi.generated" -f openapiv2 "$(pwd)"/types/petstore.json
 fi
 
 if [[ $WIRESPEC_BUILD_ALL = true || $WIRESPEC_BUILD_LINUX = true ]]; then
@@ -30,9 +30,9 @@ fi
 if [[ $WIRESPEC_BUILD_ALL = true || $WIRESPEC_BUILD_JVM = true || $buildNothing = true ]]; then
   echo "Test JVM artifact"
   java -jar src/compiler/$artifactName/build/libs/$artifactName-$version-all.jar -l Java -l Kotlin -l Scala -l TypeScript -l Wirespec -p "community.flock.wirespec.generated" "$(pwd)"/types
-  java -jar src/compiler/$artifactName/build/libs/$artifactName-$version-all.jar -l Java -l Kotlin -l Scala -l TypeScript -l Wirespec -p "community.flock.openapi.generated" -a v2 "$(pwd)"/types/petstore.json
+  java -jar src/compiler/$artifactName/build/libs/$artifactName-$version-all.jar -l Java -l Kotlin -l Scala -l TypeScript -l Wirespec -p "community.flock.openapi.generated" -f openapiv2 "$(pwd)"/types/petstore.json
 fi
 
 echo "Test Node.js artifact"
 node build/js/packages/wirespec-src-compiler-$artifactName/kotlin/wirespec-src-compiler-$artifactName.js -l Java -l Kotlin -l Scala -l TypeScript -l Wirespec -p "community.flock.wirespec.generated" "$(pwd)"/types
-node build/js/packages/wirespec-src-compiler-$artifactName/kotlin/wirespec-src-compiler-$artifactName.js -l Java -l Kotlin -l Scala -l TypeScript -l Wirespec -p "community.flock.openapi.generated" -a v2 "$(pwd)"/types/petstore.json
+node build/js/packages/wirespec-src-compiler-$artifactName/kotlin/wirespec-src-compiler-$artifactName.js -l Java -l Kotlin -l Scala -l TypeScript -l Wirespec -p "community.flock.openapi.generated" -f openapiv2 "$(pwd)"/types/petstore.json

--- a/src/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/CliTest.kt
+++ b/src/compiler/cli/src/commonTest/kotlin/community/flock/wirespec/compiler/cli/CliTest.kt
@@ -77,7 +77,7 @@ class CliTest {
         val input = "${inputDir}/openapi/petstore.json"
         val output = outputDir()
 
-        cli(arrayOf(input, "-o", output, "-l", "Kotlin", "-p", "community.flock.openapi", "-a", "v2"))
+        cli(arrayOf(input, "-o", output, "-l", "Kotlin", "-p", "community.flock.openapi", "-f", "openapiv2"))
 
         val path = FullFilePath("$output/$packageDir", "Petstore")
         val file = KotlinFile(path).read()
@@ -103,7 +103,7 @@ class CliTest {
         val input = "${inputDir}/openapi/keto.json"
         val output = outputDir()
 
-        cli(arrayOf(input, "-o", output, "-l", "Kotlin", "-p", "community.flock.openapi", "-a", "v3"))
+        cli(arrayOf(input, "-o", output, "-l", "Kotlin", "-p", "community.flock.openapi", "-f", "openapiv3"))
 
         val path = FullFilePath("$output/$packageDir", "Keto")
         val file = KotlinFile(path).read()
@@ -128,7 +128,7 @@ class CliTest {
         val input = "${inputDir}/openapi/petstore.json"
         val output = outputDir()
 
-        cli(arrayOf(input, "-o", output, "-l", "TypeScript", "-p", "community.flock.openapi", "-a", "v2"))
+        cli(arrayOf(input, "-o", output, "-l", "TypeScript", "-p", "community.flock.openapi", "-f", "openapiv2"))
 
         val path = FullFilePath("$output/$packageDir", "Petstore")
         val file = TypeScriptFile(path).read()
@@ -155,7 +155,7 @@ class CliTest {
         val output = outputDir()
 
         cli(arrayOf(input, "-o", output, "-l", "OpenApiV2", "-p", packageDir))
-        cli(arrayOf("${output}/$packageDir/Todo.json", "-o", output, "-l", "Wirespec", "-p", packageDir, "-a", "v2"))
+        cli(arrayOf("${output}/$packageDir/Todo.json", "-o", output, "-l", "Wirespec", "-p", packageDir, "-f", "openapiv2"))
 
         val pathWs = FullFilePath("$output/$packageDir", "Todo", Extension.Wirespec)
         val fileWs = WirespecFile(pathWs).read()

--- a/src/compiler/core/build.gradle.kts
+++ b/src/compiler/core/build.gradle.kts
@@ -37,7 +37,7 @@ kotlin {
             dependencies {
                 api(ARROW_CORE)
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
-                implementation("community.flock.kotlinx.openapi.bindings:kotlin-openapi-bindings:0.0.19")
+                implementation("community.flock.kotlinx.openapi.bindings:kotlin-openapi-bindings:0.0.24")
             }
         }
         commonTest {

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/WireSpecException.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/WireSpecException.kt
@@ -6,6 +6,7 @@ import kotlin.reflect.KClass
 
 sealed class WirespecException(message: String, val coordinates: Token.Coordinates) : RuntimeException(message) {
 
+    class OpenApiParse(message: String): WirespecException(message, Token.Coordinates())
     sealed class IOException(message: String) : WirespecException(message, Token.Coordinates()) {
         class FileReadException(message: String) : IOException(message)
         class FileWriteException(message: String) : IOException(message)

--- a/src/openapi/build.gradle.kts
+++ b/src/openapi/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
             dependencies {
                 implementation(project(":src:compiler:core"))
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
-                implementation("community.flock.kotlinx.openapi.bindings:kotlin-openapi-bindings:0.0.19")
+                implementation("community.flock.kotlinx.openapi.bindings:kotlin-openapi-bindings:0.0.24")
             }
         }
         commonTest {

--- a/src/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v2/OpenApiParser.kt
+++ b/src/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v2/OpenApiParser.kt
@@ -2,6 +2,7 @@ package community.flock.wirespec.openapi.v2
 
 import arrow.core.filterIsInstance
 import community.flock.kotlinx.openapi.bindings.v2.BooleanObject
+import community.flock.kotlinx.openapi.bindings.v2.HeaderObject
 import community.flock.kotlinx.openapi.bindings.v2.HeaderOrReferenceObject
 import community.flock.kotlinx.openapi.bindings.v2.OpenAPI
 import community.flock.kotlinx.openapi.bindings.v2.OperationObject
@@ -18,7 +19,6 @@ import community.flock.kotlinx.openapi.bindings.v2.SchemaOrReferenceObject
 import community.flock.kotlinx.openapi.bindings.v2.SchemaOrReferenceOrBooleanObject
 import community.flock.kotlinx.openapi.bindings.v2.StatusCode
 import community.flock.kotlinx.openapi.bindings.v2.SwaggerObject
-import community.flock.kotlinx.openapi.bindings.v2.HeaderObject
 import community.flock.wirespec.compiler.core.parse.nodes.Definition
 import community.flock.wirespec.compiler.core.parse.nodes.Endpoint
 import community.flock.wirespec.compiler.core.parse.nodes.Enum
@@ -26,14 +26,16 @@ import community.flock.wirespec.compiler.core.parse.nodes.Type
 import community.flock.wirespec.compiler.core.parse.nodes.Type.Shape.Field
 import community.flock.wirespec.compiler.core.parse.nodes.Type.Shape.Field.Reference
 import community.flock.wirespec.openapi.Common.className
+import kotlinx.serialization.json.Json
 import community.flock.kotlinx.openapi.bindings.v2.Type as OpenapiType
 
 class OpenApiParser(private val openApi: SwaggerObject) {
 
     companion object {
-        fun parse(json: String): List<Definition> = OpenAPI
-            .decodeFromString(json)
-            .let { OpenApiParser(it).parse() }
+        fun parse(json: String, ignoreUnknown: Boolean = false): List<Definition> =
+            OpenAPI(json = Json { prettyPrint = true; ignoreUnknownKeys = ignoreUnknown })
+                .decodeFromString(json)
+                .let { OpenApiParser(it).parse() }
 
         fun parse(openApi: SwaggerObject) = OpenApiParser(openApi).parse()
     }

--- a/src/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenApiParser.kt
+++ b/src/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenApiParser.kt
@@ -26,13 +26,14 @@ import community.flock.wirespec.compiler.core.parse.nodes.Type
 import community.flock.wirespec.compiler.core.parse.nodes.Type.Shape.Field
 import community.flock.wirespec.compiler.core.parse.nodes.Type.Shape.Field.Reference
 import community.flock.wirespec.openapi.Common.className
+import kotlinx.serialization.json.Json
 import community.flock.kotlinx.openapi.bindings.v3.Type as OpenapiType
 
 class OpenApiParser(private val openApi: OpenAPIObject) {
 
     companion object {
-        fun parse(json: String): List<Definition> =
-            OpenAPI
+        fun parse(json: String, strict: Boolean = false): List<Definition> =
+            OpenAPI(json = Json { prettyPrint = true; ignoreUnknownKeys = strict })
                 .decodeFromString(json)
                 .let { OpenApiParser(it).parse() }
 


### PR DESCRIPTION
Refactor the cli and maven plugin for the following:
- add flag for strict mode
- change openapi flag to format

The second change caters for extending for different formats.

```
Usage: wirespec options_list
Arguments: 
    input -> Input file { String }
Options: 
    --debug, -d [false] -> Debug mode 
    --output, -o -> Output directory { String }
    --language, -l [Kotlin] -> Language type { Value should be one of [Java, Kotlin, Scala, TypeScript, Wirespec, OpenApiV2, OpenApiV3] }
    --format, -f [Wirespec] -> Input format { Value should be one of [wirespec, openapiv2, openapiv3] }
    --packageName, -p [community.flock.wirespec.generated] -> Package name { String }
    --strict, -s [true] -> Strict mode 
    --help, -h -> Usage info 
```