### PR TITLE
fix: allow enum string values to include method names

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
@@ -64,7 +64,7 @@ object WirespecSpec : LanguageSpec {
         Regex("^\\?") to QuestionMark,
         Regex("^#") to Hash,
         Regex("^\\[\\]") to Brackets,
-        Regex("^GET|^POST|^PUT|^DELETE|^OPTIONS|^HEAD|^PATCH|^TRACE") to Method,
+        Regex("^\\b(GET|POST|PUT|DELETE|OPTIONS|HEAD|PATCH|TRACE)\\b") to Method,
         Regex("^[1-5][0-9][0-9]") to StatusCode,
         Regex("^[a-z`][a-zA-Z0-9_`]*") to CustomValue,
         Regex("^[A-Z][a-zA-Z0-9_]*") to customType,


### PR DESCRIPTION
#330 

it should work if methods are always distinct words