### PR TITLE
Make java's validate function for refined types public

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitter.kt
@@ -97,7 +97,7 @@ class JavaEmitter(
 
     override fun RefinedClass.emit() = """
         |public record ${name.sanitizeSymbol()} (String value) implements Wirespec.Refined {
-        |${SPACER}static boolean validate($name record) {
+        |${SPACER}public static boolean validate($name record) {
         |${SPACER}${validator.emit()}
         |${SPACER}}
         |${SPACER}@Override

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileRefinedTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileRefinedTest.kt
@@ -45,7 +45,7 @@ class CompileRefinedTest {
             import community.flock.wirespec.Wirespec;
             
             public record TodoId (String value) implements Wirespec.Refined {
-              static boolean validate(TodoId record) {
+              public static boolean validate(TodoId record) {
                 return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}${'$'}").matcher(record.value).find();
               }
               @Override

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitterTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitterTest.kt
@@ -3,7 +3,6 @@ package community.flock.wirespec.compiler.core.emit
 import community.flock.wirespec.compiler.core.fixture.ClassModelFixture
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class JavaEmitterTest {
 
@@ -29,7 +28,7 @@ class JavaEmitterTest {
     fun testEmitterRefined() {
         val expected = """
             |public record UUID (String value) implements Wirespec.Refined {
-            |  static boolean validate(UUID record) {
+            |  public static boolean validate(UUID record) {
             |    return java.util.regex.Pattern.compile(^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}${'$'}).matcher(record.value).find();
             |  }
             |  @Override

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/TodoId.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/TodoId.java
@@ -3,7 +3,7 @@ package community.flock.wirespec.integration.jackson.java.generated;
 import community.flock.wirespec.Wirespec;
 
 public record TodoId (String value) implements Wirespec.Refined {
-  static boolean validate(TodoId record) {
+  public static boolean validate(TodoId record) {
     return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").matcher(record.value).find();
   }
   @Override


### PR DESCRIPTION
The following code now now works.

```java
var todoId =new TodoId("some-id")
TodoId.validate(todoId)
```