### PR TITLE
Bom

### DIFF
--- a/examples/maven-spring-custom/app/pom.xml
+++ b/examples/maven-spring-custom/app/pom.xml
@@ -32,10 +32,12 @@
             <plugin>
                 <groupId>community.flock.wirespec.plugin.maven</groupId>
                 <artifactId>wirespec-maven-plugin</artifactId>
+                <version>${wirespec.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>community.flock.wirespec.example.maven</groupId>
                         <artifactId>emitter</artifactId>
+                        <version>${wirespec.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/examples/maven-spring-custom/app/pom.xml
+++ b/examples/maven-spring-custom/app/pom.xml
@@ -37,7 +37,7 @@
                     <dependency>
                         <groupId>community.flock.wirespec.example.maven</groupId>
                         <artifactId>emitter</artifactId>
-                        <version>${wirespec.version}</version>
+                        <version>0.0.0-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/examples/maven-spring-custom/app/pom.xml
+++ b/examples/maven-spring-custom/app/pom.xml
@@ -32,12 +32,10 @@
             <plugin>
                 <groupId>community.flock.wirespec.plugin.maven</groupId>
                 <artifactId>wirespec-maven-plugin</artifactId>
-                <version>0.0.0-SNAPSHOT</version>
                 <dependencies>
                     <dependency>
                         <groupId>community.flock.wirespec.example.maven</groupId>
                         <artifactId>emitter</artifactId>
-                        <version>0.0.0-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/examples/maven-spring-custom/emitter/pom.xml
+++ b/examples/maven-spring-custom/emitter/pom.xml
@@ -14,7 +14,6 @@
         <dependency>
             <groupId>community.flock.wirespec.compiler</groupId>
             <artifactId>core-jvm</artifactId>
-            <version>0.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/examples/maven-spring-custom/pom.xml
+++ b/examples/maven-spring-custom/pom.xml
@@ -11,14 +11,14 @@
     <artifactId>maven-spring-custom</artifactId>
     <packaging>pom</packaging>
 
-    <properties>
-        <wirespec.version>0.0.0-SNAPSHOT</wirespec.version>
-    </properties>
-
     <modules>
         <module>app</module>
         <module>emitter</module>
     </modules>
+
+    <properties>
+        <wirespec.version>0.0.0-SNAPSHOT</wirespec.version>
+    </properties>
 
     <dependencyManagement>
         <dependencies>

--- a/examples/maven-spring-custom/pom.xml
+++ b/examples/maven-spring-custom/pom.xml
@@ -11,8 +11,24 @@
     <artifactId>maven-spring-custom</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <wirespec.version>0.0.0-SNAPSHOT</wirespec.version>
+    </properties>
+
     <modules>
         <module>app</module>
         <module>emitter</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>community.flock.wirespec</groupId>
+                <artifactId>bom</artifactId>
+                <version>${wirespec.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ spotless = "7.0.2"
 spring_boot = "3.3.4"
 spring_webflux = "6.1.13"
 spring_dependency_management = "1.1.6"
+gradlebom_plugin = "1.0.0.Final"
 
 [libraries]
 arrow_core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
@@ -75,3 +76,4 @@ node_gradle_plugin = { id = "com.github.node-gradle.node", version.ref = "node_g
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 spring_boot = { id = "org.springframework.boot", version.ref = "spring_boot" }
 spring_dependency_management = { id = "io.spring.dependency-management", version.ref = "spring_dependency_management" }
+gradlebom_plugin = { id = "io.github.gradlebom.generator-plugin", version.ref = "gradlebom_plugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
 }
 
 include(
+    "src:bom",
     "src:compiler:core",
     "src:compiler:lib",
     "src:ide:intellij-plugin",

--- a/src/bom/build.gradle.kts
+++ b/src/bom/build.gradle.kts
@@ -14,5 +14,4 @@ bomGenerator {
     includeDependency("$group.integration", "jackson-jvm", "$version")
     includeDependency("$group.integration", "spring-jvm", "$version")
     includeDependency("$group.integration", "wirespec-jvm", "$version")
-
 }

--- a/src/bom/build.gradle.kts
+++ b/src/bom/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    alias(libs.plugins.gradlebom.plugin)
+}
+
+group = "${libs.versions.group.id.get()}"
+version = System.getenv(libs.versions.from.env.get()) ?: libs.versions.default.get()

--- a/src/bom/build.gradle.kts
+++ b/src/bom/build.gradle.kts
@@ -4,3 +4,15 @@ plugins {
 
 group = "${libs.versions.group.id.get()}"
 version = System.getenv(libs.versions.from.env.get()) ?: libs.versions.default.get()
+
+bomGenerator {
+    includeDependency("$group.compiler", "core-jvm", "$version")
+    includeDependency("$group.compiler", "lib-jvm", "$version")
+    includeDependency("$group.converter", "avro-jvm", "$version")
+    includeDependency("$group.converter", "openapi-jvm", "$version")
+    includeDependency("$group.integration", "avro-jvm", "$version")
+    includeDependency("$group.integration", "jackson-jvm", "$version")
+    includeDependency("$group.integration", "spring-jvm", "$version")
+    includeDependency("$group.integration", "wirespec-jvm", "$version")
+
+}


### PR DESCRIPTION
Publish bill of materials (BOM) for Wirespec. Instead of taking a dependency on all different modules the BOM can be loaded in the dependency manager.

```
<dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>community.flock.wirespec</groupId>
      <artifactId>bom</artifactId>
       <version>VERSION</version>
       <type>pom</type>
        <scope>import</scope>
    </dependency>
  </dependencies>
</dependencyManagement>
```