### PR TITLE
Fallback to string when no schema is available.

### DIFF
--- a/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenApiV3Parser.kt
+++ b/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenApiV3Parser.kt
@@ -559,14 +559,14 @@ object OpenApiV3Parser {
         when (val s = parameter.schema) {
             is ReferenceObject -> toReference(s)
             is SchemaObject -> toReference(s, name)
-            null -> TODO("Not yet implemented")
+            null -> Reference.Primitive(Reference.Primitive.Type.String)
         }.let { Field(Identifier(parameter.name), it, !(parameter.required ?: false)) }
 
     private fun OpenAPIObject.toField(header: HeaderObject, identifier: String, name: String) =
         when (val s = header.schema) {
             is ReferenceObject -> toReference(s)
             is SchemaObject -> toReference(s, name)
-            null -> TODO("Not yet implemented")
+            null -> Reference.Primitive(Reference.Primitive.Type.String)
         }.let { Field(Identifier(identifier), it, !(header.required ?: false)) }
 
     private data class FlattenRequest(


### PR DESCRIPTION
It's possible that a parameter has no schema, for example:

 {
    "name": "reference",
    "in": "query",
    "description": "reference in external system"
  }
  
Swagger UI fallbacks to String in this case:

<img width="227" alt="image" src="https://github.com/user-attachments/assets/d387a57a-7c4a-42a5-a2f0-0d4e128968d2">


