### PR TITLE
Control log level in maven plugin

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/Compiler.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/Compiler.kt
@@ -37,6 +37,6 @@ private enum class Stage {
     TOKENIZED, PARSED, VALIDATED, EMITTED;
 
     fun log(it: Any): HasLogger.() -> Unit = {
-        logger.info("********** $name **********\n$it\n########## $name ##########")
+        logger.debug("********** $name **********\n$it\n########## $name ##########")
     }
 }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Emitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Emitter.kt
@@ -35,7 +35,13 @@ abstract class Emitter(
 
     open fun emit(ast: AST): List<Emitted> = ast
         .map {
-            logger.info("Emitting Node $it")
+            logger.info(
+                "Emitting Node ${
+                    when (it) {
+                        is Definition -> it.emitName()
+                    }
+                }"
+            )
             when (it) {
                 is Type -> Emitted(it.emitName(), emit(it, ast))
                 is Endpoint -> Emitted(it.emitName(), emit(it))

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Parser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Parser.kt
@@ -21,7 +21,7 @@ import community.flock.wirespec.compiler.utils.Logger
 typealias AST = List<Node>
 
 abstract class AbstractParser(protected val logger: Logger) {
-    protected fun Token.log() = logger.info("Parsing $type at line ${coordinates.line} position ${coordinates.position}")
+    protected fun Token.log() = logger.debug("Parsing $type at line ${coordinates.line} position ${coordinates.position}")
 }
 
 class Parser(logger: Logger) : AbstractParser(logger) {


### PR DESCRIPTION
# Update:
After reconsidering this PR was rebranded to reduce the numbers of logs wirespec spits out.


The Pull Request mainly focuses on changes to the logging levels used within the Compiler, Emitter, and Parser classes in order to adjust verbosity and improve clarity.

- Updated log methods in Compiler.kt and Parser.kt to use debug instead of info for certain logs.
- Improved logging in Emitter.kt with more informative messages, especially when emitting nodes.
- No structural or logic changes are introduced, only logging modifications for better debugging insights.

Thanks @wilmveel  for the assist: https://github.com/flock-community/wirespec/pull/325#issuecomment-2611873429

## Before:
![Screen Recording 2025-01-23 at 23 19 42](https://github.com/user-attachments/assets/35375797-068d-4347-8c35-39a4e75c7705)

## After:
![Screen Recording 2025-01-24 at 17 28 20](https://github.com/user-attachments/assets/17a4ad7e-bf66-4cea-879f-25aaedd58364)

