### PR TITLE
Allow to generate primitives as well for a given AST

### DIFF
--- a/src/tools/generator/src/commonMain/kotlin/community/flock/wirespec/generator/Generator.kt
+++ b/src/tools/generator/src/commonMain/kotlin/community/flock/wirespec/generator/Generator.kt
@@ -24,8 +24,8 @@ fun AST.generate(type: String, random: Random = Random.Default): JsonElement = R
     isDictionary = false
 ).let { generate(it, random) }
 
-fun AST.generate(type: Reference, random: Random = Random.Default): JsonElement = resolveReference(type)
-    .let { if (type.isIterable) generateIterator(it, random) else generateObject(it, random) }
+fun AST.generate(type: Reference, random: Random = Random.Default): JsonElement =
+    generateReference(type, random)
 
 private fun AST.resolveReference(type: Reference) = filterIsInstance<Definition>()
     .find { it.identifier.value == type.value }

--- a/src/tools/generator/src/commonTest/kotlin/community/flock/wirespec/generator/GeneratorTest.kt
+++ b/src/tools/generator/src/commonTest/kotlin/community/flock/wirespec/generator/GeneratorTest.kt
@@ -3,8 +3,11 @@ package community.flock.wirespec.generator
 import arrow.core.getOrElse
 import community.flock.wirespec.compiler.core.WirespecSpec
 import community.flock.wirespec.compiler.core.parse
+import community.flock.wirespec.compiler.core.parse.Field.Reference.Primitive
+import community.flock.wirespec.compiler.core.parse.Field.Reference.Primitive.Type
 import community.flock.wirespec.compiler.utils.noLogger
 import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -52,6 +55,15 @@ class GeneratorTest {
         val res = ast.generate("Address", random)
         val expect = """{"street":"HQp4YEz0","houseNumber":2133997452,"postalCode":"7542RZ"}"""
         assertEquals(expect, res.toString())
+    }
+
+    @Test
+    fun generatePrimitive() {
+        val ast = parser(src)
+        val random = Random(0L)
+        val res = ast.generate(Primitive(Type.String, false, false), random)
+        val expect = "ZKN8V5p8ktkmmMX"
+        assertEquals(expect, res.jsonPrimitive.content)
     }
 
     @Test


### PR DESCRIPTION
Even though no AST is needed to generate a random primitive, there are usecases where you want to render a subtree. The smallest possible subtree is leaf node with a primitive.