### PR TITLE
Python emitter

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
@@ -201,7 +201,7 @@ open class PythonEmitter(
         |@staticmethod
         |def to_raw_request(serialization: Wirespec.Serializer, request: Request) -> Wirespec.RawRequest:
         |${Spacer}return Wirespec.RawRequest(
-        |${Spacer}${Spacer}path = [${path.joinToString { when (it) {is Endpoint.Segment.Literal -> """"${it.value}""""; is Endpoint.Segment.Param -> "request.path.${it.identifier.value}"} }}],
+        |${Spacer}${Spacer}path = [${path.joinToString { when (it) {is Endpoint.Segment.Literal -> """"${it.value}""""; is Endpoint.Segment.Param -> "str(request.path.${it.identifier.value})"} }}],
         |${Spacer}${Spacer}method = request.method.value,
         |${Spacer}${Spacer}queries = ${if (queries.isNotEmpty()) queries.joinToString(", ", "{", "}") { it.emitSerializedParams("request", "queries") } else "{}"},
         |${Spacer}${Spacer}headers = ${if (headers.isNotEmpty()) headers.joinToString(", ", "{", "}") { it.emitSerializedParams("request", "headers") } else "{}"},

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
@@ -1,0 +1,347 @@
+package community.flock.wirespec.compiler.core.emit
+
+import arrow.core.NonEmptyList
+import arrow.core.toNonEmptyListOrNull
+import community.flock.wirespec.compiler.core.emit.common.DEFAULT_GENERATED_PACKAGE_STRING
+import community.flock.wirespec.compiler.core.emit.common.Emitted
+import community.flock.wirespec.compiler.core.emit.common.Emitter
+import community.flock.wirespec.compiler.core.emit.common.Keywords
+import community.flock.wirespec.compiler.core.emit.common.PackageName
+import community.flock.wirespec.compiler.core.emit.common.Spacer
+import community.flock.wirespec.compiler.core.orNull
+import community.flock.wirespec.compiler.core.parse.AST
+import community.flock.wirespec.compiler.core.parse.Channel
+import community.flock.wirespec.compiler.core.parse.Definition
+import community.flock.wirespec.compiler.core.parse.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.Endpoint
+import community.flock.wirespec.compiler.core.parse.Enum
+import community.flock.wirespec.compiler.core.parse.Field
+import community.flock.wirespec.compiler.core.parse.FieldIdentifier
+import community.flock.wirespec.compiler.core.parse.Identifier
+import community.flock.wirespec.compiler.core.parse.Node
+import community.flock.wirespec.compiler.core.parse.Reference
+import community.flock.wirespec.compiler.core.parse.Refined
+import community.flock.wirespec.compiler.core.parse.Type
+import community.flock.wirespec.compiler.core.parse.Union
+import community.flock.wirespec.compiler.utils.Logger
+
+open class PythonEmitter(
+    private val packageName: PackageName = PackageName(DEFAULT_GENERATED_PACKAGE_STRING),
+) : Emitter(true) {
+
+    val import = """
+        |from abc import abstractmethod
+        |from dataclasses import dataclass
+        |from .shared.Wirespec import T, Wirespec
+        |from typing import List, Optional
+    """.trimMargin()
+
+    override fun Definition.emitName(): String = when (this) {
+        is Endpoint -> "${emit(identifier)}Endpoint"
+        is Channel -> "${emit(identifier)}Channel"
+        is Enum -> emit(identifier)
+        is Refined -> emit(identifier)
+        is Type -> emit(identifier)
+        is Union -> emit(identifier)
+    }
+
+    override val singleLineComment = "#"
+
+    override fun emit(ast: AST, logger: Logger): NonEmptyList<Emitted> {
+        val list = ast.filterIsInstance<Enum>() + ast.filterIsInstance<Refined>() + ast.filterIsInstance<Type>() + ast.filterIsInstance<Union>() + ast.filterIsInstance<Endpoint>() + ast.filterIsInstance<Channel>()
+        return super.emit(list.toNonEmptyListOrNull() ?: error("Non e"), logger).map { (typeName, result) ->
+            Emitted(
+                typeName = typeName.sanitizeSymbol(),
+                result = """
+                    |$import
+                    |
+                    |$result
+                """.trimMargin()
+            )
+        }
+    }
+
+    private fun Node.localImports():List<Reference.Custom> = when (this) {
+        is Channel -> TODO()
+        is Endpoint -> listOf(
+            path.filterIsInstance<Param>().map { it.reference },
+            headers.map { it.reference },
+            queries.map { it.reference },
+            requests.map { it.content?.reference },
+            responses.flatMap { listOf(it.content?.reference) + it.headers.map { it.reference }}
+        ).flatten().filterNotNull().map { it.flattenListDict() }.filterIsInstance<Reference.Custom>().distinct()
+        is Enum -> TODO()
+        is Refined -> TODO()
+        is Type -> shape.value.map { it.reference.flattenListDict() }.filterIsInstance<Reference.Custom>().distinct()
+        is Union -> TODO()
+    }
+
+    private fun Reference.flattenListDict():Reference = when (this) {
+        is Reference.Dict -> reference.flattenListDict()
+        is Reference.Iterable -> reference.flattenListDict()
+        else -> this
+    }
+
+    private fun Reference.Custom.emitReferenceCustomImports() = "from .${value} import ${value}"
+
+    override fun emit(type: Type, ast: AST): String =
+        if (type.shape.value.isEmpty()) """
+            |${type.localImports().joinToString ("\n"){ it.emitReferenceCustomImports() }}
+            |
+            |@dataclass
+            |class ${type.emitName()}:
+            |${Spacer}pass
+            |
+        """.trimMargin()
+        else """
+            |${type.localImports().joinToString ("\n"){ it.emitReferenceCustomImports() }}
+            |
+            |@dataclass
+            |class ${type.emitName()}${type.extends.run { if (isEmpty()) "" else "(${joinToString(", ") { it.emit() }})" }}:
+            |${type.shape.emit()}
+            |
+        """.trimMargin()
+
+    override fun Type.Shape.emit() = value.joinToString("\n") { "${Spacer}${it.emit()}" }
+
+    private fun Endpoint.Segment.Param.emit() = "${emit(identifier)}: ${reference.emit()} "
+
+    override fun Field.emit() = "${emit(identifier)}: ${reference.emit()}"
+
+    private fun Param.emit() = "${emit(identifier)}: ${reference.emit()}"
+    private fun Param.emitAssignSelf() = "${emit(identifier)} = ${emit(identifier)}"
+    private fun Endpoint.Request.emitAssignSelf(endpoint: Endpoint) = """
+        |self.path = ${endpoint.emitName()}.Request.Path(${paramList(endpoint).filter { it.type == Param.ParamType.PATH }.joinToString { it.emitAssignSelf() }})
+        |self.queries = ${endpoint.emitName()}.Request.Queries(${paramList(endpoint).filter { it.type == Param.ParamType.QUERY }.joinToString { it.emitAssignSelf() }})
+        |self.headers = ${endpoint.emitName()}.Request.Headers(${paramList(endpoint).filter { it.type == Param.ParamType.HEADER }.joinToString { it.emitAssignSelf() }})
+        |self.body = body
+    """.trimMargin()
+
+    private fun Endpoint.Response.emitAssignSelf(endpoint: Endpoint) = """
+        |self.headers = ${endpoint.emitName()}.Response${status}.Headers(${paramList().filter { it.type == Param.ParamType.HEADER }.joinToString { it.emitAssignSelf() }})
+        |self.body = body
+    """.trimMargin()
+
+    override fun Reference.emit(): String = when (this) {
+        is Reference.Dict -> "Dict[str, ${reference.emit()}]"
+        is Reference.Iterable -> "List[${reference.emit()}]"
+        is Reference.Unit -> "None"
+        is Reference.Any -> "Any"
+        is Reference.Custom -> value
+        is Reference.Primitive -> when (type) {
+            is Reference.Primitive.Type.String -> "str"
+            is Reference.Primitive.Type.Integer -> "int"
+            is Reference.Primitive.Type.Number -> "float"
+            is Reference.Primitive.Type.Boolean -> "bool"
+            is Reference.Primitive.Type.Bytes -> "bytes"
+        }
+    }.let { if (isNullable) "Optional[$it]" else it }
+
+    override fun emit(identifier: Identifier) = when (identifier) {
+        is DefinitionIdentifier -> identifier.value.sanitizeSymbol()
+        is FieldIdentifier -> identifier.value.sanitizeSymbol().sanitizeKeywords()
+    }
+
+    override fun emit(refined: Refined) = """
+        |@dataclass
+        |class ${refined.identifier.value.sanitizeSymbol()}(Wirespec.Refined):
+        |${Spacer}value: str
+        |
+        |${Spacer}def validate(self) -> bool:
+        |${Spacer(2)}return bool(re.match(r"${refined.validator.expression}", self.value))
+        |
+        |${Spacer}def __str__(self) -> str:
+        |${Spacer(2)}return self.value
+    """.trimMargin()
+
+    override fun emit(endpoint: Endpoint) = """
+        |${endpoint.localImports().joinToString ("\n"){ it.emitReferenceCustomImports() }}
+        |
+        |class ${emit(endpoint.identifier)}Endpoint (Wirespec.Endpoint):
+        |${endpoint.requests.first().emit(endpoint).spacer(1)}
+        |${endpoint.emitToRawRequest().spacer(1)}
+        |${endpoint.requests.first().emitFromRawRequest(endpoint).spacer(1)}
+        |${endpoint.responses.joinToString ("\n"){it.emit(endpoint)}.spacer(1)}
+        |${endpoint.emitResponseUnion().spacer(1)}
+        |${endpoint.emitToRawResponse().spacer(1)}
+        |${endpoint.emitFromRawResponse().spacer(1)}
+        |${endpoint.emitHandleClass().spacer(1)}
+        |
+        """.trimMargin()
+
+    private fun Endpoint.emitResponseUnion() = """
+        |Response = ${responses.joinToString(" | "){ "Response${it.status}" }}
+        |
+    """.trimMargin()
+
+    private fun Endpoint.emitHandleClass() = """
+        |@abstractmethod
+        |def ${identifier.value}(self, req: Request) -> Response: pass
+    """.trimMargin()
+
+    fun Endpoint.Request.emit(endpoint: Endpoint) = """
+        |@dataclass
+        |class Request(Wirespec.Request[${content.emit()}]):
+        |${endpoint.pathParams.emitObject("Path", "Wirespec.Request.Path") { it.emit() }}
+        |${endpoint.queries.emitObject("Queries", "Wirespec.Request.Queries") { it.emit() }}
+        |${endpoint.headers.emitObject("Headers", "Wirespec.Request.Headers") { it.emit() }}
+        | 
+        |${Spacer}body: ${content.emit()} = None
+        |${Spacer}method: Wirespec.Method = Wirespec.Method.${endpoint.method.name}
+        |${Spacer}path: Path = None
+        |${Spacer}queries: Queries = None
+        |${Spacer}headers: Headers = None
+        |
+        |${Spacer}def __init__(self, ${paramList(endpoint).joinToString (", "){ it.emit() }}):
+        |${emitAssignSelf(endpoint).spacer(2)}
+        |
+        """.trimMargin()
+
+    private fun Endpoint.emitToRawRequest() = """
+        |@staticmethod
+        |def to_raw_request(serialization: Wirespec.Serializer, request: Request) -> Wirespec.RawRequest:
+        |${Spacer}return Wirespec.RawRequest(
+        |${Spacer}${Spacer}path = [${path.joinToString { when (it) {is Endpoint.Segment.Literal -> """"${it.value}""""; is Endpoint.Segment.Param -> "request.path.${it.identifier.value}"} }}],
+        |${Spacer}${Spacer}method = request.method.value,
+        |${Spacer}${Spacer}queries = ${if (queries.isNotEmpty()) queries.joinToString(", ", "{", "}") { it.emitSerializedParams("request", "queries") } else "{}"},
+        |${Spacer}${Spacer}headers = ${if (headers.isNotEmpty()) headers.joinToString(", ", "{", "}") { it.emitSerializedParams("request", "headers") } else "{}"},
+        |${Spacer}${Spacer}body = serialization.serialize(request.body, ${this.requests.first().content.emit()}),
+        |${Spacer})
+        |
+    """.trimMargin()
+
+    private fun Endpoint.Request.emitFromRawRequest(endpoint: Endpoint) = """
+        |@staticmethod
+        |def from_raw_request(serialization: Wirespec.Deserializer, request: Wirespec.RawRequest) -> Request:
+        |${Spacer}return ${endpoint.emitName()}.Request${emitDeserializedParams(endpoint)}
+        |
+    """.trimMargin()
+
+    private fun Endpoint.Request.emitDeserializedParams(endpoint: Endpoint) = listOfNotNull(
+        endpoint.indexedPathParams.joinToString { it.emitDeserialized() }.orNull(),
+        endpoint.queries.joinToString (",\n"){ it.emitDeserializedParams("request", "queries") }.orNull(),
+        endpoint.headers.joinToString (",\n"){ it.emitDeserializedParams("request", "headers") }.orNull(),
+        content?.let { """${Spacer(3)}body = serialization.deserialize(request.body, ${it.emit()}),""" }
+    ).joinToString(",\n").let { if (it.isBlank()) "" else "(\n$it\n)" }
+
+    private fun IndexedValue<Endpoint.Segment.Param>.emitDeserialized() =
+        """${Spacer(3)}${emit(value.identifier)} = serialization.deserialize(request.path[${index}], ${value.reference.emit()})"""
+
+    private fun Field.emitDeserializedParams(type: String, fields: String) =
+        if (reference.isNullable)
+            """${emit(identifier)} = serialization.deserialize_param($type.$fields["${identifier.value}"], ${reference.emit()})"""
+        else
+            """${emit(identifier)} = serialization.deserialize_param($type.$fields["${identifier.value}"], ${reference.emit()})"""
+
+    fun Endpoint.Response.emit(endpoint: Endpoint) = """
+        |@dataclass
+        |class Response${status}(Wirespec.Response[${content.emit()}]):
+        |${headers.emitObject("Headers", "Wirespec.Response.Headers") { it.emit() }}
+        |
+        |${Spacer}body: ${content.emit()} = None
+        |${Spacer}status: int = $status
+        |${Spacer}headers: Headers = None
+        |
+        |${Spacer}def __init__(self, ${paramList().joinToString (", "){ it.emit() }}):
+        |${emitAssignSelf(endpoint).spacer(2)}
+        |
+        """.trimMargin()
+
+    private fun Endpoint.emitToRawResponse() = """
+        |@staticmethod
+        |def to_raw_response(serialization: Wirespec.Serializer, response: Response) -> Wirespec.RawResponse:
+        |${Spacer}match response:
+        |${responses.distinctBy { it.status }.joinToString("\n") { it.emitSerialized(this) }.spacer(2)}
+        |
+        """.trimMargin()
+
+    private fun Endpoint.emitFromRawResponse() = """
+        |@staticmethod
+        |def from_raw_response(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> Response:
+        |${Spacer}match response.status_code:
+        |${responses.filter { it.status.isStatusCode() }.distinctBy { it.status }.joinToString("\n") { it.emitDeserialized(this) }.spacer(2)}
+        |${Spacer(2)}case _: 
+        |${Spacer(3)}raise Exception("Cannot match response with status: " + str(response.status_code))
+        |
+    """.trimMargin()
+
+    private fun Endpoint.Response.emitDeserialized(endpoint: Endpoint) = listOfNotNull(
+        "case $status:",
+        "${Spacer}return ${endpoint.emitName()}.Response$status(",
+        "${Spacer(2)}body = serialization.deserialize(response.body, ${content.emit()}),",
+        headers.joinToString(",\n") { it.emitDeserializedParams("response", "headers") }.orNull()?.spacer(2),
+        "${Spacer})"
+    ).joinToString("\n")
+
+
+    private fun Endpoint.Response.emitSerialized(endpoint: Endpoint) = """
+        |case ${endpoint.emitName()}.Response$status():
+        |${Spacer(1)}return Wirespec.RawResponse(
+        |${Spacer(2)}status_code = response.status,
+        |${Spacer(2)}headers = ${if (headers.isNotEmpty()) headers.joinToString(", ", "{", "}") { it.emitSerializedParams("response", "headers") } else "{}"},
+        |${Spacer(2)}body = ${if (content != null) "serialization.serialize(response.body, ${content.emit()})" else "null"},
+        |${Spacer(1)})
+    """.trimMargin()
+
+    private fun Field.emitSerializedParams(type: String, fields: String) =
+        """"${emit(identifier)}": serialization.serialize_param($type.$fields.${emit(identifier)}, ${reference.emit()})"""
+
+
+    private fun <E> List<E>.emitObject(name: String, extends: String, spaces: Int = 1, block: (E) -> String) =
+        if (isEmpty()) """
+            |${Spacer(spaces)}@dataclass
+            |${Spacer(spaces)}class $name ($extends): pass
+        """.trimMargin()
+        else """
+            |${Spacer(spaces)}@dataclass
+            |${Spacer(spaces)}class $name ($extends):
+            |${joinToString("\n") { "${Spacer(spaces + 2)}${block(it)}" }}
+        """.trimMargin()
+
+    override fun emit(channel: Channel) = ""
+
+    override fun Refined.Validator.emit() = "re.compile(r\"${expression}\").match(value) is not None"
+
+    override fun emit(enum: Enum, ast: AST) = """
+        |class ${enum.identifier.value.sanitizeSymbol()}(str, Enum):
+        |${enum.entries.joinToString("\n") { "${Spacer}${it.sanitizeEnum().sanitizeKeywords()} = \"$it\"" }}
+        |
+        |${Spacer}@property
+        |${Spacer}def label(self) -> str:
+        |${Spacer(2)}return self.value
+        |
+        |${Spacer}def __str__(self) -> str:
+        |${Spacer(2)}return self.value
+    """.trimMargin()
+
+    override fun emit(union: Union) = """
+        |class ${union.emitName()}(ABC):
+        |${Spacer}pass
+    """.trimMargin()
+
+    private fun Endpoint.Content?.emit() = this?.reference?.emit() ?: "None"
+
+    private fun String.sanitizeSymbol() = this
+        .split(".", " ")
+        .mapIndexed { index, s -> if (index > 0) s.firstToUpper() else s }
+        .joinToString("")
+        .filter { it.isLetterOrDigit() || it == '_' }
+        .let { if (it.firstOrNull()?.isDigit() == true) "_$it" else it }
+
+    fun String.sanitizeEnum() = split("-", ", ", ".", " ", "//").joinToString("_")
+        .let { if (it.firstOrNull()?.isDigit() == true) "_$it" else it }
+
+    fun String.sanitizeKeywords() = if (this in reservedKeywords) "_$this" else this
+
+    companion object : Keywords {
+        override val reservedKeywords = setOf(
+            "False", "None", "True", "and", "as", "assert",
+            "break", "class", "continue", "def", "del",
+            "elif", "else", "except", "finally", "for",
+            "from", "global", "if", "import", "in",
+            "is", "lambda", "nonlocal", "not", "or",
+            "pass", "raise", "return", "try", "while",
+            "with", "yield"
+        )
+    }
+}

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
@@ -75,7 +75,7 @@ open class PythonEmitter(
                             |$result
                         """.trimMargin().trimStart()
                 )
-            } + Emitted("__init__", "")
+            } + Emitted("__init__", module.statements.map { "from .${it.emitName()} import ${it.emitName()}" }.joinToString("\n"))
     }
 
     private fun Node.localImports():List<Reference.Custom> = when (this) {
@@ -104,20 +104,19 @@ open class PythonEmitter(
 
     override fun emit(type: Type, module: Module): String =
         if (type.shape.value.isEmpty()) """
-            |${type.localImports().joinToString ("\n"){ it.emitReferenceCustomImports() }}
-            |
             |@dataclass
             |class ${type.emitName()}:
             |${Spacer}pass
             |
-        """.trimMargin()
-        else """
             |${type.localImports().joinToString ("\n"){ it.emitReferenceCustomImports() }}
             |
+        """.trimMargin()
+        else """
             |@dataclass
             |class ${type.emitName()}:
             |${type.shape.emit()}
             |
+            |${type.localImports().joinToString ("\n"){ it.emitReferenceCustomImports() }}
         """.trimMargin()
 
     override fun Type.Shape.emit() = value.joinToString("\n") { "${Spacer}${it.emit()}" }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
@@ -202,8 +202,9 @@ open class PythonEmitter(
     """.trimMargin()
 
     private fun Endpoint.emitHandleClass() = """
-        |@abstractmethod
-        |def ${identifier.value}(self, req: Request) -> Response: pass
+        |class Handler(Wirespec.Handler):
+        |${Spacer}@abstractmethod
+        |${Spacer}def ${identifier.value}(self, req: '${emitName()}.Request') -> '${emitName()}.Response': pass
     """.trimMargin()
 
     fun Endpoint.Request.emit(endpoint: Endpoint) = """

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
@@ -112,14 +112,14 @@ open class PythonEmitter(
     private fun Param.emitAssignSelf() = "${emit(identifier)} = ${emit(identifier)}"
     private fun Endpoint.Request.emitAssignSelf(endpoint: Endpoint) = """
         |self.path = ${endpoint.emitName()}.Request.Path(${paramList(endpoint).filter { it.type == Param.ParamType.PATH }.joinToString { it.emitAssignSelf() }})
-        |self.queries = ${endpoint.emitName()}.Request.Queries(${paramList(endpoint).filter { it.type == Param.ParamType.QUERY }.joinToString { it.emitAssignSelf() }})
-        |self.headers = ${endpoint.emitName()}.Request.Headers(${paramList(endpoint).filter { it.type == Param.ParamType.HEADER }.joinToString { it.emitAssignSelf() }})
-        |self.body = body
+        |self.queries = ${endpoint.emitName()}.Request.Queries(${paramList(endpoint).filter { it.type == Param.ParamType.QUERY }.joinToString(",\n") { it.emitAssignSelf() }.spacer(1)})
+        |self.headers = ${endpoint.emitName()}.Request.Headers(${paramList(endpoint).filter { it.type == Param.ParamType.HEADER }.joinToString(",\n") { it.emitAssignSelf() }.spacer(1)})
+        |self.body = ${content?.let { "body" } ?: "None"}
     """.trimMargin()
 
     private fun Endpoint.Response.emitAssignSelf(endpoint: Endpoint) = """
-        |self.headers = ${endpoint.emitName()}.Response${status}.Headers(${paramList().filter { it.type == Param.ParamType.HEADER }.joinToString { it.emitAssignSelf() }})
-        |self.body = body
+        |self.headers = ${endpoint.emitName()}.Response${status}.Headers(${paramList().filter { it.type == Param.ParamType.HEADER }.joinToString(",\n") { it.emitAssignSelf() }.spacer(1)})
+        |self.body = ${content?.let { "body" } ?: "None"}
     """.trimMargin()
 
     override fun Reference.emit(): String = when (this) {

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
@@ -229,9 +229,9 @@ open class PythonEmitter(
 
     private fun Field.emitDeserializedParams(type: String, fields: String) =
         if (reference.isNullable)
-            """${emit(identifier)} = serialization.deserialize_param($type.$fields["${identifier.value}"], ${reference.emit()})"""
+            """${emit(identifier)} = serialization.deserialize_param($type.$fields.get("${identifier.value}".lower()), ${reference.emit()})"""
         else
-            """${emit(identifier)} = serialization.deserialize_param($type.$fields["${identifier.value}"], ${reference.emit()})"""
+            """${emit(identifier)} = serialization.deserialize_param($type.$fields.get("${identifier.value}".lower()), ${reference.emit()})"""
 
     fun Endpoint.Response.emit(endpoint: Endpoint) = """
         |@dataclass
@@ -284,7 +284,7 @@ open class PythonEmitter(
     """.trimMargin()
 
     private fun Field.emitSerializedParams(type: String, fields: String) =
-        """"${emit(identifier)}": serialization.serialize_param($type.$fields.${emit(identifier)}, ${reference.emit()})"""
+        """"${identifier.value}": serialization.serialize_param($type.$fields.${emit(identifier)}, ${reference.emit()})"""
 
 
     private fun <E> List<E>.emitObject(name: String, extends: String, spaces: Int = 1, block: (E) -> String) =

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Emitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Emitter.kt
@@ -74,7 +74,6 @@ abstract class Emitter(
             is Endpoint.Segment.Param -> "{${identifier.value}}"
         }
 
-
     internal fun Endpoint.Segment.emitMap() =
         when (this) {
             is Endpoint.Segment.Literal -> value

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Emitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Emitter.kt
@@ -74,6 +74,7 @@ abstract class Emitter(
             is Endpoint.Segment.Param -> "{${identifier.value}}"
         }
 
+
     internal fun Endpoint.Segment.emitMap() =
         when (this) {
             is Endpoint.Segment.Literal -> value

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/FileExtension.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/FileExtension.kt
@@ -7,6 +7,7 @@ enum class FileExtension(override val value: String) : Value<String> {
     Kotlin("kt"),
     Scala("scala"),
     TypeScript("ts"),
+    Python("py"),
     Wirespec("ws"),
     JSON("json"),
     Avro("avsc"),

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/PythonShared.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/PythonShared.kt
@@ -1,0 +1,138 @@
+package community.flock.wirespec.compiler.core.emit.shared
+
+import community.flock.wirespec.compiler.core.emit.common.DEFAULT_SHARED_PACKAGE_STRING
+import community.flock.wirespec.compiler.core.emit.common.Spacer
+
+data object PythonShared : Shared {
+    override val packageString: String = "shared"
+
+    override val source = """
+        |from abc import ABC, abstractmethod
+        |from dataclasses import dataclass
+        |from enum import Enum
+        |from typing import Any, Generic, List, Dict, Optional, TypeVar, NoReturn
+        |
+        |T = TypeVar('T', bound=Any)
+        |RAW = TypeVar('RAW', bound=Any)
+        |Req = TypeVar('Req', bound='Request')
+        |Res = TypeVar('Res', bound='Response')
+        |
+        |
+        |class Wirespec:
+        |
+        |    class Endpoint(ABC): pass
+        |
+        |    class Refined(ABC):
+        |        @property
+        |        @abstractmethod
+        |        def value(self) -> str: pass
+        |
+        |    class Handler(ABC): pass
+        |
+        |    class ServerEdge(Generic[Req, Res], ABC):
+        |        @abstractmethod
+        |        def from_request(self, request: 'RawRequest') -> Req: pass
+        |
+        |        @abstractmethod
+        |        def to_response(self, response: Res) -> 'RawResponse': pass
+        |
+        |    class ClientEdge(Generic[Req, Res], ABC):
+        |        @abstractmethod
+        |        def to_request(self, request: Req) -> 'RawRequest': pass
+        |
+        |        @abstractmethod
+        |        def from_response(self, response: 'RawResponse') -> Res: pass
+        |
+        |    class Method(Enum):
+        |        GET = "GET"
+        |        PUT = "PUT"
+        |        POST = "POST"
+        |        DELETE = "DELETE"
+        |        OPTIONS = "OPTIONS"
+        |        HEAD = "HEAD"
+        |        PATCH = "PATCH"
+        |        TRACE = "TRACE"
+        |
+        |    class Request(Generic[T], ABC):
+        |
+        |        class Path(ABC): pass
+        |
+        |        class Queries(ABC): pass
+        |
+        |        class Headers(ABC): pass
+        |
+        |        @property
+        |        @abstractmethod
+        |        def path(self) -> Path: pass
+        |
+        |        @property
+        |        @abstractmethod
+        |        def method(self) -> 'Method': pass
+        |
+        |        @property
+        |        @abstractmethod
+        |        def queries(self) -> Queries: pass
+        |
+        |        @property
+        |        @abstractmethod
+        |        def headers(self) -> Headers: pass
+        |
+        |        @property
+        |        @abstractmethod
+        |        def body(self) -> T: pass
+        |
+        |    class Response(Generic[T], ABC):
+        |
+        |        class Headers(ABC): pass
+        |
+        |        @property
+        |        @abstractmethod
+        |        def status(self) -> int: pass
+        |
+        |        @property
+        |        @abstractmethod
+        |        def headers(self) -> Headers: pass
+        |
+        |        @property
+        |        @abstractmethod
+        |        def body(self) -> T: pass
+        |
+        |    class Serializer(ABC):
+        |        @abstractmethod
+        |        def serialize_param(self, value: T, t: type) -> List[str]: pass
+        |        @abstractmethod
+        |        def serialize(self, value: T, t: type) -> str: pass
+        |
+        |    class Deserializer(ABC):
+        |        @abstractmethod
+        |        def deserialize_param(self, value: List[str], t): pass
+        |        @abstractmethod
+        |        def deserialize(self, value: str, t: type) -> T: pass
+        |
+        |    class Serialization(Serializer, Deserializer):
+        |        @abstractmethod
+        |        def serialize_param(self, value: T, t: type) -> List[str]: pass
+        |        @abstractmethod
+        |        def serialize(self, value: T, t: type) -> str: pass
+        |        @abstractmethod
+        |        def deserialize_param(self, value: List[str], t): pass
+        |        @abstractmethod
+        |        def deserialize(self, value: str, t): pass
+        |
+        |    @dataclass
+        |    class RawRequest:
+        |        method: str
+        |        path: List[str]
+        |        queries: Dict[str, List[str]]
+        |        headers: Dict[str, List[str]]
+        |        body: Optional[str]
+        |
+        |
+        |    @dataclass
+        |    class RawResponse:
+        |        status_code: int
+        |        headers: Dict[str, List[str]]
+        |        body: Optional[str]
+        |
+        """.trimMargin()
+}

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/PythonShared.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/PythonShared.kt
@@ -10,10 +10,6 @@ data object PythonShared : Shared {
         |from typing import Any, Generic, List, Dict, Optional, TypeVar, NoReturn
         |
         |T = TypeVar('T', bound=Any)
-        |RAW = TypeVar('RAW', bound=Any)
-        |Req = TypeVar('Req', bound='Request')
-        |Res = TypeVar('Res', bound='Response')
-        |
         |
         |class Wirespec:
         |
@@ -25,20 +21,6 @@ data object PythonShared : Shared {
         |        def value(self) -> str: pass
         |
         |    class Handler(ABC): pass
-        |
-        |    class ServerEdge(Generic[Req, Res], ABC):
-        |        @abstractmethod
-        |        def from_request(self, request: 'RawRequest') -> Req: pass
-        |
-        |        @abstractmethod
-        |        def to_response(self, response: Res) -> 'RawResponse': pass
-        |
-        |    class ClientEdge(Generic[Req, Res], ABC):
-        |        @abstractmethod
-        |        def to_request(self, request: Req) -> 'RawRequest': pass
-        |
-        |        @abstractmethod
-        |        def from_response(self, response: 'RawResponse') -> Res: pass
         |
         |    class Method(Enum):
         |        GET = "GET"
@@ -64,7 +46,7 @@ data object PythonShared : Shared {
         |
         |        @property
         |        @abstractmethod
-        |        def method(self) -> 'Method': pass
+        |        def method(self) -> 'Wirespec.Method': pass
         |
         |        @property
         |        @abstractmethod
@@ -94,27 +76,27 @@ data object PythonShared : Shared {
         |        @abstractmethod
         |        def body(self) -> T: pass
         |
-        |    class Serializer(ABC):
-        |        @abstractmethod
-        |        def serialize_param(self, value: T, t: type) -> List[str]: pass
-        |        @abstractmethod
-        |        def serialize(self, value: T, t: type) -> str: pass
-        |
-        |    class Deserializer(ABC):
-        |        @abstractmethod
-        |        def deserialize_param(self, value: List[str], t): pass
-        |        @abstractmethod
-        |        def deserialize(self, value: str, t: type) -> T: pass
-        |
-        |    class Serialization(Serializer, Deserializer):
-        |        @abstractmethod
-        |        def serialize_param(self, value: T, t: type) -> List[str]: pass
+        |    class Serializer(Generic[T], ABC):
         |        @abstractmethod
         |        def serialize(self, value: T, t: type) -> str: pass
         |        @abstractmethod
-        |        def deserialize_param(self, value: List[str], t): pass
+        |        def serialize_param(self, value: T, t: type) -> List[str]: pass
+        |
+        |    class Deserializer(Generic[T], ABC):
         |        @abstractmethod
-        |        def deserialize(self, value: str, t): pass
+        |        def deserialize(self, value: str | None, t: type) -> T: pass
+        |        @abstractmethod
+        |        def deserialize_param(self, value: List[str] | None, t): pass
+        |
+        |    class Serialization(Generic[T], Serializer, Deserializer):
+        |        @abstractmethod
+        |        def serialize(self, value: T, t: type) -> str: pass
+        |        @abstractmethod
+        |        def serialize_param(self, value: T, t: type) -> List[str]: pass
+        |        @abstractmethod
+        |        def deserialize(self, value: str | None, t: type) -> T: pass
+        |        @abstractmethod
+        |        def deserialize_param(self, value: List[str] | None, t): pass
         |
         |    @dataclass
         |    class RawRequest:

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/PythonShared.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/PythonShared.kt
@@ -1,8 +1,5 @@
 package community.flock.wirespec.compiler.core.emit.shared
 
-import community.flock.wirespec.compiler.core.emit.common.DEFAULT_SHARED_PACKAGE_STRING
-import community.flock.wirespec.compiler.core.emit.common.Spacer
-
 data object PythonShared : Shared {
     override val packageString: String = "shared"
 
@@ -134,5 +131,5 @@ data object PythonShared : Shared {
         |        headers: Dict[str, List[str]]
         |        body: Optional[str]
         |
-        """.trimMargin()
+    """.trimMargin()
 }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/PythonShared.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/PythonShared.kt
@@ -7,20 +7,40 @@ data object PythonShared : Shared {
         |from abc import ABC, abstractmethod
         |from dataclasses import dataclass
         |from enum import Enum
-        |from typing import Any, Generic, List, Dict, Optional, TypeVar, NoReturn
+        |from typing import Generic, List, Dict, Optional, TypeVar
         |
-        |T = TypeVar('T', bound=Any)
+        |T = TypeVar('T')
+        |REQ = TypeVar('REQ')
+        |RES = TypeVar('RES')
         |
         |class Wirespec:
-        |
-        |    class Endpoint(ABC): pass
         |
         |    class Refined(ABC):
         |        @property
         |        @abstractmethod
         |        def value(self) -> str: pass
         |
-        |    class Handler(ABC): pass
+        |    class Endpoint(ABC):
+        |
+        |        class Handler(ABC):
+        |            pass
+        |
+        |        class Convert(ABC, Generic[REQ, RES]):
+        |            @staticmethod
+        |            @abstractmethod
+        |            def to_raw_request(serializer: 'Wirespec.Serializer', req: REQ) -> 'Wirespec.RawRequest': pass
+        |
+        |            @staticmethod
+        |            @abstractmethod
+        |            def from_raw_response(serializer: 'Wirespec.Deserializer', res: 'Wirespec.RawResponse') -> RES: pass
+        |
+        |            @staticmethod
+        |            @abstractmethod
+        |            def to_raw_response(serializer: 'Wirespec.Serializer', res: RES) -> 'Wirespec.RawResponse': pass
+        |
+        |            @staticmethod
+        |            @abstractmethod
+        |            def from_raw_request(serializer: 'Wirespec.Deserializer[T]', req: 'Wirespec.RawRequest') -> REQ: pass
         |
         |    class Method(Enum):
         |        GET = "GET"
@@ -78,25 +98,25 @@ data object PythonShared : Shared {
         |
         |    class Serializer(Generic[T], ABC):
         |        @abstractmethod
-        |        def serialize(self, value: T, t: type) -> str: pass
+        |        def serialize(self, value: T, t: type[T]) -> str: pass
         |        @abstractmethod
-        |        def serialize_param(self, value: T, t: type) -> List[str]: pass
+        |        def serialize_param(self, value: T, t: type[T]) -> List[str]: pass
         |
         |    class Deserializer(Generic[T], ABC):
         |        @abstractmethod
-        |        def deserialize(self, value: str | None, t: type) -> T: pass
+        |        def deserialize[T](self, value: str | None, t: type[T]) -> T: pass
         |        @abstractmethod
-        |        def deserialize_param(self, value: List[str] | None, t): pass
+        |        def deserialize_param[T](self, value: List[str] | None, t: type[T]) -> T: pass
         |
-        |    class Serialization(Generic[T], Serializer, Deserializer):
+        |    class Serialization(Serializer, Deserializer):
         |        @abstractmethod
-        |        def serialize(self, value: T, t: type) -> str: pass
+        |        def serialize(self, value: T, t: type[T]) -> str: pass
         |        @abstractmethod
-        |        def serialize_param(self, value: T, t: type) -> List[str]: pass
+        |        def serialize_param(self, value: T, t: type[T]) -> List[str]: pass
         |        @abstractmethod
-        |        def deserialize(self, value: str | None, t: type) -> T: pass
+        |        def deserialize[T](self, value: str | None, t: type[T]) -> T: pass
         |        @abstractmethod
-        |        def deserialize_param(self, value: List[str] | None, t): pass
+        |        def deserialize_param[T](self, value: List[str] | None, t: type[T]) -> T: pass
         |
         |    @dataclass
         |    class RawRequest:

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
@@ -530,17 +530,17 @@ class CompileFullEndpointTest {
     @Test
     fun python() {
         val python = """
-            |package community.flock.wirespec.generated
             |from abc import abstractmethod
             |from dataclasses import dataclass
-            |from .shared.Wirespec import T, Wirespec
             |from typing import List, Optional
             |
+            |from .shared.Wirespec import T, Wirespec
             |
             |@dataclass
             |class PotentialTodoDto:
-            |  name: str
-            |  done: bool
+            |  name: 'str'
+            |  done: 'bool'
+            |
             |
         """.trimMargin()
         compiler { PythonEmitter() } shouldBeRight python

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
@@ -2,6 +2,7 @@ package community.flock.wirespec.compiler.core
 
 import community.flock.wirespec.compiler.core.emit.JavaEmitter
 import community.flock.wirespec.compiler.core.emit.KotlinEmitter
+import community.flock.wirespec.compiler.core.emit.PythonEmitter
 import community.flock.wirespec.compiler.core.emit.ScalaEmitter
 import community.flock.wirespec.compiler.core.emit.TypeScriptEmitter
 import community.flock.wirespec.compiler.core.emit.WirespecEmitter
@@ -524,6 +525,12 @@ class CompileFullEndpointTest {
         """.trimMargin()
 
         compiler { TypeScriptEmitter() } shouldBeRight ts
+    }
+
+    @Test
+    fun python() {
+        val python = "".trimMargin()
+        compiler { PythonEmitter() } shouldBeRight python
     }
 
     @Test

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
@@ -322,6 +322,46 @@ class CompileFullEndpointTest {
             |  }
             |}
             |
+            |package community.flock.wirespec.generated;
+            |
+            |import community.flock.wirespec.java.Wirespec;
+            |
+            |public record PotentialTodoDto (
+            |  String name,
+            |  Boolean done
+            |) {
+            |};
+            |
+            |package community.flock.wirespec.generated;
+            |
+            |import community.flock.wirespec.java.Wirespec;
+            |
+            |public record Token (
+            |  String iss
+            |) {
+            |};
+            |
+            |package community.flock.wirespec.generated;
+            |
+            |import community.flock.wirespec.java.Wirespec;
+            |
+            |public record TodoDto (
+            |  String id,
+            |  String name,
+            |  Boolean done
+            |) {
+            |};
+            |
+            |package community.flock.wirespec.generated;
+            |
+            |import community.flock.wirespec.java.Wirespec;
+            |
+            |public record Error (
+            |  Long code,
+            |  String description
+            |) {
+            |};
+            |
         """.trimMargin()
 
         compiler { JavaEmitter() } shouldBeRight java
@@ -542,6 +582,233 @@ class CompileFullEndpointTest {
             |  done: 'bool'
             |
             |
+            |from abc import abstractmethod
+            |from dataclasses import dataclass
+            |from typing import List, Optional
+            |
+            |from .shared.Wirespec import T, Wirespec
+            |
+            |@dataclass
+            |class Token:
+            |  iss: 'str'
+            |
+            |
+            |from abc import abstractmethod
+            |from dataclasses import dataclass
+            |from typing import List, Optional
+            |
+            |from .shared.Wirespec import T, Wirespec
+            |
+            |@dataclass
+            |class TodoDto:
+            |  id: 'str'
+            |  name: 'str'
+            |  done: 'bool'
+            |
+            |
+            |from abc import abstractmethod
+            |from dataclasses import dataclass
+            |from typing import List, Optional
+            |
+            |from .shared.Wirespec import T, Wirespec
+            |
+            |@dataclass
+            |class Error:
+            |  code: 'int'
+            |  description: 'str'
+            |
+            |
+            |from abc import abstractmethod
+            |from dataclasses import dataclass
+            |from typing import List, Optional
+            |
+            |from .shared.Wirespec import T, Wirespec
+            |
+            |from .Token import Token
+            |from .PotentialTodoDto import PotentialTodoDto
+            |from .TodoDto import TodoDto
+            |from .Error import Error
+            |
+            |class PutTodoEndpoint (Wirespec.Endpoint):
+            |  @dataclass
+            |  class Request(Wirespec.Request[PotentialTodoDto]):
+            |    @dataclass
+            |    class Path (Wirespec.Request.Path):
+            |        id: str 
+            |    @dataclass
+            |    class Queries (Wirespec.Request.Queries):
+            |        done: 'bool'
+            |    @dataclass
+            |    class Headers (Wirespec.Request.Headers):
+            |        token: 'Token'
+            | 
+            |    @property
+            |    def body(self) -> PotentialTodoDto:
+            |      return self._body
+            |
+            |    @property
+            |    def path(self) -> Path:
+            |      return self._path
+            |
+            |    @property
+            |    def queries(self) -> Queries:
+            |      return self._queries
+            |
+            |    @property
+            |    def headers(self) -> Headers:
+            |      return self._headers
+            |
+            |    _body:  PotentialTodoDto
+            |    _headers: Headers
+            |    _queries: Queries
+            |    _path: Path
+            |    method: Wirespec.Method = Wirespec.Method.PUT
+            |
+            |    def __init__(self, id: str, done: bool, token: Token, body: PotentialTodoDto):
+            |      self._path = PutTodoEndpoint.Request.Path(id = id)
+            |      self._queries = PutTodoEndpoint.Request.Queries(  done = done)
+            |      self._headers = PutTodoEndpoint.Request.Headers(  token = token)
+            |      self._body = body
+            |
+            |  @dataclass
+            |  class Response200(Wirespec.Response[TodoDto]):
+            |    @dataclass
+            |    class Headers (Wirespec.Response.Headers): pass
+            |
+            |    @property
+            |    def headers(self) -> Headers:
+            |      return self._headers
+            |
+            |    @property
+            |    def body(self) -> TodoDto:
+            |      return self._body
+            |
+            |    _body: TodoDto
+            |    _headers: Headers
+            |    status: int = 200
+            |
+            |    def __init__(self, body: TodoDto):
+            |      self._headers = PutTodoEndpoint.Response200.Headers()
+            |      self._body = body
+            |
+            |  @dataclass
+            |  class Response201(Wirespec.Response[TodoDto]):
+            |    @dataclass
+            |    class Headers (Wirespec.Response.Headers):
+            |        token: 'Token'
+            |
+            |    @property
+            |    def headers(self) -> Headers:
+            |      return self._headers
+            |
+            |    @property
+            |    def body(self) -> TodoDto:
+            |      return self._body
+            |
+            |    _body: TodoDto
+            |    _headers: Headers
+            |    status: int = 201
+            |
+            |    def __init__(self, token: Token, body: TodoDto):
+            |      self._headers = PutTodoEndpoint.Response201.Headers(  token = token)
+            |      self._body = body
+            |
+            |  @dataclass
+            |  class Response500(Wirespec.Response[Error]):
+            |    @dataclass
+            |    class Headers (Wirespec.Response.Headers): pass
+            |
+            |    @property
+            |    def headers(self) -> Headers:
+            |      return self._headers
+            |
+            |    @property
+            |    def body(self) -> Error:
+            |      return self._body
+            |
+            |    _body: Error
+            |    _headers: Headers
+            |    status: int = 500
+            |
+            |    def __init__(self, body: Error):
+            |      self._headers = PutTodoEndpoint.Response500.Headers()
+            |      self._body = body
+            |
+            |  Response = Response200 | Response201 | Response500
+            |
+            |  class Handler(Wirespec.Endpoint.Handler):
+            |    @abstractmethod
+            |    def PutTodo(self, req: 'PutTodoEndpoint.Request') -> 'PutTodoEndpoint.Response': pass
+            |
+            |  class Convert(Wirespec.Endpoint.Convert[Request, Response]):
+            |    @staticmethod
+            |    def to_raw_request(serialization: Wirespec.Serializer, request: 'PutTodoEndpoint.Request') -> Wirespec.RawRequest:
+            |      return Wirespec.RawRequest(
+            |        path = ["todos", str(request.path.id)],
+            |        method = request.method.value,
+            |        queries = {"done": serialization.serialize_param(request.queries.done, bool)},
+            |        headers = {"token": serialization.serialize_param(request.headers.token, Token)},
+            |        body = serialization.serialize(request.body, PotentialTodoDto),
+            |      )
+            |
+            |    @staticmethod
+            |    def from_raw_request(serialization: Wirespec.Deserializer, request: Wirespec.RawRequest) -> 'PutTodoEndpoint.Request':
+            |      return PutTodoEndpoint.Request(
+            |          id = serialization.deserialize(request.path[1], str),
+            |    done = serialization.deserialize_param(request.queries.get("done".lower()), bool),
+            |    token = serialization.deserialize_param(request.headers.get("token".lower()), Token),
+            |          body = serialization.deserialize(request.body, PotentialTodoDto),
+            |    )
+            |
+            |    @staticmethod
+            |    def to_raw_response(serialization: Wirespec.Serializer, response: 'PutTodoEndpoint.Response') -> Wirespec.RawResponse:
+            |      match response:
+            |        case PutTodoEndpoint.Response200():
+            |          return Wirespec.RawResponse(
+            |            status_code = response.status,
+            |            headers = {},
+            |            body = serialization.serialize(response.body, TodoDto),
+            |          )
+            |        case PutTodoEndpoint.Response201():
+            |          return Wirespec.RawResponse(
+            |            status_code = response.status,
+            |            headers = {"token": serialization.serialize_param(response.headers.token, Token)},
+            |            body = serialization.serialize(response.body, TodoDto),
+            |          )
+            |        case PutTodoEndpoint.Response500():
+            |          return Wirespec.RawResponse(
+            |            status_code = response.status,
+            |            headers = {},
+            |            body = serialization.serialize(response.body, Error),
+            |          )
+            |        case _:
+            |          raise Exception("Cannot match response with status: " + str(response.status))
+            |    @staticmethod
+            |    def from_raw_response(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> 'PutTodoEndpoint.Response':
+            |      match response.status_code:
+            |        case 200:
+            |          return PutTodoEndpoint.Response200(
+            |            body = serialization.deserialize(response.body, TodoDto),
+            |          )
+            |        case 201:
+            |          return PutTodoEndpoint.Response201(
+            |            body = serialization.deserialize(response.body, TodoDto),
+            |            token = serialization.deserialize_param(response.headers.get("token".lower()), Token)
+            |          )
+            |        case 500:
+            |          return PutTodoEndpoint.Response500(
+            |            body = serialization.deserialize(response.body, Error),
+            |          )
+            |        case _: 
+            |          raise Exception("Cannot match response with status: " + str(response.status_code))
+            |
+            |
+            |
+            |from .PutTodoEndpoint import PutTodoEndpoint
+            |from .PotentialTodoDto import PotentialTodoDto
+            |from .Token import Token
+            |from .TodoDto import TodoDto
+            |from .Error import Error
         """.trimMargin()
         compiler { PythonEmitter() } shouldBeRight python
     }

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
@@ -529,7 +529,20 @@ class CompileFullEndpointTest {
 
     @Test
     fun python() {
-        val python = "".trimMargin()
+        val python = """
+            |package community.flock.wirespec.generated
+            |from abc import abstractmethod
+            |from dataclasses import dataclass
+            |from .shared.Wirespec import T, Wirespec
+            |from typing import List, Optional
+            |
+            |
+            |@dataclass
+            |class PotentialTodoDto:
+            |  name: str
+            |  done: bool
+            |
+        """.trimMargin()
         compiler { PythonEmitter() } shouldBeRight python
     }
 

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
@@ -205,6 +205,15 @@ class CompileMinimalEndpointTest {
             |  }
             |}
             |
+            |package community.flock.wirespec.generated;
+            |
+            |import community.flock.wirespec.java.Wirespec;
+            |
+            |public record TodoDto (
+            |  String description
+            |) {
+            |};
+            |
         """.trimMargin()
 
         compiler { JavaEmitter() } shouldBeRight java
@@ -242,6 +251,119 @@ class CompileMinimalEndpointTest {
             |  description: 'str'
             |
             |
+            |from abc import abstractmethod
+            |from dataclasses import dataclass
+            |from typing import List, Optional
+            |
+            |from .shared.Wirespec import T, Wirespec
+            |
+            |from .TodoDto import TodoDto
+            |
+            |class GetTodosEndpoint (Wirespec.Endpoint):
+            |  @dataclass
+            |  class Request(Wirespec.Request[None]):
+            |    @dataclass
+            |    class Path (Wirespec.Request.Path): pass
+            |    @dataclass
+            |    class Queries (Wirespec.Request.Queries): pass
+            |    @dataclass
+            |    class Headers (Wirespec.Request.Headers): pass
+            | 
+            |    @property
+            |    def body(self) -> None:
+            |      return self._body
+            |
+            |    @property
+            |    def path(self) -> Path:
+            |      return self._path
+            |
+            |    @property
+            |    def queries(self) -> Queries:
+            |      return self._queries
+            |
+            |    @property
+            |    def headers(self) -> Headers:
+            |      return self._headers
+            |
+            |    _body:  None
+            |    _headers: Headers
+            |    _queries: Queries
+            |    _path: Path
+            |    method: Wirespec.Method = Wirespec.Method.GET
+            |
+            |    def __init__(self, ):
+            |      self._path = GetTodosEndpoint.Request.Path()
+            |      self._queries = GetTodosEndpoint.Request.Queries()
+            |      self._headers = GetTodosEndpoint.Request.Headers()
+            |      self._body = None
+            |
+            |  @dataclass
+            |  class Response200(Wirespec.Response[List[TodoDto]]):
+            |    @dataclass
+            |    class Headers (Wirespec.Response.Headers): pass
+            |
+            |    @property
+            |    def headers(self) -> Headers:
+            |      return self._headers
+            |
+            |    @property
+            |    def body(self) -> List[TodoDto]:
+            |      return self._body
+            |
+            |    _body: List[TodoDto]
+            |    _headers: Headers
+            |    status: int = 200
+            |
+            |    def __init__(self, body: List[TodoDto]):
+            |      self._headers = GetTodosEndpoint.Response200.Headers()
+            |      self._body = body
+            |
+            |  Response = Response200
+            |
+            |  class Handler(Wirespec.Endpoint.Handler):
+            |    @abstractmethod
+            |    def GetTodos(self, req: 'GetTodosEndpoint.Request') -> 'GetTodosEndpoint.Response': pass
+            |
+            |  class Convert(Wirespec.Endpoint.Convert[Request, Response]):
+            |    @staticmethod
+            |    def to_raw_request(serialization: Wirespec.Serializer, request: 'GetTodosEndpoint.Request') -> Wirespec.RawRequest:
+            |      return Wirespec.RawRequest(
+            |        path = ["todos"],
+            |        method = request.method.value,
+            |        queries = {},
+            |        headers = {},
+            |        body = serialization.serialize(request.body, type(None)),
+            |      )
+            |
+            |    @staticmethod
+            |    def from_raw_request(serialization: Wirespec.Deserializer, request: Wirespec.RawRequest) -> 'GetTodosEndpoint.Request':
+            |      return GetTodosEndpoint.Request
+            |
+            |    @staticmethod
+            |    def to_raw_response(serialization: Wirespec.Serializer, response: 'GetTodosEndpoint.Response') -> Wirespec.RawResponse:
+            |      match response:
+            |        case GetTodosEndpoint.Response200():
+            |          return Wirespec.RawResponse(
+            |            status_code = response.status,
+            |            headers = {},
+            |            body = serialization.serialize(response.body, List[TodoDto]),
+            |          )
+            |        case _:
+            |          raise Exception("Cannot match response with status: " + str(response.status))
+            |    @staticmethod
+            |    def from_raw_response(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> 'GetTodosEndpoint.Response':
+            |      match response.status_code:
+            |        case 200:
+            |          return GetTodosEndpoint.Response200(
+            |            body = serialization.deserialize(response.body, List[TodoDto]),
+            |          )
+            |        case _: 
+            |          raise Exception("Cannot match response with status: " + str(response.status_code))
+            |
+            |
+            |
+            |from .GetTodosEndpoint import GetTodosEndpoint
+            |from .TodoDto import TodoDto
         """.trimMargin()
         compiler { PythonEmitter() } shouldBeRight python
     }

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
@@ -231,16 +231,16 @@ class CompileMinimalEndpointTest {
     @Test
     fun python() {
         val python = """
-            |package community.flock.wirespec.generated
             |from abc import abstractmethod
             |from dataclasses import dataclass
-            |from .shared.Wirespec import T, Wirespec
             |from typing import List, Optional
             |
+            |from .shared.Wirespec import T, Wirespec
             |
             |@dataclass
             |class TodoDto:
-            |  description: str
+            |  description: 'str'
+            |
             |
         """.trimMargin()
         compiler { PythonEmitter() } shouldBeRight python

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
@@ -230,7 +230,19 @@ class CompileMinimalEndpointTest {
 
     @Test
     fun python() {
-        val python = "".trimMargin()
+        val python = """
+            |package community.flock.wirespec.generated
+            |from abc import abstractmethod
+            |from dataclasses import dataclass
+            |from .shared.Wirespec import T, Wirespec
+            |from typing import List, Optional
+            |
+            |
+            |@dataclass
+            |class TodoDto:
+            |  description: str
+            |
+        """.trimMargin()
         compiler { PythonEmitter() } shouldBeRight python
     }
 

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
@@ -2,6 +2,7 @@ package community.flock.wirespec.compiler.core
 
 import community.flock.wirespec.compiler.core.emit.JavaEmitter
 import community.flock.wirespec.compiler.core.emit.KotlinEmitter
+import community.flock.wirespec.compiler.core.emit.PythonEmitter
 import community.flock.wirespec.compiler.core.emit.ScalaEmitter
 import community.flock.wirespec.compiler.core.emit.TypeScriptEmitter
 import community.flock.wirespec.compiler.core.emit.WirespecEmitter
@@ -225,6 +226,12 @@ class CompileMinimalEndpointTest {
         """.trimMargin()
 
         compiler { ScalaEmitter() } shouldBeRight scala
+    }
+
+    @Test
+    fun python() {
+        val python = "".trimMargin()
+        compiler { PythonEmitter() } shouldBeRight python
     }
 
     @Test

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileUnionTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileUnionTest.kt
@@ -58,6 +58,29 @@ class CompileUnionTest {
             |
             |public sealed interface UserAccount permits UserAccountPassword, UserAccountToken {}
             |
+            |package community.flock.wirespec.generated;
+            |
+            |public record UserAccountPassword (
+            |  String username,
+            |  String password
+            |) extends UserAccountimplements UserAccount {
+            |};
+            |
+            |package community.flock.wirespec.generated;
+            |
+            |public record UserAccountToken (
+            |  String token
+            |) extends UserAccountimplements UserAccount {
+            |};
+            |
+            |package community.flock.wirespec.generated;
+            |
+            |public record User (
+            |  String username,
+            |  UserAccount account
+            |) {
+            |};
+            |
         """.trimMargin()
 
         compiler { JavaEmitter() } shouldBeRight java

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/TestUtils.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/TestUtils.kt
@@ -9,6 +9,6 @@ fun compile(source: String) = { emitter: () -> Emitter ->
         override val spec = WirespecSpec
         override val emitter = emitter()
     }.compile(nonEmptyListOf(source))
-        .map { it.first().result }
+        .map { it.joinToString("\n") { it.result } }
         .onLeft(::println)
 }

--- a/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Language.kt
+++ b/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Language.kt
@@ -5,6 +5,7 @@ enum class Language {
     Kotlin,
     Scala,
     TypeScript,
+    Python,
     Wirespec,
     OpenAPIV2,
     OpenAPIV3,

--- a/src/plugin/arguments/src/commonTest/kotlin/community/flock/wirespec/plugin/LanguageTest.kt
+++ b/src/plugin/arguments/src/commonTest/kotlin/community/flock/wirespec/plugin/LanguageTest.kt
@@ -6,6 +6,6 @@ import kotlin.test.Test
 class LanguageTest {
     @Test
     fun testLanguages() {
-        Language.toString() shouldBe "Java, Kotlin, Scala, TypeScript, Wirespec, OpenAPIV2, OpenAPIV3"
+        Language.toString() shouldBe "Java, Kotlin, Scala, TypeScript, Python, Wirespec, OpenAPIV2, OpenAPIV3"
     }
 }

--- a/src/plugin/cli/src/commonMain/kotlin/community/flock/wirespec/plugin/cli/CommandLineArgumentsParser.kt
+++ b/src/plugin/cli/src/commonMain/kotlin/community/flock/wirespec/plugin/cli/CommandLineArgumentsParser.kt
@@ -16,6 +16,7 @@ import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.enum
 import community.flock.wirespec.compiler.core.emit.JavaEmitter
 import community.flock.wirespec.compiler.core.emit.KotlinEmitter
+import community.flock.wirespec.compiler.core.emit.PythonEmitter
 import community.flock.wirespec.compiler.core.emit.ScalaEmitter
 import community.flock.wirespec.compiler.core.emit.TypeScriptEmitter
 import community.flock.wirespec.compiler.core.emit.WirespecEmitter
@@ -117,6 +118,7 @@ private class Compile(
                 Language.Kotlin -> KotlinEmitter(PackageName(packageName))
                 Language.Scala -> ScalaEmitter(PackageName(packageName))
                 Language.TypeScript -> TypeScriptEmitter()
+                Language.Python -> PythonEmitter()
                 Language.Wirespec -> WirespecEmitter()
                 Language.OpenAPIV2 -> OpenAPIV2Emitter
                 Language.OpenAPIV3 -> OpenAPIV3Emitter
@@ -164,6 +166,7 @@ private class Convert(
                 Language.Kotlin -> KotlinEmitter(PackageName(packageName))
                 Language.Scala -> ScalaEmitter(PackageName(packageName))
                 Language.TypeScript -> TypeScriptEmitter()
+                Language.Python -> PythonEmitter()
                 Language.Wirespec -> WirespecEmitter()
                 Language.OpenAPIV2 -> OpenAPIV2Emitter
                 Language.OpenAPIV3 -> OpenAPIV3Emitter

--- a/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
+++ b/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
@@ -3,6 +3,7 @@ package community.flock.wirespec.plugin.gradle
 import arrow.core.toNonEmptySetOrNull
 import community.flock.wirespec.compiler.core.emit.JavaEmitter
 import community.flock.wirespec.compiler.core.emit.KotlinEmitter
+import community.flock.wirespec.compiler.core.emit.PythonEmitter
 import community.flock.wirespec.compiler.core.emit.ScalaEmitter
 import community.flock.wirespec.compiler.core.emit.TypeScriptEmitter
 import community.flock.wirespec.compiler.core.emit.WirespecEmitter
@@ -87,6 +88,7 @@ abstract class BaseWirespecTask : DefaultTask() {
             Language.Kotlin -> KotlinEmitter(packageNameValue())
             Language.Scala -> ScalaEmitter(packageNameValue())
             Language.TypeScript -> TypeScriptEmitter()
+            Language.Python -> PythonEmitter()
             Language.Wirespec -> WirespecEmitter()
             Language.OpenAPIV2 -> OpenAPIV2Emitter
             Language.OpenAPIV3 -> OpenAPIV3Emitter

--- a/src/plugin/maven/src/main/kotlin/BaseMojo.kt
+++ b/src/plugin/maven/src/main/kotlin/BaseMojo.kt
@@ -3,6 +3,7 @@ package community.flock.wirespec.plugin.maven
 import arrow.core.toNonEmptySetOrNull
 import community.flock.wirespec.compiler.core.emit.JavaEmitter
 import community.flock.wirespec.compiler.core.emit.KotlinEmitter
+import community.flock.wirespec.compiler.core.emit.PythonEmitter
 import community.flock.wirespec.compiler.core.emit.ScalaEmitter
 import community.flock.wirespec.compiler.core.emit.TypeScriptEmitter
 import community.flock.wirespec.compiler.core.emit.WirespecEmitter
@@ -103,6 +104,7 @@ abstract class BaseMojo : AbstractMojo() {
                 Language.Kotlin -> KotlinEmitter(PackageName(packageName))
                 Language.Scala -> ScalaEmitter(PackageName(packageName))
                 Language.TypeScript -> TypeScriptEmitter()
+                Language.Python -> PythonEmitter()
                 Language.Wirespec -> WirespecEmitter()
                 Language.OpenAPIV2 -> OpenAPIV2Emitter
                 Language.OpenAPIV3 -> OpenAPIV3Emitter

--- a/src/plugin/npm/src/jsMain/kotlin/community/flock/wirespec/plugin/npm/Main.kt
+++ b/src/plugin/npm/src/jsMain/kotlin/community/flock/wirespec/plugin/npm/Main.kt
@@ -10,6 +10,7 @@ import community.flock.wirespec.compiler.core.ParseContext
 import community.flock.wirespec.compiler.core.WirespecSpec
 import community.flock.wirespec.compiler.core.emit.JavaEmitter
 import community.flock.wirespec.compiler.core.emit.KotlinEmitter
+import community.flock.wirespec.compiler.core.emit.PythonEmitter
 import community.flock.wirespec.compiler.core.emit.ScalaEmitter
 import community.flock.wirespec.compiler.core.emit.TypeScriptEmitter
 import community.flock.wirespec.compiler.core.emit.WirespecEmitter
@@ -54,6 +55,7 @@ enum class Emitters {
     JAVA,
     KOTLIN,
     SCALA,
+    PYTHON,
     OPENAPI_V2,
     OPENAPI_V3,
     AVRO,
@@ -102,6 +104,7 @@ fun emit(ast: WsAST, emitter: Emitters, packageName: String) = ast
             Emitters.JAVA -> JavaEmitter(PackageName(packageName)).emit(it, noLogger)
             Emitters.KOTLIN -> KotlinEmitter(PackageName(packageName)).emit(it, noLogger)
             Emitters.SCALA -> ScalaEmitter(PackageName(packageName)).emit(it, noLogger)
+            Emitters.PYTHON -> PythonEmitter(PackageName(packageName)).emit(it, noLogger)
             Emitters.OPENAPI_V2 -> listOf(it)
                 .map(OpenAPIV2Emitter::emitSwaggerObject)
                 .map(encode(SwaggerObject.serializer()))


### PR DESCRIPTION
This Pull Request adds Python support to the Wirespec compiler, including file emission, shared utilities, language enumeration, and corresponding tests.
- **Added Python support for the Wirespec compiler:**
  - Introduced PythonEmitter for generating Python files.
  - Implemented PythonShared with shared components and utilities for Python language integration.
  - Included Python as a selectable language in language enumeration files (Language.kt).
- **Updated Compilation Logic:**
  - Adjusted major parts of the compilation flow to handle Python-based outputs.
  - Enhanced Testing and Utilities:
  - Extended file extension and language mapping utilities to include Python.
  - Updated unit tests to verify Python functionality.