### PR TITLE
Add support for Optional parameter serialization

### DIFF
--- a/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/serde/DefaultParamSerialization.java
+++ b/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/serde/DefaultParamSerialization.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.List;
 import java.util.Collections;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Function;
 
 public interface DefaultParamSerialization extends Wirespec.ParamSerialization {
@@ -34,6 +35,11 @@ public interface DefaultParamSerialization extends Wirespec.ParamSerialization {
       return ((List<?>) value).stream()
           .map(Object::toString)
           .toList();
+    }
+    if(isOptional(type)) {
+      return ((Optional<?>) value)
+              .map(it -> Collections.singletonList(it.toString()))
+              .orElseGet(Collections::emptyList);
     }
     return Collections.singletonList(value.toString());
   }
@@ -103,6 +109,13 @@ public interface DefaultParamSerialization extends Wirespec.ParamSerialization {
       return List.class.isAssignableFrom((Class<?>) parameterizedType.getRawType());
     }
     return type instanceof Class<?> && List.class.isAssignableFrom((Class<?>) type);
+  }
+
+  private boolean isOptional(Type type) {
+    if (type instanceof ParameterizedType parameterizedType) {
+      return Optional.class.isAssignableFrom((Class<?>) parameterizedType.getRawType());
+    }
+    return type instanceof Class<?> && Optional.class.isAssignableFrom((Class<?>) type);
   }
 
   private boolean isWirespecEnum(Class<?> clazz) {


### PR DESCRIPTION
This update adds handling for `Optional` types in parameter serialization. It ensures that `Optional` values are correctly converted to a list format or an empty list when absent. A new helper method `isOptional` is introduced to identify `Optional` types.

## Description
<!-- Provide a clear and concise description of the changes you've made -->

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
