### PR TITLE
feat: Update refined type for typescript with type guard validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,30 @@ Wirespec can read and convert OpenApiSpecification (OAS) files.
 
 Wirespec knows four definitions: `refined`, `enum`, `type`, `endpoint`.
 
-```
+### Refined
+```wirespec
 refined DEFINITION /REGEX/g
+```
 
+### Enum
+```wirespec
 enum DEFINITION {
     ENTRY, ENTRY, ...
 }
+```
 
+### Type
+```wirespec
 type DEFINITION {
     IDENTIFIER: REFERENCE
 }
+```
 
+### Endpoint
+```wirespec
 endpoint DEFINITION METHOD [INPUT_REFERENCE] PATH [? QUERY] [# HEADER] -> {
     STATUS -> REFERENCE
 }
-
 ```
 
 ## Example

--- a/examples/spring-boot-gradle-plugin/src/main/wirespec/todos.ws
+++ b/examples/spring-boot-gradle-plugin/src/main/wirespec/todos.ws
@@ -1,4 +1,4 @@
-refined TodoId /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/g
+refined TodoId /^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$/g
 
 type Todo {
     id: TodoId,

--- a/examples/spring-boot-maven-plugin/src/main/wirespec/todos.ws
+++ b/examples/spring-boot-maven-plugin/src/main/wirespec/todos.ws
@@ -1,4 +1,4 @@
-refined TodoId /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/g
+refined TodoId /^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$/g
 
 type Todo {
     id: TodoId,

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/TypeScriptEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/TypeScriptEmitter.kt
@@ -78,16 +78,15 @@ class TypeScriptEmitter(logger: Logger = noLogger) : AbstractEmitter(logger) {
     }
 
     override fun Refined.emit() = withLogging(logger) {
-        """export type ${name.sanitizeSymbol()} = {
-            |${SPACER}value: string
-            |}
-            |const validate$name = (type: $name) => (${validator.emit()}).test(type.value);
-            |
+        """export type ${name.sanitizeSymbol()} = string;
+            |const regExp$name = ${validator.emit()};
+            |export const validate$name = (value: string): value is ${name.sanitizeSymbol()} => 
+            |${SPACER}regExp$name.test(value);
             |""".trimMargin()
     }
 
     override fun Refined.Validator.emit() = withLogging(logger) {
-        "new RegExp('${value.drop(1).dropLast(1)}')"
+        "RegExp('${value.drop(1).dropLast(1)}')"
     }
 
     override fun Endpoint.emit() = withLogging(logger) {
@@ -149,7 +148,7 @@ class TypeScriptEmitter(logger: Logger = noLogger) : AbstractEmitter(logger) {
         """.trimMargin()
     }
 
-    override fun Definition.emitName(): String = when(this){
+    override fun Definition.emitName(): String = when (this) {
         is Endpoint -> this.name
         is Enum -> this.name
         is Refined -> this.name

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileRefinedTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileRefinedTest.kt
@@ -76,13 +76,11 @@ class CompileRefinedTest {
     @Test
     fun testRefinedTypeScript() {
         val ts = """
-            export type TodoId = {
-              value: string
-            }
-            const validateTodoId = (type: TodoId) => (new RegExp('^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}${'$'}')).test(type.value);
-
-
-        """.trimIndent()
+            |export type TodoId = string;
+            |const regExpTodoId = RegExp('^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}${'$'}');
+            |export const validateTodoId = (value: string): value is TodoId => 
+            |  regExpTodoId.test(value);
+            |""".trimMargin()
 
         compiler(TypeScriptEmitter(logger = logger)) shouldBeRight ts
     }

--- a/src/integration/jackson/src/commonTest/resources/wirespec/todos.ws
+++ b/src/integration/jackson/src/commonTest/resources/wirespec/todos.ws
@@ -1,4 +1,4 @@
-refined TodoId /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/g
+refined TodoId /^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$/g
 
 type Todo {
     id: TodoId,

--- a/types/endpoint.ws
+++ b/types/endpoint.ws
@@ -1,4 +1,4 @@
-refined TodoIdentifier /^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$/g
+refined TodoIdentifier /^[0-9a-f]{8}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{12}$/g
 refined Name /^[0-9a-zA-Z]{1,50}$/g
 refined DutchPostalCode /^([0-9]{4}[A-Z]{2})$/g
 refined Date /^([0-9]{2}-[0-9]{2}-20[0-9]{2})$/g


### PR DESCRIPTION
Based on initial experience, the wrapped value for Typescript's refined type seems a bit bloated.

Old generated code for typescript: 
```typescript
export type UUID = {
   value: String
}
const validateUUID = (type: UUID) => (new = RegExp(
  "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").test(type.value);
```

New generated code for typescript:
```typescript
export type UUID = string;
const regExp: RegExp = RegExp(
  "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$"
);
export const validateUUID = (value: string): value is UUID =>
  regExp.test(value);
```

In an ideal world, the UUID would be more strongly typed string template literals, but this seems an open discussion within the typescript community. https://github.com/microsoft/TypeScript/issues/41160

