### PR TITLE
Only add non-empty params to Spring request

### DIFF
--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/java/client/WirespecWebClient.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/java/client/WirespecWebClient.kt
@@ -1,5 +1,6 @@
 package community.flock.wirespec.integration.spring.java.client
 
+import community.flock.wirespec.integration.spring.shared.filterNotEmpty
 import community.flock.wirespec.java.Wirespec
 import community.flock.wirespec.java.Wirespec.Serialization
 import org.springframework.http.HttpMethod
@@ -38,11 +39,11 @@ class WirespecWebClient(
         .uri { uriBuilder ->
             uriBuilder
                 .path(request.path.joinToString("/"))
-                .apply { request.queries.forEach { (key, value) -> queryParam(key, value) } }
+                .apply { request.queries.filterNotEmpty().forEach { (key, value) -> queryParam(key, value) } }
                 .build()
         }
         .headers { headers ->
-            request.headers.forEach { (key, value) -> headers.addAll(key, value) }
+            request.headers.filterNotEmpty().forEach { (key, value) -> headers.addAll(key, value) }
         }
         .bodyValue(request.body)
         .exchangeToMono { response ->

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
@@ -1,5 +1,6 @@
 package community.flock.wirespec.integration.spring.kotlin.client
 
+import community.flock.wirespec.integration.spring.shared.filterNotEmpty
 import community.flock.wirespec.kotlin.Wirespec
 import community.flock.wirespec.kotlin.Wirespec.Serialization
 import kotlinx.coroutines.reactor.awaitSingle
@@ -30,11 +31,11 @@ class WirespecWebClient(
         .uri { uriBuilder ->
             uriBuilder
                 .path(request.path.joinToString("/"))
-                .apply { request.queries.forEach { (key, value) -> queryParam(key, value) } }
+                .apply { request.queries.filterNotEmpty().forEach { (key, value) -> queryParam(key, value) } }
                 .build()
         }
         .headers { headers ->
-            request.headers.forEach { (key, value) -> headers.addAll(key, value) }
+            request.headers.filterNotEmpty().forEach { (key, value) -> headers.addAll(key, value) }
         }
         .bodyValue(request.body)
         .exchangeToMono { response ->

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/shared/Client.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/shared/Client.kt
@@ -1,0 +1,3 @@
+package community.flock.wirespec.integration.spring.shared
+
+fun Map<String, List<String>>.filterNotEmpty(): Map<String, List<String>> = filter { it.value.isNotEmpty() }


### PR DESCRIPTION
If empty params are not filtered out they still end up in the query string.

I.e. something like: `mapOf("isActive" to emptyList())` would result in `?isActive` if not filtered out. Frameworks like Spring will interpret this as `isActive=true` which is incorrect