### PR TITLE
playground - add default package name for emitted code. Improve syntax highlighting

### DIFF
--- a/src/site/playground/src/components/PlayGroundInput.tsx
+++ b/src/site/playground/src/components/PlayGroundInput.tsx
@@ -1,14 +1,20 @@
 import Editor from "@monaco-editor/react";
+import { Language } from "../routes";
 
 interface PlayGroundInputProps {
   code: string;
   setCode: (input: string) => void;
+  language: Language;
 }
 
-export function PlayGroundInput({ code, setCode }: PlayGroundInputProps) {
+export function PlayGroundInput({
+  code,
+  setCode,
+  language,
+}: PlayGroundInputProps) {
   return (
     <Editor
-      language="wirespec"
+      language={language}
       theme="vs-dark"
       height="100vh"
       options={{ minimap: { enabled: false } }}

--- a/src/site/playground/src/components/PlayGroundOutput.tsx
+++ b/src/site/playground/src/components/PlayGroundOutput.tsx
@@ -1,8 +1,9 @@
 import Editor from "@monaco-editor/react";
+import { Language } from "../routes";
 
 interface PlayGroundOutputProps {
   code: string;
-  language: string;
+  language: Language;
 }
 
 export function PlayGroundOutput({ code, language }: PlayGroundOutputProps) {

--- a/src/site/playground/src/routes/index.tsx
+++ b/src/site/playground/src/routes/index.tsx
@@ -35,6 +35,14 @@ export type CompilerEmitter =
 export type ConverterEmitter = "wirespec";
 export type Emitter = CompilerEmitter | ConverterEmitter;
 
+export type Language =
+  | "wirespec"
+  | "kotlin"
+  | "java"
+  | "typescript"
+  | "scala"
+  | "json";
+
 type Search = {
   specification: Specification;
   emitter: Emitter;
@@ -43,10 +51,11 @@ type Search = {
 export type CompilationResult = {
   result: WsEmitted[];
   errors: WsError[];
+  language: Language;
 };
 
-function createFileHeaderFor(fileName: string, language: string) {
-  switch (language) {
+const createFileHeaderFor = (fileName: string, emitter: Emitter): string => {
+  switch (emitter) {
     case "typescript":
     case "kotlin":
     case "scala":
@@ -57,10 +66,8 @@ function createFileHeaderFor(fileName: string, language: string) {
       return "";
     case "java":
       return `\n/**\n/* ${fileName}\n**/\n`;
-    default:
-      throw `unknown language: ${language}`;
   }
-}
+};
 
 export const Route = createFileRoute("/")({
   component: RouteComponent,
@@ -169,13 +176,20 @@ function RouteComponent() {
       <Box flex={1}>
         <SpecificationSelector />
         <Box marginTop={1} height="100%">
-          <PlayGroundInput code={code} setCode={setCode} />
+          <PlayGroundInput
+            code={code}
+            setCode={setCode}
+            language={specification === "wirespec" ? "wirespec" : "json"}
+          />
         </Box>
       </Box>
       <Box flex={1}>
         <EmitterSelector />
         <Box marginTop={1} minHeight="80vh" height="100%">
-          <PlayGroundOutput code={wirespecResult} language={emitter} />
+          <PlayGroundOutput
+            code={wirespecResult}
+            language={wirespecOutput?.language || "wirespec"}
+          />
         </Box>
       </Box>
     </StyledContainer>

--- a/src/site/playground/src/transformations/OpenAPIToWirespec.tsx
+++ b/src/site/playground/src/transformations/OpenAPIToWirespec.tsx
@@ -1,31 +1,35 @@
-import {
-  Converters,
-  convert,
-  emit,
-  Emitters,
-  type WsEmitted,
-} from "@flock/wirespec";
+import { Converters, convert, emit, Emitters } from "@flock/wirespec";
+import { CompilationResult } from "../routes";
 
-export const openApiV2ToWirespec: (openapi: string) => {
-  result: WsEmitted[];
-  errors: [];
-} = (x: string) => {
+export const openApiV2ToWirespec: (openapi: string) => CompilationResult = (
+  x: string,
+) => {
   const ast = convert(x, Converters.OPENAPI_V2);
-  return { result: emit(ast, Emitters.WIRESPEC, ""), errors: [] };
+  return {
+    result: emit(ast, Emitters.WIRESPEC, ""),
+    errors: [],
+    language: "wirespec",
+  };
 };
 
-export const openApiV3ToWirespec: (openapi: string) => {
-  result: WsEmitted[];
-  errors: [];
-} = (x: string) => {
+export const openApiV3ToWirespec: (openapi: string) => CompilationResult = (
+  x: string,
+) => {
   const ast = convert(x, Converters.OPENAPI_V3);
-  return { result: emit(ast, Emitters.WIRESPEC, ""), errors: [] };
+  return {
+    result: emit(ast, Emitters.WIRESPEC, ""),
+    errors: [],
+    language: "wirespec",
+  };
 };
 
-export const avroToWirespec: (avro: string) => {
-  result: WsEmitted[];
-  errors: [];
-} = (x: string) => {
+export const avroToWirespec: (avro: string) => CompilationResult = (
+  x: string,
+) => {
   const ast = convert(x, Converters.AVRO);
-  return { result: emit(ast, Emitters.WIRESPEC, ""), errors: [] };
+  return {
+    result: emit(ast, Emitters.WIRESPEC, ""),
+    errors: [],
+    language: "wirespec",
+  };
 };

--- a/src/site/playground/src/transformations/WirespecToTarget.tsx
+++ b/src/site/playground/src/transformations/WirespecToTarget.tsx
@@ -1,8 +1,10 @@
-import { parse, emit, Emitters, WsEmitted, WsError } from "@flock/wirespec";
-import { CompilationResult } from "../routes/index";
+import { emit, Emitters, parse, WsEmitted, WsError } from "@flock/wirespec";
+import { CompilationResult, Emitter, Language } from "../routes";
 
-const getEmitterFor = (language: string) => {
-  switch (language) {
+const getEmitterFor: (emitter: Emitter) => Emitters = (emitter: Emitter) => {
+  switch (emitter) {
+    case "wirespec":
+      return Emitters.WIRESPEC;
     case "typescript":
       return Emitters.TYPESCRIPT;
     case "kotlin":
@@ -17,24 +19,55 @@ const getEmitterFor = (language: string) => {
       return Emitters.OPENAPI_V3;
     case "avro":
       return Emitters.AVRO;
-    default:
-      throw new Error(`unknown language: ${language}`);
   }
 };
 
-export const wirespecToTarget: (x: string, y: string) => CompilationResult = (
+const getLanguageFor: (emitter: Emitter) => Language = (emitter: Emitter) => {
+  switch (emitter) {
+    case "typescript":
+    case "kotlin":
+    case "scala":
+    case "java":
+    case "wirespec":
+      return emitter;
+    case "open_api_v2":
+    case "open_api_v3":
+    case "avro":
+      return "json";
+  }
+};
+
+export const wirespecToTarget: (
   wirespec: string,
-  language: string,
-) => {
-  const emitter = getEmitterFor(language);
+  emitter: Emitter,
+) => CompilationResult = (wirespec, emitter) => {
+  const internalEmitter = getEmitterFor(emitter);
   const parseResult = parse(wirespec);
   let result = [] as WsEmitted[];
   let errors = [] as WsError[];
   if (parseResult.result) {
-    result = emit(parseResult.result, emitter, "");
+    result = emit(
+      parseResult.result,
+      internalEmitter,
+      "community.flock.wirespec.generated",
+    );
+    if (
+      internalEmitter === Emitters.OPENAPI_V3 ||
+      internalEmitter === Emitters.OPENAPI_V2 ||
+      internalEmitter === Emitters.AVRO
+    ) {
+      result = result.map((it) => ({
+        typeName: it.typeName,
+        result: prettyJson(it.result),
+      }));
+    }
   }
   if (parseResult.errors) {
     errors = parseResult.errors;
   }
-  return { result, errors };
+  return { result, errors, language: getLanguageFor(emitter) };
+};
+
+const prettyJson = (code: string) => {
+  return JSON.stringify(JSON.parse(code), null, 2);
 };


### PR DESCRIPTION


Chores:
- Added default package name `community.flock.wirespec.generated` for generated code, (fixing the empty 'package ' line for kotlin,java,scala

![image](https://github.com/user-attachments/assets/d79fcd5e-1525-45f0-bb5e-9aea2389fedb)

- Ensured Json output from Avro and OpenAPI is prettified and syntax highlighting works.

old
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0fd3d3bf-d9e3-45ca-ace1-5606a28a88bc" />

new
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/3a0c775a-d559-4f7f-bf37-c056aa39af18" />


Misc:
- Improved typesafe handling of input args for specification and emitter, allowing for exhaustive switches in functions.
- `CompilationResult` is extended with Language ('json', 'wirespec', 'kotlin', etc.) to help signal the code editors which syntax highlighting to use.

Left todo (out of scope): improve the query param validation to ensure only allowed emitters / specifications are used