### PR TITLE
feat: Add `_` character to CustomType to allow for enums and other types in (screaming) snake case

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
@@ -59,7 +59,7 @@ object Wirespec : LanguageSpec {
         Regex("^/.*/g") to CustomRegex,
         Regex("^[1-5][0-9][0-9]") to StatusCode,
         Regex("^[a-z][a-zA-Z]*") to CustomValue,
-        Regex("^[A-Z][a-zA-Z]*") to CustomType,
+        Regex("^[A-Z][a-zA-Z_]*") to CustomType,
         Regex("^/[a-z]+") to Path,
         Regex("^/") to ForwardSlash,
         Regex("^.") to Invalid // Catch all regular expression if none of the above matched

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileEnumTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileEnumTest.kt
@@ -17,7 +17,7 @@ class CompileEnumTest {
     private val compiler = compile(
         """
         enum MyAwesomeEnum {
-          ONE, Two
+          ONE, Two, THREE_MORE
         }
         """.trimIndent()
     )
@@ -29,7 +29,8 @@ class CompileEnumTest {
             
             enum class MyAwesomeEnum (val label: String){
               ONE("ONE"),
-              Two("Two");
+              Two("Two"),
+              THREE_MORE("THREE_MORE");
             
               override fun toString(): String {
                 return label
@@ -48,7 +49,8 @@ class CompileEnumTest {
             
             public enum MyAwesomeEnum {
               ONE("ONE"),
-              Two("Two");
+              Two("Two"),
+              THREE_MORE("THREE_MORE");
               public final String label;
               MyAwesomeEnum(String label) {
                 this.label = label;
@@ -73,6 +75,7 @@ class CompileEnumTest {
             object MyAwesomeEnum {
               final case object ONE extends MyAwesomeEnum(label = "ONE")
               final case object TWO extends MyAwesomeEnum(label = "Two")
+              final case object THREE_MORE extends MyAwesomeEnum(label = "THREE_MORE")
             }
 
         """.trimIndent()
@@ -83,7 +86,7 @@ class CompileEnumTest {
     @Test
     fun testEnumTypeScript() {
         val ts = """
-            type MyAwesomeEnum = "ONE" | "Two"
+            type MyAwesomeEnum = "ONE" | "Two" | "THREE_MORE"
 
         """.trimIndent()
 
@@ -94,7 +97,7 @@ class CompileEnumTest {
     fun testEnumWirespec() {
         val wirespec = """
             enum MyAwesomeEnum {
-              ONE, Two
+              ONE, Two, THREE_MORE
             }
         
         """.trimIndent()


### PR DESCRIPTION

The following example did not work for me:

```ws
type Todo {
    id:String,
    todoType: TodoType,
    description: String
}

enum TodoType {
    HOLIDAY,
    PAID_PARENTAL_LEAVE    
}

```

I strongly believe enums typed in in SCREAMING_SNAKE_CASE is a commonly used convention.