### PR TITLE
fix: do not parse endpoint with /g as refined type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Run
         run: |
           make build
@@ -127,7 +127,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - name: Build lib
         run: |
           ./gradlew :src:plugin:npm:build
@@ -229,7 +229,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
       - name: Build
         run: |

--- a/examples/npm-typescript/Makefile
+++ b/examples/npm-typescript/Makefile
@@ -1,7 +1,10 @@
 .PHONY: *
 
 build:
-	make clean && npm install && npm run generate && npm test
+	npm run build
 
 clean:
-	rm -rf node_modules
+	npm run clean
+
+update:
+	npm run update

--- a/examples/npm-typescript/package-lock.json
+++ b/examples/npm-typescript/package-lock.json
@@ -8,17 +8,16 @@
       "name": "npm-typescript",
       "version": "1.0.0",
       "license": "ISC",
-      "dependencies": {
-        "typescript": "^5.6.2",
-        "wirespec": "../../src/plugin/npm/build/dist/js/productionLibrary"
-      },
       "devDependencies": {
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.2",
+        "wirespec": "file://../../src/plugin/npm/build/dist/js/productionLibrary"
       }
     },
     "../../src/plugin/npm/build/dist/js/productionLibrary": {
       "name": "@flock/wirespec",
       "version": "0.0.0-SNAPSHOT",
+      "dev": true,
       "dependencies": {
         "format-util": "^1.0.5"
       },
@@ -181,6 +180,7 @@
     },
     "node_modules/typescript": {
       "version": "5.6.2",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/examples/npm-typescript/package.json
+++ b/examples/npm-typescript/package.json
@@ -3,19 +3,22 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "build": "npm install && npm run generate && npm test",
+    "clean": "npm run clean:node_modules && npm run clean:generated",
+    "clean:node_modules": "npx rimraf ./node_modules",
+    "clean:generated": "npx rimraf ./src/gen",
     "generate": "wirespec compile -d ./wirespec -o ./src/gen -l TypeScript -p ''",
     "test": "npm run test:client && npm run test:server",
     "test:client": "ts-node src/client.ts",
-    "test:server": "ts-node src/server.ts"
+    "test:server": "ts-node src/server.ts",
+    "update": "npx --yes update-ruecksichtslos"
   },
   "author": "",
   "license": "ISC",
   "description": "",
-  "dependencies": {
-    "typescript": "^5.6.2",
-    "wirespec": "../../src/plugin/npm/build/dist/js/productionLibrary"
-  },
   "devDependencies": {
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.2",
+    "wirespec": "file://../../src/plugin/npm/build/dist/js/productionLibrary"
   }
 }

--- a/examples/spring-boot-custom-maven-plugin/pom.xml
+++ b/examples/spring-boot-custom-maven-plugin/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <modules>

--- a/examples/spring-boot-maven-plugin/src/main/java/community/flock/wirespec/examples/app/user/UserContext.java
+++ b/examples/spring-boot-maven-plugin/src/main/java/community/flock/wirespec/examples/app/user/UserContext.java
@@ -4,7 +4,8 @@ import java.util.List;
 
 public interface UserContext extends UserAdapter.Module {
     class Service {
-        private Service() {}
+        private Service() {
+        }
 
         public static List<User> getAllUsers(final UserContext ctx) {
             return ctx.userAdapter().getAllUsers();

--- a/examples/spring-boot-openapi-maven-plugin/pom.xml
+++ b/examples/spring-boot-openapi-maven-plugin/pom.xml
@@ -13,7 +13,7 @@
     <version>0.0.1-SNAPSHOT</version>
     <description>Demo project for Wirespec</description>
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <kotlin.version>2.0.0</kotlin.version>
     </properties>
     <dependencies>

--- a/examples/wirespec-gradle-plugin-ktor/gradle/libs.versions.toml
+++ b/examples/wirespec-gradle-plugin-ktor/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 default = "0.0.0-SNAPSHOT"
-java = "17"
+java = "21"
 ktor = "2.3.9"
 kotlin = "2.0.0"
 jackson = "2.17.2"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -6,6 +6,7 @@ root="$dir/.."
 ./gradlew clean &&
   (cd "$root" && rm -rf kotlin-js-store) &&
   (cd "$root"/src/ide/vscode && npm run clean) &&
+  (cd "$root"/examples/npm-typescript && make clean) &&
   (cd "$root"/examples/spring-boot-custom-maven-plugin && ./mvnw clean) &&
   (cd "$root"/examples/spring-boot-maven-plugin && ./mvnw clean) &&
   (cd "$root"/examples/spring-boot-openapi-maven-plugin && ./mvnw clean) &&

--- a/scripts/example.sh
+++ b/scripts/example.sh
@@ -6,9 +6,8 @@ dir="$(dirname -- "$0")"
 ./gradlew src:plugin:gradle:publishToMavenLocal &&
   ./gradlew src:plugin:maven:publishToMavenLocal &&
   # build examples
+  (cd "$dir"/../examples/npm-typescript && make build) &&
   (cd "$dir"/../examples/wirespec-gradle-plugin-ktor && make build) &&
   (cd "$dir"/../examples/spring-boot-maven-plugin && make build) &&
   (cd "$dir"/../examples/spring-boot-custom-maven-plugin &&  make build) &&
-  (cd "$dir"/../examples/spring-boot-openapi-maven-plugin && make build) &&
-  (cd "$dir"/../examples/npm-typescript && make build)
-
+  (cd "$dir"/../examples/spring-boot-openapi-maven-plugin && make build)

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
@@ -2,15 +2,14 @@ package community.flock.wirespec.compiler.core
 
 import community.flock.wirespec.compiler.core.tokenize.types.Arrow
 import community.flock.wirespec.compiler.core.tokenize.types.Brackets
+import community.flock.wirespec.compiler.core.tokenize.types.Character
 import community.flock.wirespec.compiler.core.tokenize.types.Colon
 import community.flock.wirespec.compiler.core.tokenize.types.Comma
-import community.flock.wirespec.compiler.core.tokenize.types.CustomRegex
 import community.flock.wirespec.compiler.core.tokenize.types.CustomType
 import community.flock.wirespec.compiler.core.tokenize.types.CustomValue
 import community.flock.wirespec.compiler.core.tokenize.types.Equals
 import community.flock.wirespec.compiler.core.tokenize.types.ForwardSlash
 import community.flock.wirespec.compiler.core.tokenize.types.Hash
-import community.flock.wirespec.compiler.core.tokenize.types.Character
 import community.flock.wirespec.compiler.core.tokenize.types.LeftCurly
 import community.flock.wirespec.compiler.core.tokenize.types.Method
 import community.flock.wirespec.compiler.core.tokenize.types.NewLine

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
@@ -10,7 +10,7 @@ import community.flock.wirespec.compiler.core.tokenize.types.CustomValue
 import community.flock.wirespec.compiler.core.tokenize.types.Equals
 import community.flock.wirespec.compiler.core.tokenize.types.ForwardSlash
 import community.flock.wirespec.compiler.core.tokenize.types.Hash
-import community.flock.wirespec.compiler.core.tokenize.types.Invalid
+import community.flock.wirespec.compiler.core.tokenize.types.Character
 import community.flock.wirespec.compiler.core.tokenize.types.LeftCurly
 import community.flock.wirespec.compiler.core.tokenize.types.Method
 import community.flock.wirespec.compiler.core.tokenize.types.NewLine
@@ -63,13 +63,12 @@ object WirespecSpec : LanguageSpec {
         Regex("^Boolean") to WsBoolean,
         Regex("^Unit") to WsUnit,
         Regex("^GET|^POST|^PUT|^DELETE|^OPTIONS|^HEAD|^PATCH|^TRACE") to Method,
-        Regex("^/.*/g") to CustomRegex,
         Regex("^[1-5][0-9][0-9]") to StatusCode,
         Regex("^[a-z`][a-zA-Z0-9`]*") to CustomValue,
         Regex("^[A-Z][a-zA-Z0-9_]*") to CustomType,
         Regex("^/[a-zA-Z0-9-_]+") to Path,
         Regex("^\\/\\*(\\*(?!\\/)|[^*])*\\*\\/") to WsComment,
         Regex("^/") to ForwardSlash,
-        Regex("^.") to Invalid // Catch all regular expression if none of the above matched
+        Regex("^.") to Character // Catch all regular expression if none of the above matched
     )
 }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitter.kt
@@ -103,7 +103,7 @@ open class JavaEmitter(
     """.trimMargin()
 
     override fun Refined.Validator.emit() =
-        """${Spacer}return java.util.regex.Pattern.compile(${value.replace("\\", "\\\\")}).matcher(record.value).find();"""
+        """${Spacer}return java.util.regex.Pattern.compile("${expression.replace("\\", "\\\\")}").matcher(record.value).find();"""
 
     override fun emit(enum: Enum) = """
         |public enum ${enum.identifier.value.sanitizeSymbol()} implements Wirespec.Enum {

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaLegacyEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaLegacyEmitter.kt
@@ -105,7 +105,7 @@ open class JavaLegacyEmitter(
 
     override fun RefinedClass.Validator.emit() = run {
         """
-        |${Spacer}return java.util.regex.Pattern.compile(${value.replace("\\", "\\\\")}).matcher(record.value).find();
+        |${Spacer}return java.util.regex.Pattern.compile(${expression.replace("\\", "\\\\")}).matcher(record.value).find();
         """.trimMargin()
     }
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitter.kt
@@ -97,7 +97,7 @@ open class KotlinEmitter(
         |fun ${refined.identifier.value}.validate() = ${refined.validator.emit()}
     """.trimMargin()
 
-    override fun Refined.Validator.emit() = "Regex(\"\"$value\"\").matches(value)"
+    override fun Refined.Validator.emit() = "Regex(\"\"\"${expression}\"\"\").matches(value)"
 
     override fun emit(enum: Enum) = """
         |enum class ${enum.identifier.value.sanitizeSymbol()} (val label: String): Wirespec.Enum {

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/KotlinLegacyEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/KotlinLegacyEmitter.kt
@@ -82,7 +82,7 @@ open class KotlinLegacyEmitter(
         |fun $name.validate() = ${validator.emit()}
     """.trimMargin()
 
-    override fun RefinedClass.Validator.emit() = "Regex(\"\"$value\"\").matches(value)"
+    override fun RefinedClass.Validator.emit() = "Regex(\"\"$expression\"\").matches(value)"
 
     override fun emit(enum: Enum) = enum.transform().emit()
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/ScalaEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/ScalaEmitter.kt
@@ -100,7 +100,7 @@ open class ScalaEmitter(
 
 
     override fun Refined.Validator.emit() =
-        """${Spacer(2)}val regex = new scala.util.matching.Regex(""$value"")
+        """${Spacer(2)}val regex = new scala.util.matching.Regex(${"\"\"\""}$expression${"\"\"\""})
             |${Spacer(2)}regex.findFirstIn(that.value)""".trimMargin()
 
     override fun emit(endpoint: Endpoint) = notYetImplemented()

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/TypeScriptEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/TypeScriptEmitter.kt
@@ -84,7 +84,7 @@ open class TypeScriptEmitter(logger: Logger = noLogger) : DefinitionModelEmitter
             |${Spacer}regExp${refined.identifier.emit()}.test(value);
             |""".trimMargin()
 
-    override fun Refined.Validator.emit() = "/${value.drop(1).dropLast(1)}/g"
+    override fun Refined.Validator.emit() = value
 
     override fun emit(endpoint: Endpoint) =
         """

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/WirespecEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/WirespecEmitter.kt
@@ -66,7 +66,7 @@ open class WirespecEmitter(logger: Logger = noLogger) : DefinitionModelEmitter, 
 
     override fun emit(refined: Refined) = "type ${refined.identifier.emit()} ${refined.validator.emit()}\n"
 
-    override fun Refined.Validator.emit() = "/${value.drop(1).dropLast(1)}/g"
+    override fun Refined.Validator.emit() = value
 
     override fun emit(endpoint: Endpoint) = """
         |endpoint ${endpoint.identifier.emit()} ${endpoint.method}${endpoint.requests.emitRequest()} ${endpoint.path.emitPath()}${endpoint.queries.emitQuery()} -> {

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/transformer/ClassModel.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/transformer/ClassModel.kt
@@ -16,7 +16,13 @@ data class RefinedClass(
     override val name: String,
     val validator: Validator
 ) : ClassModel {
-    data class Validator(override val value: String) : Value<String>
+    data class Validator(override val value: String) : Value<String>{
+        val expression get() = value
+            .split("/")
+            .drop(1)
+            .dropLast(1)
+            .joinToString("/")
+    }
 }
 
 data class EnumClass(

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/WireSpecException.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/WireSpecException.kt
@@ -2,6 +2,7 @@ package community.flock.wirespec.compiler.core.exceptions
 
 import community.flock.wirespec.compiler.core.tokenize.Token
 import community.flock.wirespec.compiler.core.tokenize.types.TokenType
+import community.flock.wirespec.compiler.core.tokenize.types.name
 import kotlin.reflect.KClass
 
 sealed class WirespecException(message: String, val coordinates: Token.Coordinates) : RuntimeException(message) {

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/optimize/Optimizer.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/optimize/Optimizer.kt
@@ -2,11 +2,5 @@ package community.flock.wirespec.compiler.core.optimize
 
 import arrow.core.NonEmptyList
 import community.flock.wirespec.compiler.core.tokenize.Token
-import community.flock.wirespec.compiler.core.tokenize.types.CustomRegex
 
-fun NonEmptyList<Token>.optimize(): NonEmptyList<Token> = map {
-    when (it.type) {
-        is CustomRegex -> it.copy(value = """"${it.value.drop(1).dropLast(2)}"""")
-        else -> it
-    }
-}
+fun NonEmptyList<Token>.optimize(): NonEmptyList<Token> = this

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Node.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Node.kt
@@ -74,7 +74,14 @@ data class Refined(
     override val identifier: Identifier,
     val validator: Validator,
 ) : Definition {
-    data class Validator(override val value: String) : Value<String>
+    data class Validator(override val value: String) : Value<String>{
+        val expression get() =
+            value.split("/")
+                .drop(1)
+                .dropLast(1)
+                .joinToString("/")
+
+    }
 }
 
 data class Endpoint(

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/types/TokenTypes.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/types/TokenTypes.kt
@@ -1,23 +1,27 @@
 package community.flock.wirespec.compiler.core.tokenize.types
 
-sealed interface TokenType {
-    fun name(): String = this::class.simpleName!!
-}
+fun TokenType.name(): String = this::class.simpleName!!
 
-data object LeftCurly : TokenType
+sealed interface TokenType
 data object RightCurly : TokenType
 data object Colon : TokenType
 data object Comma : TokenType
 data object QuestionMark : TokenType
 data object Hash : TokenType
-data object ForwardSlash : TokenType
 data object Brackets : TokenType
 data object CustomValue : TokenType
 data object WsComment : TokenType
 data object Character : TokenType
+data object Arrow : TokenType
+data object Pipe : TokenType
 data object EndOfProgram : TokenType {
     const val VALUE = "EOP"
 }
+
+sealed interface TypeDefinitionStart : TokenType
+data object LeftCurly : TypeDefinitionStart
+data object ForwardSlash : TypeDefinitionStart
+data object Equals : TypeDefinitionStart
 
 sealed interface WhiteSpace : TokenType
 data object WhiteSpaceExceptNewLine : WhiteSpace
@@ -44,8 +48,3 @@ data object Method : Keyword
 data object Path : Keyword
 
 data object StatusCode : Keyword
-data object Arrow : Keyword
-data object Equals : Keyword
-data object Pipe : Keyword
-
-data object CustomRegex : TokenType

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/types/TokenTypes.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/types/TokenTypes.kt
@@ -14,7 +14,7 @@ data object ForwardSlash : TokenType
 data object Brackets : TokenType
 data object CustomValue : TokenType
 data object WsComment : TokenType
-data object Invalid : TokenType
+data object Character : TokenType
 data object EndOfProgram : TokenType {
     const val VALUE = "EOP"
 }

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitterTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitterTest.kt
@@ -40,7 +40,7 @@ class KotlinEmitterTest {
             |  override fun toString() = value
             |}
             |
-            |fun UUID.validate() = Regex(${"\"\""}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}${'$'}${"\"\""}).matches(value)
+            |fun UUID.validate() = Regex(${"\"\"\""}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}${'$'}${"\"\"\""}).matches(value)
             |
         """.trimMargin()
 

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/fixture/NodeFixtures.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/fixture/NodeFixtures.kt
@@ -1,6 +1,5 @@
 package community.flock.wirespec.compiler.core.fixture
 
-import community.flock.wirespec.compiler.core.parse.Endpoint
 import community.flock.wirespec.compiler.core.parse.Enum
 import community.flock.wirespec.compiler.core.parse.Field
 import community.flock.wirespec.compiler.core.parse.Identifier
@@ -58,23 +57,5 @@ object NodeFixtures {
             )
         ),
         extends = emptyList(),
-    )
-
-    val endpoint = Endpoint(
-        comment = null,
-        identifier = Identifier(""),
-        method = Endpoint.Method.GET,
-        path = listOf(Endpoint.Segment.Literal("/todos")),
-        queries = emptyList(),
-        headers = emptyList(),
-        cookies = emptyList(),
-        requests = emptyList(),
-        responses = listOf(
-            Endpoint.Response(
-                status = "200",
-                headers = emptyList(),
-                content = null,
-            )
-        ),
     )
 }

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/fixture/NodeFixtures.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/fixture/NodeFixtures.kt
@@ -14,7 +14,7 @@ object NodeFixtures {
         comment = null,
         identifier = Identifier("UUID"),
         validator = Refined.Validator(
-            "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}\$"
+            "/^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}\$/"
         )
     )
 

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/tokenize/TestUtils.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/tokenize/TestUtils.kt
@@ -1,23 +1,19 @@
 package community.flock.wirespec.compiler.core.tokenize
 
 import community.flock.wirespec.compiler.core.WirespecSpec
-import community.flock.wirespec.compiler.core.tokenize.types.Invalid
 import community.flock.wirespec.compiler.core.tokenize.types.TokenType
 import io.kotest.matchers.collections.shouldNotBeEmpty
-import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 
 fun testTokenizer(
     source: String,
     vararg expected: TokenType,
     removeWhiteSpace: Boolean = true,
-    noInvalid: Boolean = true,
 ) {
     WirespecSpec.tokenize(source)
         .run { if (removeWhiteSpace) removeWhiteSpace() else this }
         .shouldNotBeEmpty()
         .apply { size shouldBe expected.size }
         .map { it.type }
-        .apply { if (noInvalid) shouldNotContain(Invalid) }
         .onEachIndexed { index, tokenType -> tokenType shouldBe expected[index] }
 }

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenizeEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenizeEndpointTest.kt
@@ -9,7 +9,7 @@ import community.flock.wirespec.compiler.core.tokenize.types.CustomValue
 import community.flock.wirespec.compiler.core.tokenize.types.EndOfProgram
 import community.flock.wirespec.compiler.core.tokenize.types.ForwardSlash
 import community.flock.wirespec.compiler.core.tokenize.types.Hash
-import community.flock.wirespec.compiler.core.tokenize.types.Invalid
+import community.flock.wirespec.compiler.core.tokenize.types.Character
 import community.flock.wirespec.compiler.core.tokenize.types.LeftCurly
 import community.flock.wirespec.compiler.core.tokenize.types.Method
 import community.flock.wirespec.compiler.core.tokenize.types.Path
@@ -25,12 +25,11 @@ class TokenizeEndpointTest {
     @Test
     fun testStatusCodeTokenize() = testTokenizer(
         """000 099 100 199 200 299 300 399 400 499 500 599 600 699""",
-        Invalid, Invalid, Invalid, Invalid, Invalid, Invalid,
+        Character, Character, Character, Character, Character, Character,
         StatusCode, StatusCode, StatusCode, StatusCode, StatusCode,
         StatusCode, StatusCode, StatusCode, StatusCode, StatusCode,
-        Invalid, Invalid, Invalid, Invalid, Invalid, Invalid,
+        Character, Character, Character, Character, Character, Character,
         EndOfProgram,
-        noInvalid = false,
     )
 
     @Test

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenizeTypeTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenizeTypeTest.kt
@@ -1,14 +1,19 @@
 package community.flock.wirespec.compiler.core.tokenize
 
+import community.flock.wirespec.compiler.core.tokenize.types.Character
 import community.flock.wirespec.compiler.core.tokenize.types.Colon
 import community.flock.wirespec.compiler.core.tokenize.types.CustomRegex
 import community.flock.wirespec.compiler.core.tokenize.types.CustomType
 import community.flock.wirespec.compiler.core.tokenize.types.CustomValue
 import community.flock.wirespec.compiler.core.tokenize.types.EndOfProgram
 import community.flock.wirespec.compiler.core.tokenize.types.Equals
+import community.flock.wirespec.compiler.core.tokenize.types.ForwardSlash
 import community.flock.wirespec.compiler.core.tokenize.types.LeftCurly
+import community.flock.wirespec.compiler.core.tokenize.types.Path
 import community.flock.wirespec.compiler.core.tokenize.types.Pipe
 import community.flock.wirespec.compiler.core.tokenize.types.RightCurly
+import community.flock.wirespec.compiler.core.tokenize.types.StartOfProgram
+import community.flock.wirespec.compiler.core.tokenize.types.WhiteSpaceExceptNewLine
 import community.flock.wirespec.compiler.core.tokenize.types.WsString
 import community.flock.wirespec.compiler.core.tokenize.types.WsTypeDef
 import kotlin.test.Test
@@ -29,7 +34,11 @@ class TokenizeTypeTest {
     @Test
     fun testRefinedTypeTokenize() = testTokenizer(
         "type DutchPostalCode /^([0-9]{4}[A-Z]{2})$/g",
-        WsTypeDef, CustomType, CustomRegex, EndOfProgram,
+        WsTypeDef, CustomType, ForwardSlash, Character, Character,
+        Character, Character, Character, Character, Character,
+        LeftCurly, Character, RightCurly, Character, CustomType,
+        Character, CustomType, Character, LeftCurly, Character,
+        RightCurly, Character, Character, Path, EndOfProgram
     )
 
     @Test

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenizeTypeTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenizeTypeTest.kt
@@ -2,7 +2,6 @@ package community.flock.wirespec.compiler.core.tokenize
 
 import community.flock.wirespec.compiler.core.tokenize.types.Character
 import community.flock.wirespec.compiler.core.tokenize.types.Colon
-import community.flock.wirespec.compiler.core.tokenize.types.CustomRegex
 import community.flock.wirespec.compiler.core.tokenize.types.CustomType
 import community.flock.wirespec.compiler.core.tokenize.types.CustomValue
 import community.flock.wirespec.compiler.core.tokenize.types.EndOfProgram
@@ -12,8 +11,6 @@ import community.flock.wirespec.compiler.core.tokenize.types.LeftCurly
 import community.flock.wirespec.compiler.core.tokenize.types.Path
 import community.flock.wirespec.compiler.core.tokenize.types.Pipe
 import community.flock.wirespec.compiler.core.tokenize.types.RightCurly
-import community.flock.wirespec.compiler.core.tokenize.types.StartOfProgram
-import community.flock.wirespec.compiler.core.tokenize.types.WhiteSpaceExceptNewLine
 import community.flock.wirespec.compiler.core.tokenize.types.WsString
 import community.flock.wirespec.compiler.core.tokenize.types.WsTypeDef
 import kotlin.test.Test

--- a/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Tokens.kt
+++ b/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Tokens.kt
@@ -3,8 +3,7 @@
 package community.flock.wirespec.compiler.lib
 
 import community.flock.wirespec.compiler.core.tokenize.Token
-
-fun List<Token>.produce(): WsTokenResult = WsTokenResult(tokens = WsTokens(value = map { it.produce() }.toTypedArray()))
+import community.flock.wirespec.compiler.core.tokenize.types.name
 
 fun Token.produce() = WsToken(
     type = type.name(),

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
@@ -14,7 +14,7 @@ import community.flock.wirespec.compiler.core.tokenize.types.EndOfProgram
 import community.flock.wirespec.compiler.core.tokenize.types.Equals
 import community.flock.wirespec.compiler.core.tokenize.types.ForwardSlash
 import community.flock.wirespec.compiler.core.tokenize.types.Hash
-import community.flock.wirespec.compiler.core.tokenize.types.Invalid
+import community.flock.wirespec.compiler.core.tokenize.types.Character
 import community.flock.wirespec.compiler.core.tokenize.types.LeftCurly
 import community.flock.wirespec.compiler.core.tokenize.types.Method
 import community.flock.wirespec.compiler.core.tokenize.types.Path
@@ -65,7 +65,7 @@ class Lexer : IntellijLexer() {
         is Brackets -> Types.BRACKETS
         is CustomValue -> Types.CUSTOM_VALUE
         is WsComment -> Types.COMMENT
-        is Invalid -> Types.INVALID
+        is Character -> Types.Character
         is EndOfProgram -> Types.END_OF_PROGRAM
         is WhiteSpace -> Types.WHITE_SPACE
         is WsTypeDef -> Types.TYPE_DEF

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
@@ -5,16 +5,15 @@ import community.flock.wirespec.compiler.core.tokenize.Token
 import community.flock.wirespec.compiler.core.tokenize.tokenize
 import community.flock.wirespec.compiler.core.tokenize.types.Arrow
 import community.flock.wirespec.compiler.core.tokenize.types.Brackets
+import community.flock.wirespec.compiler.core.tokenize.types.Character
 import community.flock.wirespec.compiler.core.tokenize.types.Colon
 import community.flock.wirespec.compiler.core.tokenize.types.Comma
-import community.flock.wirespec.compiler.core.tokenize.types.CustomRegex
 import community.flock.wirespec.compiler.core.tokenize.types.CustomType
 import community.flock.wirespec.compiler.core.tokenize.types.CustomValue
 import community.flock.wirespec.compiler.core.tokenize.types.EndOfProgram
 import community.flock.wirespec.compiler.core.tokenize.types.Equals
 import community.flock.wirespec.compiler.core.tokenize.types.ForwardSlash
 import community.flock.wirespec.compiler.core.tokenize.types.Hash
-import community.flock.wirespec.compiler.core.tokenize.types.Character
 import community.flock.wirespec.compiler.core.tokenize.types.LeftCurly
 import community.flock.wirespec.compiler.core.tokenize.types.Method
 import community.flock.wirespec.compiler.core.tokenize.types.Path
@@ -24,6 +23,7 @@ import community.flock.wirespec.compiler.core.tokenize.types.RightCurly
 import community.flock.wirespec.compiler.core.tokenize.types.StatusCode
 import community.flock.wirespec.compiler.core.tokenize.types.WhiteSpace
 import community.flock.wirespec.compiler.core.tokenize.types.WsBoolean
+import community.flock.wirespec.compiler.core.tokenize.types.WsChannelDef
 import community.flock.wirespec.compiler.core.tokenize.types.WsComment
 import community.flock.wirespec.compiler.core.tokenize.types.WsEndpointDef
 import community.flock.wirespec.compiler.core.tokenize.types.WsEnumTypeDef
@@ -32,7 +32,6 @@ import community.flock.wirespec.compiler.core.tokenize.types.WsNumber
 import community.flock.wirespec.compiler.core.tokenize.types.WsString
 import community.flock.wirespec.compiler.core.tokenize.types.WsTypeDef
 import community.flock.wirespec.compiler.core.tokenize.types.WsUnit
-import community.flock.wirespec.compiler.core.tokenize.types.WsChannelDef
 import com.intellij.lexer.LexerBase as IntellijLexer
 
 class Lexer : IntellijLexer() {
@@ -65,7 +64,7 @@ class Lexer : IntellijLexer() {
         is Brackets -> Types.BRACKETS
         is CustomValue -> Types.CUSTOM_VALUE
         is WsComment -> Types.COMMENT
-        is Character -> Types.Character
+        is Character -> Types.CHARACTER
         is EndOfProgram -> Types.END_OF_PROGRAM
         is WhiteSpace -> Types.WHITE_SPACE
         is WsTypeDef -> Types.TYPE_DEF
@@ -84,7 +83,6 @@ class Lexer : IntellijLexer() {
         is Arrow -> Types.ARROW
         is Equals -> Types.EQUALS
         is Pipe -> Types.PIPE
-        is CustomRegex -> Types.CUSTOM_REGEX
     }
 
     override fun getTokenStart() = tokens[index]

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
@@ -16,7 +16,7 @@ interface Types {
         val BRACKETS = ElementType("BRACKETS")
         val CUSTOM_VALUE = ElementType("CUSTOM_VALUE")
         val COMMENT = ElementType("COMMENT")
-        val Character = ElementType("CHARACTER")
+        val CHARACTER = ElementType("CHARACTER")
         val END_OF_PROGRAM = ElementType("END_OF_PROGRAM")
         val WHITE_SPACE = ElementType("WHITE_SPACE")
         val TYPE_DEF = ElementType("TYPE_DEF")

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
@@ -16,7 +16,7 @@ interface Types {
         val BRACKETS = ElementType("BRACKETS")
         val CUSTOM_VALUE = ElementType("CUSTOM_VALUE")
         val COMMENT = ElementType("COMMENT")
-        val Character = ElementType("INVALID")
+        val Character = ElementType("CHARACTER")
         val END_OF_PROGRAM = ElementType("END_OF_PROGRAM")
         val WHITE_SPACE = ElementType("WHITE_SPACE")
         val TYPE_DEF = ElementType("TYPE_DEF")

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
@@ -16,7 +16,7 @@ interface Types {
         val BRACKETS = ElementType("BRACKETS")
         val CUSTOM_VALUE = ElementType("CUSTOM_VALUE")
         val COMMENT = ElementType("COMMENT")
-        val INVALID = ElementType("INVALID")
+        val Character = ElementType("INVALID")
         val END_OF_PROGRAM = ElementType("END_OF_PROGRAM")
         val WHITE_SPACE = ElementType("WHITE_SPACE")
         val TYPE_DEF = ElementType("TYPE_DEF")


### PR DESCRIPTION
endpoint GET /test/gird/ is parse as refined type