### PR TITLE
Switch from CommonJS to EsModules

### DIFF
--- a/src/compiler/core/build.gradle.kts
+++ b/src/compiler/core/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
     linuxX64()
     js(IR) {
         nodejs()
+        useEsModules()
     }
     jvm {
         withJava()

--- a/src/compiler/lib/build.gradle.kts
+++ b/src/compiler/lib/build.gradle.kts
@@ -12,11 +12,6 @@ repositories {
 kotlin {
     js(IR) {
         nodejs()
-        generateTypeScriptDefinitions()
-        binaries.library()
-        compilations["main"].packageJson {
-            customField("name", "@flock/wirespec-lib")
-        }
     }
     jvm {
         withJava()

--- a/src/ide/vscode/package-lock.json
+++ b/src/ide/vscode/package-lock.json
@@ -8,13 +8,13 @@
       "name": "wirespec-vscode-plugin",
       "version": "0.0.0",
       "dependencies": {
+        "@flock/wirespec": "file:../../plugin/npm/build/dist/js/productionLibrary",
         "format-util": "^1.0.5",
         "source-map-support": "^0.5.21",
         "typescript": "^5.4.5",
         "vscode-languageclient": "9.0.1",
         "vscode-languageserver": "9.0.1",
-        "vscode-languageserver-textdocument": "1.0.11",
-        "wirespec": "file:../../plugin/npm/build/dist/js/productionLibrary"
+        "vscode-languageserver-textdocument": "1.0.11"
       },
       "devDependencies": {
         "@types/node": "^20.12.12",
@@ -33,7 +33,7 @@
       "name": "@flock/wirespec",
       "version": "0.0.0-SNAPSHOT",
       "bin": {
-        "wirespec": "wirespec-bin.js"
+        "wirespec": "wirespec-bin.mjs"
       },
       "devDependencies": {
         "source-map-support": "0.5.21",
@@ -407,6 +407,10 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@flock/wirespec": {
+      "resolved": "../../plugin/npm/build/dist/js/productionLibrary",
+      "link": true
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2207,10 +2211,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wirespec": {
-      "resolved": "../../plugin/npm/build/dist/js/productionLibrary",
-      "link": true
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/src/ide/vscode/package.json
+++ b/src/ide/vscode/package.json
@@ -14,13 +14,13 @@
   ],
   "main": "./build/extension",
   "dependencies": {
+    "@flock/wirespec": "file:../../plugin/npm/build/dist/js/productionLibrary",
     "format-util": "^1.0.5",
     "source-map-support": "^0.5.21",
     "typescript": "^5.4.5",
     "vscode-languageclient": "9.0.1",
     "vscode-languageserver": "9.0.1",
-    "vscode-languageserver-textdocument": "1.0.11",
-    "wirespec": "file:../../plugin/npm/build/dist/js/productionLibrary"
+    "vscode-languageserver-textdocument": "1.0.11"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",
@@ -28,7 +28,6 @@
     "esbuild": "^0.21.4",
     "prettier": "^3.2.5",
     "rimraf": "^5.0.7",
-
     "update-ruecksichtslos": "^0.0.17",
     "vsce": "^2.15.0"
   },

--- a/src/ide/vscode/src/server.ts
+++ b/src/ide/vscode/src/server.ts
@@ -1,12 +1,8 @@
+import { WsToken, tokenize, parse } from "@flock/wirespec";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { createConnection, DiagnosticSeverity, SemanticTokensBuilder, TextDocuments } from "vscode-languageserver";
 import { ServerCapabilities } from "vscode-languageserver-protocol/lib/common/protocol";
 import { Range, SemanticTokensLegend } from "vscode-languageserver-types";
-
-import { community } from "wirespec";
-import tokenize = community.flock.wirespec.plugin.npm.tokenize
-import parse = community.flock.wirespec.plugin.npm.parse
-import WsToken = community.flock.wirespec.compiler.lib.WsToken
 
 const getCompilerErrors = (text) => {
   const {errors} = parse(text);

--- a/src/plugin/npm/build.gradle.kts
+++ b/src/plugin/npm/build.gradle.kts
@@ -19,11 +19,12 @@ plugins.withId("maven-publish") {
 kotlin {
     js(IR) {
         nodejs()
+        useEsModules()
         generateTypeScriptDefinitions()
         binaries.library()
         compilations["main"].packageJson {
             customField("name", "@flock/wirespec")
-            customField("bin", mapOf("wirespec" to "wirespec-bin.js"))
+            customField("bin", mapOf("wirespec" to "wirespec-bin.mjs"))
         }
     }
 

--- a/src/plugin/npm/src/jsMain/resources/wirespec-bin.js
+++ b/src/plugin/npm/src/jsMain/resources/wirespec-bin.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-const cli = require("./wirespec-src-plugin-cli.js");
-cli.community.flock.wirespec.plugin.cli.cli(process.argv.slice(2))

--- a/src/plugin/npm/src/jsMain/resources/wirespec-bin.mjs
+++ b/src/plugin/npm/src/jsMain/resources/wirespec-bin.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import {cli} from "./wirespec-src-plugin-cli.mjs";
+
+// https://github.com/Kotlin/kotlinx-io/issues/345
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+import buffer from "node:buffer";
+global.require = function require(input) {
+    switch (input) {
+        case "os": return os
+        case "fs": return fs
+        case "path": return path
+        case "buffer": return buffer
+    }
+}
+
+cli(process.argv.slice(2))

--- a/src/plugin/npm/src/jsTest/kotlin/community/flock/wirespec/plugin/npm/MainTest.kt
+++ b/src/plugin/npm/src/jsTest/kotlin/community/flock/wirespec/plugin/npm/MainTest.kt
@@ -61,7 +61,7 @@ class MainTest {
             200 -> Todo
             404 -> Error
         }
-    """.trimIndent()
+        """.trimIndent()
 
     @Test
     fun testEmit() {

--- a/src/plugin/npm/src/jsTest/kotlin/community/flock/wirespec/plugin/npm/MainTest.kt
+++ b/src/plugin/npm/src/jsTest/kotlin/community/flock/wirespec/plugin/npm/MainTest.kt
@@ -5,24 +5,70 @@ import community.flock.wirespec.compiler.core.WirespecSpec
 import community.flock.wirespec.compiler.core.parse
 import community.flock.wirespec.compiler.lib.produce
 import community.flock.wirespec.compiler.utils.noLogger
-import kotlinx.io.buffered
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
-import kotlinx.io.readString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class MainTest {
 
+    private val personWs =
+        // language=ws
+        """
+        type TodoIdentifier /^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}${'$'}/g
+        type Name /^[0-9a-zA-Z]{1,50}${'$'}/g
+        type DutchPostalCode /^([0-9]{4}[A-Z]{2})${'$'}/g
+        type Date /^([0-9]{2}-[0-9]{2}-20[0-9]{2})${'$'}/g
+
+        type Address {
+          street: Name,
+          houseNumber: Integer,
+          postalCode: DutchPostalCode
+        }
+
+        type Person {
+          firstname: Name,
+          lastName: Name,
+          age: Integer,
+          address: Address
+        }
+
+        type Todo {
+          id: TodoIdentifier,
+          person: Person,
+          done: Boolean,
+          prio: Integer,
+          date: Date
+        }
+
+        type Error {
+          reason: String
+        }
+
+        endpoint GetTodos GET /todos -> {
+            200 -> Todo[]
+        }
+
+        endpoint PostTodo POST Todo /todos -> {
+            200 -> Todo
+        }
+
+        endpoint PutTodo PUT Todo /todos/{id: TodoIdentifier} -> {
+            200 -> Todo
+            404 -> Error
+        }
+
+        endpoint DeleteTodo DELETE /todos/{id: TodoIdentifier} -> {
+            200 -> Todo
+            404 -> Error
+        }
+    """.trimIndent()
+
     @Test
     fun testEmit() {
-        val path = Path("src/jsTest/resources/person.ws")
-        val file = SystemFileSystem.source(path).buffered().readString()
         val res = object : ParseContext {
             override val spec = WirespecSpec
             override val logger = noLogger
-        }.parse(file).getOrNull()
+        }.parse(personWs).getOrNull()
         assertNotNull(res)
         val openApiV2 = emit(res.produce(), Emitters.OPENAPI_V2, "")
         val openApiV3 = emit(res.produce(), Emitters.OPENAPI_V3, "")


### PR DESCRIPTION
Using EsModules instead of CommonJS, wirespec becomes more future proof in the (node)js ecosystem.

BREAKING: changing from one module system to another is breaking, and consumers might run into compatibility issues. Using dynamic imports, it is possible to use ES Modules in a commonJS context. Find out more here: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c


Especially the namespaces becomes a lot more trival with ESModule.

Take this example from the wirespec playground, which is a `module` type application, currently abusing the commonJS module.:

```ts
import {community} from "@flock/wirespec";

import Converters = community.flock.wirespec.plugin.npm.Converters;
import convert = community.flock.wirespec.plugin.npm.convert;
import emit = community.flock.wirespec.plugin.npm.emit;
import Emitters = community.flock.wirespec.plugin.npm.Emitters;
import WsEmitted = community.flock.wirespec.compiler.lib.WsEmitted;

export const openApiV2ToWirespec: (openapi: string) => WsEmitted[] = (x: string) => {
    const ast = convert(x, Converters.OPENAPI_V2);
    return emit(ast, Emitters.WIRESPEC, '');
};

export const openApiV3ToWirespec: (openapi: string) => WsEmitted[] = (x: string) => {
    const ast = convert(x, Converters.OPENAPI_V3);
    return emit(ast, Emitters.WIRESPEC, '');
};

```

which can be changes into the following after this PR is merged and included in a release:

```ts
import {Converters, convert, emit, Emitters, WsEmitted} from "@flock/wirespec";

export const openApiV2ToWirespec: (openapi: string) => WsEmitted[] = (x: string) => {
    const ast = convert(x, Converters.OPENAPI_V2);
    return emit(ast, Emitters.WIRESPEC, '');
};

export const openApiV3ToWirespec: (openapi: string) => WsEmitted[] = (x: string) => {
    const ast = convert(x, Converters.OPENAPI_V3);
    return emit(ast, Emitters.WIRESPEC, '');
};

export const avroToWirespec: (avro: string) => WsEmitted[] = (x: string) => {
    const ast = convert(x, Converters.AVRO);
    return emit(ast, Emitters.WIRESPEC, '');
};

```