### PR TITLE
Only emit RequestBodyObject when there is a body

### DIFF
--- a/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenApiV3Emitter.kt
+++ b/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenApiV3Emitter.kt
@@ -150,10 +150,15 @@ object OpenApiV3Emitter : Emitter(noLogger) {
                 ParameterLocation.HEADER
             )
         },
-        requestBody = RequestBodyObject(
-            content = requests.mapNotNull { it.content?.emit() }.toMap().ifEmpty { null },
-            required = !requests.any { it.content?.isNullable ?: false }
-        ),
+        requestBody = requests.mapNotNull { it.content?.emit() }
+            .toMap()
+            .takeIf { it.isNotEmpty() }
+            ?.let { content ->
+                RequestBodyObject(
+                    content = content,
+                    required = requests.any { it.content?.isNullable == false }
+                )
+            },
         responses = responses
             .groupBy { it.status }
             .map { (statusCode, res) ->


### PR DESCRIPTION
A request without request body was emitted with a `requestBody`:

```
 "/some-endpoint": {
            "get": {
                "description": "...",
                "operationId": "...",
                "parameters": [],
                "requestBody": {
                    "required": true
                }
```

This PR fixes 2 problems with this:

1. Don't emit RequestBody when there is none
2. Don't inverse required boolean
