### PR TITLE
Refactor Python emitter for namespace support (model, endpoint, channel)

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
@@ -245,7 +245,7 @@ open class PythonEmitter(
         |${Spacer}${Spacer}method = request.method.value,
         |${Spacer}${Spacer}queries = ${if (endpoint.queries.isNotEmpty()) endpoint.queries.joinToString(",\n", "{", "}") { it.emitSerializedParams("request", "queries") } else "{}"},
         |${Spacer}${Spacer}headers = ${if (endpoint.headers.isNotEmpty()) endpoint.headers.joinToString(",\n", "{", "}") { it.emitSerializedParams("request", "headers") } else "{}"},
-        |${Spacer}${Spacer}body = ${content?.let { "serialization.serialize(request.body, ${it.reference.emitType()})" } ?: NONE},
+        |${Spacer}${Spacer}body = serialization.serialize(request.body, ${content?.reference?.emitType() ?: NONE}),
         |${Spacer})
         |
     """.trimMargin()
@@ -314,7 +314,7 @@ open class PythonEmitter(
     private fun Endpoint.Response.emitDeserialized(endpoint: Endpoint) = listOfNotNull(
         "case $status:",
         "${Spacer}return ${emit(endpoint.identifier)}.Response$status(",
-        "${Spacer(2)}body = ${content?.let { "serialization.deserialize(response.body, ${it.reference.emitType()})" } ?: NONE},",
+        "${Spacer(2)}body = serialization.deserialize(response.body, ${content?.reference?.emitType() ?: NONE}),",
         headers.joinToString(",\n") { it.emitDeserializedParams("response", "headers") }.orNull()?.spacer(2),
         "${Spacer})"
     ).joinToString("\n")
@@ -325,7 +325,7 @@ open class PythonEmitter(
         |${Spacer(1)}return Wirespec.RawResponse(
         |${Spacer(2)}status_code = response.status,
         |${Spacer(2)}headers = ${if (headers.isNotEmpty()) headers.joinToString(", ", "{", "}") { it.emitSerializedParams("response", "headers") } else "{}"},
-        |${Spacer(2)}body = ${content?.let { "serialization.serialize(response.body, ${it.reference.emitType()})" } ?: NONE},
+        |${Spacer(2)}body = ${if (content != null) "serialization.serialize(response.body, ${content.reference.emitType()}" else NONE}),
         |${Spacer(1)})
     """.trimMargin()
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Defaults.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Defaults.kt
@@ -1,8 +1,19 @@
 package community.flock.wirespec.compiler.core.emit.common
 
+import community.flock.wirespec.compiler.core.parse.Channel
+import community.flock.wirespec.compiler.core.parse.Definition
+import community.flock.wirespec.compiler.core.parse.Endpoint
+import community.flock.wirespec.compiler.core.parse.Model
+
 const val DEFAULT_PACKAGE = "community.flock.wirespec"
 const val DEFAULT_SHARED_PACKAGE_STRING = DEFAULT_PACKAGE
 const val DEFAULT_GENERATED_PACKAGE_STRING = "$DEFAULT_PACKAGE.generated"
+
+fun Definition.namespace () = when (this) {
+    is Endpoint -> "endpoint"
+    is Channel -> "channel"
+    is Model -> "model"
+}
 
 data object Spacer {
     private const val SPACER = "  "

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Defaults.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/Defaults.kt
@@ -9,7 +9,7 @@ const val DEFAULT_PACKAGE = "community.flock.wirespec"
 const val DEFAULT_SHARED_PACKAGE_STRING = DEFAULT_PACKAGE
 const val DEFAULT_GENERATED_PACKAGE_STRING = "$DEFAULT_PACKAGE.generated"
 
-fun Definition.namespace () = when (this) {
+fun Definition.namespace() = when (this) {
     is Endpoint -> "endpoint"
     is Channel -> "channel"
     is Model -> "model"

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/PackageName.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/PackageName.kt
@@ -19,17 +19,12 @@ class PackageName(override val value: String, val createDirectory: Boolean) : Va
 
         @JvmSynthetic
         operator fun invoke(value: String? = null) = value
-            ?.takeIf(String::isNotBlank)
             .let { PackageName(it ?: DEFAULT_SHARED_PACKAGE_STRING, it != null) }
     }
 
     fun toDir(): String = value.replace(".", "/") + "/"
 }
 
-operator fun PackageName.plus(definition: Definition) = this + when (definition) {
-    is Endpoint -> "endpoint"
-    is Channel -> "channel"
-    is Model -> "model"
-}
+operator fun PackageName.plus(definition: Definition) = this + definition.namespace()
 
 private operator fun PackageName.plus(subPackage: String) = PackageName("$value.$subPackage")

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/PackageName.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/common/PackageName.kt
@@ -1,10 +1,7 @@
 package community.flock.wirespec.compiler.core.emit.common
 
 import community.flock.wirespec.compiler.core.Value
-import community.flock.wirespec.compiler.core.parse.Channel
 import community.flock.wirespec.compiler.core.parse.Definition
-import community.flock.wirespec.compiler.core.parse.Endpoint
-import community.flock.wirespec.compiler.core.parse.Model
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
@@ -568,7 +568,7 @@ class CompileFullEndpointTest {
             |from dataclasses import dataclass
             |from typing import List, Optional
             |
-            |from .shared.Wirespec import T, Wirespec
+            |from ..wirespec import T, Wirespec
             |
             |@dataclass
             |class PotentialTodoDto:
@@ -580,7 +580,7 @@ class CompileFullEndpointTest {
             |from dataclasses import dataclass
             |from typing import List, Optional
             |
-            |from .shared.Wirespec import T, Wirespec
+            |from ..wirespec import T, Wirespec
             |
             |@dataclass
             |class Token:
@@ -591,7 +591,7 @@ class CompileFullEndpointTest {
             |from dataclasses import dataclass
             |from typing import List, Optional
             |
-            |from .shared.Wirespec import T, Wirespec
+            |from ..wirespec import T, Wirespec
             |
             |@dataclass
             |class TodoDto:
@@ -604,7 +604,7 @@ class CompileFullEndpointTest {
             |from dataclasses import dataclass
             |from typing import List, Optional
             |
-            |from .shared.Wirespec import T, Wirespec
+            |from ..wirespec import T, Wirespec
             |
             |@dataclass
             |class Error:
@@ -616,14 +616,14 @@ class CompileFullEndpointTest {
             |from dataclasses import dataclass
             |from typing import List, Optional
             |
-            |from .shared.Wirespec import T, Wirespec
+            |from ..wirespec import T, Wirespec
             |
-            |from .Token import Token
-            |from .PotentialTodoDto import PotentialTodoDto
-            |from .TodoDto import TodoDto
-            |from .Error import Error
+            |from ..model.Token import Token
+            |from ..model.PotentialTodoDto import PotentialTodoDto
+            |from ..model.TodoDto import TodoDto
+            |from ..model.Error import Error
             |
-            |class PutTodoEndpoint (Wirespec.Endpoint):
+            |class PutTodo (Wirespec.Endpoint):
             |  @dataclass
             |  class Request(Wirespec.Request[PotentialTodoDto]):
             |    @dataclass
@@ -798,11 +798,10 @@ class CompileFullEndpointTest {
             |
             |
             |
-            |from .PutTodo import PutTodo
-            |from .PotentialTodoDto import PotentialTodoDto
-            |from .Token import Token
-            |from .TodoDto import TodoDto
-            |from .Error import Error
+            |from . import model
+            |from . import endpoint
+            |from . import wirespec
+            |
         """.trimMargin()
         compiler { PythonEmitter() } shouldBeRight python
     }

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
@@ -234,7 +234,7 @@ class CompileMinimalEndpointTest {
             |from dataclasses import dataclass
             |from typing import List, Optional
             |
-            |from .shared.Wirespec import T, Wirespec
+            |from ..wirespec import T, Wirespec
             |
             |@dataclass
             |class TodoDto:
@@ -245,11 +245,11 @@ class CompileMinimalEndpointTest {
             |from dataclasses import dataclass
             |from typing import List, Optional
             |
-            |from .shared.Wirespec import T, Wirespec
+            |from ..wirespec import T, Wirespec
             |
-            |from .TodoDto import TodoDto
+            |from ..model.TodoDto import TodoDto
             |
-            |class GetTodosEndpoint (Wirespec.Endpoint):
+            |class GetTodos (Wirespec.Endpoint):
             |  @dataclass
             |  class Request(Wirespec.Request[None]):
             |    @dataclass
@@ -352,8 +352,10 @@ class CompileMinimalEndpointTest {
             |
             |
             |
-            |from .GetTodos import GetTodos
-            |from .TodoDto import TodoDto
+            |from . import model
+            |from . import endpoint
+            |from . import wirespec
+            |
         """.trimMargin()
         compiler { PythonEmitter() } shouldBeRight python
     }

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
@@ -322,7 +322,7 @@ class CompileMinimalEndpointTest {
             |        method = request.method.value,
             |        queries = {},
             |        headers = {},
-            |        body = type(None),
+            |        body = serialization.serialize(request.body, type(None)),
             |      )
             |
             |    @staticmethod

--- a/src/plugin/cli/src/commonMain/kotlin/community/flock/wirespec/plugin/cli/CommandLineArgumentsParser.kt
+++ b/src/plugin/cli/src/commonMain/kotlin/community/flock/wirespec/plugin/cli/CommandLineArgumentsParser.kt
@@ -114,8 +114,8 @@ private class Compile(
             when (it) {
                 Language.Java -> JavaEmitter(PackageName(packageName), shared)
                 Language.Kotlin -> KotlinEmitter(PackageName(packageName), shared)
+                Language.Python -> PythonEmitter(PackageName(packageName), shared)
                 Language.TypeScript -> TypeScriptEmitter(shared)
-                Language.Python -> PythonEmitter(shared)
                 Language.Wirespec -> WirespecEmitter()
                 Language.OpenAPIV2 -> OpenAPIV2Emitter
                 Language.OpenAPIV3 -> OpenAPIV3Emitter

--- a/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
+++ b/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
@@ -68,6 +68,7 @@ abstract class BaseWirespecTask : DefaultTask() {
     }
 
     protected fun packageNameValue() = packageName.getOrElse(DEFAULT_GENERATED_PACKAGE_STRING).let(PackageName::invoke)
+    protected fun sharedValue() = shared.getOrElse(false)
 
     protected fun emitter() = try {
         emitterClass.orNull?.getDeclaredConstructor()?.newInstance() as? Emitter
@@ -79,8 +80,8 @@ abstract class BaseWirespecTask : DefaultTask() {
     protected fun emitters() = languages.get().map {
         when (it) {
             Language.Java -> JavaEmitter(packageNameValue(), sharedValue())
-            Language.Kotlin -> KotlinEmitter(packageNameValue(),sharedValue())
-            Language.Python -> PythonEmitter(packageNameValue(),sharedValue())
+            Language.Kotlin -> KotlinEmitter(packageNameValue(), sharedValue())
+            Language.Python -> PythonEmitter(packageNameValue(), sharedValue())
             Language.TypeScript -> TypeScriptEmitter(sharedValue())
             Language.Wirespec -> WirespecEmitter()
             Language.OpenAPIV2 -> OpenAPIV2Emitter

--- a/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
+++ b/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
@@ -78,10 +78,10 @@ abstract class BaseWirespecTask : DefaultTask() {
 
     protected fun emitters() = languages.get().map {
         when (it) {
-            Language.Java -> JavaEmitter(packageNameValue())
-            Language.Kotlin -> KotlinEmitter(packageNameValue())
-            Language.TypeScript -> TypeScriptEmitter()
-            Language.Python -> PythonEmitter()
+            Language.Java -> JavaEmitter(packageNameValue(), sharedValue())
+            Language.Kotlin -> KotlinEmitter(packageNameValue(),sharedValue())
+            Language.Python -> PythonEmitter(packageNameValue(),sharedValue())
+            Language.TypeScript -> TypeScriptEmitter(sharedValue())
             Language.Wirespec -> WirespecEmitter()
             Language.OpenAPIV2 -> OpenAPIV2Emitter
             Language.OpenAPIV3 -> OpenAPIV3Emitter


### PR DESCRIPTION
# Pull Request

## Description
This PR refactors the emitter logic to enhance module namespace resolution and streamline shared module generation. A new `namespace` function has been introduced for consistent logic across definitions. Additionally, support for emitting Python in sub-packages has been implemented.

## Type of Change
<!-- Please check the option that best describes your PR -->
- [x] Feature (new functionality)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):
- [ ] Bug fix (resolves an issue)

## Related Issues
<!-- Link to any related issues using the format: Fixes #issue_number or Relates to #issue_number -->

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/main/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ]