### PR TITLE
Ensure to release artifacts from all modules, unless explicitly excluded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,17 +220,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
       - name: Run
         run: |
-          ./gradlew :src:compiler:core:publish \
-                    :src:compiler:lib:publish \
-                    :src:converter:avro:publish \
-                    :src:converter:openapi:publish \
-                    :src:plugin:gradle:publish \
-                    :src:plugin:maven:publish \
-                    :src:plugin:arguments:publish \
-                    :src:integration:jackson:publish \
-                    :src:integration:wirespec:publish \
-                    :src:integration:spring:publish \
-                    :src:tools:generator:publish
+          ./gradlew publish
 
   release-lib-npm:
 

--- a/scripts/example.sh
+++ b/scripts/example.sh
@@ -1,16 +1,7 @@
 dir="$(dirname -- "$0")"
 
 ./gradlew \
-  src:converter:openapi:jvmJar \
-  src:plugin:arguments:jvmJar \
-  src:converter:avro:jvmJar \
-  src:converter:avro:publishToMavenLocal \
-  src:integration:avro:publishToMavenLocal \
-  src:integration:jackson:publishToMavenLocal \
-  src:integration:wirespec:publishToMavenLocal \
-  src:integration:spring:publishToMavenLocal \
-  src:plugin:gradle:publishToMavenLocal \
-  src:plugin:maven:publishToMavenLocal \
+  publishToMavenLocal \
   src:plugin:npm:jsNodeProductionLibraryDistribution &&
 (cd "$dir"/../src/ide/vscode && npm i && npm run build) &&
-(cd "$dir"/../examples && make clean && make build)
+(cd "$dir"/../examples && make clean build)

--- a/src/ide/intellij-plugin/build.gradle.kts
+++ b/src/ide/intellij-plugin/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 group = "${libs.versions.group.id.get()}.lsp.intellij-plugin"
 version = System.getenv(libs.versions.from.env.get()) ?: libs.versions.default.get()
 
+
 kotlin {
     jvmToolchain(libs.versions.java.get().toInt())
 }
@@ -14,6 +15,13 @@ repositories {
     mavenCentral()
     intellijPlatform {
         defaultRepositories()
+    }
+}
+
+plugins.withId("maven-publish") {
+    tasks.withType(AbstractPublishToMaven::class) {
+        logger.info("Disabling ${name} task in project ${project.name}...")
+        enabled = false
     }
 }
 

--- a/src/plugin/cli/build.gradle.kts
+++ b/src/plugin/cli/build.gradle.kts
@@ -7,12 +7,21 @@ plugins {
     alias(libs.plugins.kotlinx.resources)
 }
 
+
 group = "${libs.versions.group.id.get()}.plugin.cli"
 version = System.getenv(libs.versions.from.env.get()) ?: libs.versions.default.get()
 
 repositories {
     mavenCentral()
 }
+
+plugins.withId("maven-publish") {
+    tasks.withType(AbstractPublishToMaven::class) {
+        logger.info("Disabling ${name} task in project ${project.name}...")
+        enabled = false
+    }
+}
+
 
 kotlin {
     targets.all {

--- a/src/plugin/npm/build.gradle.kts
+++ b/src/plugin/npm/build.gradle.kts
@@ -10,6 +10,13 @@ repositories {
     mavenCentral()
 }
 
+plugins.withId("maven-publish") {
+    tasks.withType(AbstractPublishToMaven::class) {
+        logger.info("Disabling ${name} task in project ${project.name}...")
+        enabled = false
+    }
+}
+
 kotlin {
     js(IR) {
         nodejs()


### PR DESCRIPTION
Following a blacklist model to exclude artifacts from being published to maven central, seems like a more sensible thing, then whitelisting, at least for the moment. Seeing we've been missing the publication for almost all artifacts added in the past year: spring integration, cli arguments, integration wirespec, converter-avro, integration avro.
    

 To test this feature, I recommend to locally delete all artifacts of wirespec:
    
```bash
    rm -rfv ~/.m2/repository/community/flock/wirespec/
```
and then run `./scripts/example.sh` to see if all necessary artifacts are generated.

