### PR TITLE
Fix white space issue in data object

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitter.kt
@@ -68,7 +68,7 @@ open class KotlinEmitter(
         }
 
     override fun emit(type: Type, module: Module) =
-        if (type.shape.value.isEmpty()) "${Spacer}data object ${emit(type.identifier)}"
+        if (type.shape.value.isEmpty()) "data object ${emit(type.identifier)}"
         else """
             |data class ${emit(type.identifier)}(
             |${type.shape.emit()}

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitter.kt
@@ -68,7 +68,7 @@ open class KotlinEmitter(
         }
 
     override fun emit(type: Type, module: Module) =
-        if (type.shape.value.isEmpty()) "${Spacer}data object${emit(type.identifier)}"
+        if (type.shape.value.isEmpty()) "${Spacer}data object ${emit(type.identifier)}"
         else """
             |data class ${emit(type.identifier)}(
             |${type.shape.emit()}

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitterTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitterTest.kt
@@ -38,6 +38,24 @@ class JavaEmitterTest {
     }
 
     @Test
+    fun testEmitterEmptyType() {
+        val expected = listOf(
+            """
+            |package community.flock.wirespec.generated.model;
+            |
+            |public record TodoWithoutProperties (
+            |
+            |) {
+            |};
+            |
+            """.trimMargin(),
+        )
+
+        val res = emitContext.emitFirst(NodeFixtures.emptyType)
+        res shouldBe expected
+    }
+
+    @Test
     fun testEmitterRefined() {
         val expected = listOf(
             """

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitterTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/emit/KotlinEmitterTest.kt
@@ -37,6 +37,20 @@ class KotlinEmitterTest {
     }
 
     @Test
+    fun testEmitterEmptyType() {
+        val expected = listOf(
+            """
+            |package community.flock.wirespec.generated.model
+            |
+            |data object TodoWithoutProperties
+            """.trimMargin(),
+        )
+
+        val res = emitContext.emitFirst(NodeFixtures.emptyType)
+        res shouldBe expected
+    }
+
+    @Test
     fun testEmitterRefined() {
         val expected = listOf(
             """

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/fixture/NodeFixtures.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/fixture/NodeFixtures.kt
@@ -69,4 +69,13 @@ object NodeFixtures {
         ),
         extends = emptyList(),
     )
+
+    val emptyType = Type(
+        comment = null,
+        identifier = DefinitionIdentifier("TodoWithoutProperties"),
+        shape = Type.Shape(
+            value = emptyList(),
+        ),
+        extends = emptyList(),
+    )
 }


### PR DESCRIPTION
# Pull Request

## Description
This pull request fixes a white space issue in a data object to ensure proper functionality and consistency.

## Type of Change
<!-- Please check the option that best describes your PR -->
- [x] Bug fix (resolves an issue)
- [ ] Feature (new functionality)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Related Issues
<!-- Link to any related issues using the format: Fixes #issue_number or Relates to #issue_number -->

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/main/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)
- [ ] I have updated the documentation if necessary
- [ ] My changes pass all tests
- [ ] I have written a [conventional commit message](https://www.conventionalcommits.org/)

## Additional Context
<!-- Add any other context about the PR here, such as screenshots, implementation details, or challenges faced -->

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable