### PR TITLE
Refactor type handling in serialization and deserialization

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitter.kt
@@ -290,7 +290,7 @@ open class JavaEmitter(
         |${Spacer(4)}java.util.List.of(${endpoint.path.joinToString { when (it) {is Endpoint.Segment.Literal -> """"${it.value}""""; is Endpoint.Segment.Param -> it.emitIdentifier() } }}),
         |${Spacer(4)}${if (endpoint.queries.isNotEmpty()) "java.util.Map.ofEntries(${endpoint.queries.joinToString { it.emitSerializedParams("queries") }})" else EMPTY_MAP},
         |${Spacer(4)}${if (endpoint.headers.isNotEmpty()) "java.util.Map.ofEntries(${endpoint.headers.joinToString { it.emitSerializedParams("headers") }})" else EMPTY_MAP},
-        |${Spacer(4)}serialization.serialize(request.getBody(), Wirespec.getType(${content?.reference.emitRoot("Void")}.class, ${content?.reference?.isIterable ?: false}))
+        |${Spacer(4)}serialization.serialize(request.getBody(), ${content?.reference?.emitGetType()})
         |${Spacer(3)});
         |${Spacer(2)}}
         |
@@ -298,6 +298,13 @@ open class JavaEmitter(
         |${Spacer(3)}return new Request(${emitDeserializedParams(endpoint)});
         |${Spacer(2)}}
     """.trimMargin()
+
+    private fun Reference.emitGetType() = "Wirespec.getType(${emitRoot("Void")}.class, ${emitGetTypeRaw()})"
+    private fun Reference.emitGetTypeRaw() = when {
+        this.isNullable -> "java.util.Optional.class"
+        this is Reference.Iterable -> "java.util.List.class"
+        else -> null
+    }
 
     fun Endpoint.Response.emit() = """
         |${Spacer}record Response${status.firstToUpper()}(${listOfNotNull(headers.joinToString { it.emit() }.orNull(), content?.let { "${it.emit()} body" }).joinToString()}) implements Response${status.first()}XX<${content.emit()}>, Response${content.emit().concatGenerics()} {
@@ -329,39 +336,38 @@ open class JavaEmitter(
 
     private fun Endpoint.Request.emitDeserializedParams(endpoint: Endpoint) = listOfNotNull(
         endpoint.indexedPathParams.joinToString { it.emitDeserialized() }.orNull(),
-        endpoint.queries.joinToString { it.emitDeserializedParams("queries") }.orNull(),
-        endpoint.headers.joinToString { it.emitDeserializedParams("headers") }.orNull(),
-        content?.let { """${Spacer(4)}serialization.deserialize(request.body(), Wirespec.getType(${it.reference.emitRoot("Void")}.class, ${it.reference.isIterable}))""" }
+        endpoint.queries.joinToString(",\n"){ it.emitDeserializedParams("queries") }.orNull(),
+        endpoint.headers.joinToString(",\n"){ it.emitDeserializedParams("headers") }.orNull(),
+        content?.let { """${Spacer(4)}serialization.deserialize(request.body(), ${it.reference.emitGetType()})""" }
     ).joinToString(",\n").let { if (it.isBlank()) "" else "\n$it\n${Spacer(3)}" }
 
     private fun Endpoint.Response.emitDeserializedParams() = listOfNotNull(
-        headers.joinToString { """${Spacer(4)}java.util.Optional.ofNullable(response.headers().get("${it.identifier.value}")).map(it -> serialization.<${it.reference.emitType()}>deserializeParam(it, Wirespec.getType(${it.reference.emitRoot()}.class, ${it.reference.isIterable})))${if (!it.reference.isNullable) ".get()" else ""}""" }
-            .orNull(),
-        content?.let { """${Spacer(4)}serialization.deserialize(response.body(), Wirespec.getType(${it.reference.emitRoot("Void")}.class, ${it.reference.isIterable}))""" }
+        headers.joinToString(",\n") { """${Spacer(4)}serialization.deserializeParam(response.headers().getOrDefault("${it.identifier.value}", java.util.Collections.emptyList()), ${it.reference.emitGetType()})""" }.orNull(),
+        content?.let { """${Spacer(4)}serialization.deserialize(response.body(), ${it.reference.emitGetType()})""" }
     ).joinToString(",\n").let { if (it.isBlank()) "" else "\n$it\n${Spacer(3)}" }
 
     private fun Endpoint.Response.emitSerialized() =
         """${Spacer(3)}if (response instanceof Response${status.firstToUpper()} r) { return new Wirespec.RawResponse(r.getStatus(), ${if (headers.isNotEmpty()) "java.util.Map.ofEntries(${headers.joinToString { it.emitSerializedHeader() }})" else EMPTY_MAP}, ${
-            if (content != null) "serialization.serialize(r.body, Wirespec.getType(${content.reference.emitRoot("Void")}.class, ${content.reference.isIterable}))"
+            if (content != null) "serialization.serialize(r.body, ${content.reference.emitGetType()})"
             else "null"}); }"""
 
     private fun Endpoint.Response.emitDeserialized() =
         """${Spacer(4)}case $status: return new Response${status.firstToUpper()}(${this.emitDeserializedParams()});"""
 
     private fun Field.emitSerializedParams(fields: String) =
-        """java.util.Map.entry("${identifier.value}", serialization.serializeParam(request.$fields.${emit(identifier)}, Wirespec.getType(${reference.emitRoot()}.class, ${reference.isIterable})))"""
+        """java.util.Map.entry("${identifier.value}", serialization.serializeParam(request.$fields.${emit(identifier)}, ${reference.emitGetType()}))"""
 
     private fun IndexedValue<Endpoint.Segment.Param>.emitDeserialized() =
-        """${Spacer(4)}serialization.<${value.reference.emit()}>deserialize(request.path().get(${index}), Wirespec.getType(${value.reference.emitRoot()}.class, ${value.reference.isIterable}))"""
+        """${Spacer(4)}serialization.deserialize(request.path().get(${index}), ${value.reference.emitGetType()})"""
 
     private fun Field.emitDeserializedParams(fields: String) =
-        """${Spacer(4)}java.util.Optional.ofNullable(request.$fields().get("${identifier.value}")).map(it -> serialization.<${reference.emitType()}>deserializeParam(it, Wirespec.getType(${reference.emitRoot()}.class, ${reference.isIterable})))${if (!reference.isNullable) ".get()" else ""}"""
+        """${Spacer(4)}serialization.deserializeParam(request.$fields().getOrDefault("${identifier.value}", java.util.Collections.emptyList()), ${reference.emitGetType()})"""
 
     private fun Field.emitSerializedHeader() =
-        """java.util.Map.entry("${identifier.value}", serialization.serializeParam(r.getHeaders().${emit(identifier)}(), Wirespec.getType(${reference.emitRoot()}.class, ${reference.isIterable})))"""
+        """java.util.Map.entry("${identifier.value}", serialization.serializeParam(r.getHeaders().${emit(identifier)}(), ${reference.emitGetType()}))"""
 
     private fun Endpoint.Segment.Param.emitIdentifier() =
-        "serialization.serialize(request.path.${emit(identifier).firstToLower()}, Wirespec.getType(${reference.emitRoot()}.class, ${reference.isIterable}))"
+        "serialization.serialize(request.path.${emit(identifier).firstToLower()}, ${reference.emitGetType()})"
 
     private fun Endpoint.Content?.emit() = this?.reference?.emit() ?: "Void"
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/JavaEmitter.kt
@@ -299,9 +299,9 @@ open class JavaEmitter(
         |${Spacer(2)}}
     """.trimMargin()
 
-    private fun Reference.emitGetType() = "Wirespec.getType(${emitRoot("Void")}.class, ${emitGetTypeRaw()})"
-    private fun Reference.emitGetTypeRaw() = when {
-        this.isNullable -> "java.util.Optional.class"
+    private fun Reference?.emitGetType() = "Wirespec.getType(${emitRoot("Void")}.class, ${emitGetTypeRaw()})"
+    private fun Reference?.emitGetTypeRaw() = when {
+        this?.isNullable?:false -> "java.util.Optional.class"
         this is Reference.Iterable -> "java.util.List.class"
         else -> null
     }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/JavaShared.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/shared/JavaShared.kt
@@ -51,15 +51,15 @@ data object JavaShared : Shared {
         |${Spacer}interface Deserializer<RAW> extends ParamDeserializer { <T> T deserialize(RAW raw, Type type); }
         |${Spacer}record RawRequest(String method, List<String> path, Map<String, List<String>> queries, Map<String, List<String>> headers, String body) {} 
         |${Spacer}record RawResponse(int statusCode, Map<String, List<String>> headers, String body) {}
-        |${Spacer}static Type getType(final Class<?> type, final boolean isIterable) {
-        |${Spacer(2)}if(isIterable) {
+        |${Spacer}static Type getType(final Class<?> actualTypeArguments, final Class<?> rawType) {
+        |${Spacer(2)}if(rawType != null) {
         |${Spacer(3)}return new ParameterizedType() {
-        |${Spacer(4)}public Type getRawType() { return java.util.List.class; }
-        |${Spacer(4)}public Type[] getActualTypeArguments() { return new Class<?>[]{type}; }
+        |${Spacer(4)}public Type getRawType() { return rawType; }
+        |${Spacer(4)}public Type[] getActualTypeArguments() { return new Class<?>[]{actualTypeArguments}; }
         |${Spacer(4)}public Type getOwnerType() { return null; }
         |${Spacer(3)}};
         |${Spacer(2)}}
-        |${Spacer(2)}else { return type; }
+        |${Spacer(2)}else { return actualTypeArguments; }
         |$Spacer}
         |}
         |

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
@@ -292,40 +292,40 @@ class CompileFullEndpointTest {
             |    static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
             |      return new Wirespec.RawRequest(
             |        request.method.name(),
-            |        java.util.List.of("todos", serialization.serialize(request.path.id, Wirespec.getType(String.class, false))),
-            |        java.util.Map.ofEntries(java.util.Map.entry("done", serialization.serializeParam(request.queries.done, Wirespec.getType(Boolean.class, false)))),
-            |        java.util.Map.ofEntries(java.util.Map.entry("token", serialization.serializeParam(request.headers.token, Wirespec.getType(Token.class, false)))),
-            |        serialization.serialize(request.getBody(), Wirespec.getType(PotentialTodoDto.class, false))
+            |        java.util.List.of("todos", serialization.serialize(request.path.id, Wirespec.getType(String.class, null))),
+            |        java.util.Map.ofEntries(java.util.Map.entry("done", serialization.serializeParam(request.queries.done, Wirespec.getType(Boolean.class, null)))),
+            |        java.util.Map.ofEntries(java.util.Map.entry("token", serialization.serializeParam(request.headers.token, Wirespec.getType(Token.class, null)))),
+            |        serialization.serialize(request.getBody(), Wirespec.getType(PotentialTodoDto.class, null))
             |      );
             |    }
             |
             |    static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
             |      return new Request(
-            |        serialization.<String>deserialize(request.path().get(1), Wirespec.getType(String.class, false)),
-            |        java.util.Optional.ofNullable(request.queries().get("done")).map(it -> serialization.<Boolean>deserializeParam(it, Wirespec.getType(Boolean.class, false))).get(),
-            |        java.util.Optional.ofNullable(request.headers().get("token")).map(it -> serialization.<Token>deserializeParam(it, Wirespec.getType(Token.class, false))).get(),
-            |        serialization.deserialize(request.body(), Wirespec.getType(PotentialTodoDto.class, false))
+            |        serialization.deserialize(request.path().get(1), Wirespec.getType(String.class, null)),
+            |        serialization.deserializeParam(request.queries().getOrDefault("done", java.util.Collections.emptyList()), Wirespec.getType(Boolean.class, null)),
+            |        serialization.deserializeParam(request.headers().getOrDefault("token", java.util.Collections.emptyList()), Wirespec.getType(Token.class, null)),
+            |        serialization.deserialize(request.body(), Wirespec.getType(PotentialTodoDto.class, null))
             |      );
             |    }
             |
             |    static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-            |      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(TodoDto.class, false))); }
-            |      if (response instanceof Response201 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Map.ofEntries(java.util.Map.entry("token", serialization.serializeParam(r.getHeaders().token(), Wirespec.getType(Token.class, false)))), serialization.serialize(r.body, Wirespec.getType(TodoDto.class, false))); }
-            |      if (response instanceof Response500 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Error.class, false))); }
+            |      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(TodoDto.class, null))); }
+            |      if (response instanceof Response201 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Map.ofEntries(java.util.Map.entry("token", serialization.serializeParam(r.getHeaders().token(), Wirespec.getType(Token.class, null)))), serialization.serialize(r.body, Wirespec.getType(TodoDto.class, null))); }
+            |      if (response instanceof Response500 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Error.class, null))); }
             |      else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
             |    }
             |
             |    static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
             |      switch (response.statusCode()) {
             |        case 200: return new Response200(
-            |        serialization.deserialize(response.body(), Wirespec.getType(TodoDto.class, false))
+            |        serialization.deserialize(response.body(), Wirespec.getType(TodoDto.class, null))
             |      );
             |        case 201: return new Response201(
-            |        java.util.Optional.ofNullable(response.headers().get("token")).map(it -> serialization.<Token>deserializeParam(it, Wirespec.getType(Token.class, false))).get(),
-            |        serialization.deserialize(response.body(), Wirespec.getType(TodoDto.class, false))
+            |        serialization.deserializeParam(response.headers().getOrDefault("token", java.util.Collections.emptyList()), Wirespec.getType(Token.class, null)),
+            |        serialization.deserialize(response.body(), Wirespec.getType(TodoDto.class, null))
             |      );
             |        case 500: return new Response500(
-            |        serialization.deserialize(response.body(), Wirespec.getType(Error.class, false))
+            |        serialization.deserialize(response.body(), Wirespec.getType(Error.class, null))
             |      );
             |        default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());
             |      }

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
@@ -171,7 +171,7 @@ class CompileMinimalEndpointTest {
             |        java.util.List.of("todos"),
             |        java.util.Collections.emptyMap(),
             |        java.util.Collections.emptyMap(),
-            |        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+            |        serialization.serialize(request.getBody(), null)
             |      );
             |    }
             |
@@ -180,14 +180,14 @@ class CompileMinimalEndpointTest {
             |    }
             |
             |    static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-            |      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(TodoDto.class, true))); }
+            |      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(TodoDto.class, java.util.List.class))); }
             |      else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
             |    }
             |
             |    static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
             |      switch (response.statusCode()) {
             |        case 200: return new Response200(
-            |        serialization.deserialize(response.body(), Wirespec.getType(TodoDto.class, true))
+            |        serialization.deserialize(response.body(), Wirespec.getType(TodoDto.class, java.util.List.class))
             |      );
             |        default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());
             |      }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterTest.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterTest.kt
@@ -137,32 +137,32 @@ class SpringJavaEmitterTest {
             |      return new Wirespec.RawRequest(
             |        request.method.name(),
             |        java.util.List.of("api", "todos"),
-            |        java.util.Map.ofEntries(java.util.Map.entry("done", serialization.serializeParam(request.queries.done, Wirespec.getType(Boolean.class, false)))),
+            |        java.util.Map.ofEntries(java.util.Map.entry("done", serialization.serializeParam(request.queries.done, Wirespec.getType(Boolean.class, java.util.Optional.class)))),
             |        java.util.Collections.emptyMap(),
-            |        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+            |        serialization.serialize(request.getBody(), null)
             |      );
             |    }
             |
             |    static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
             |      return new Request(
-            |        java.util.Optional.ofNullable(request.queries().get("done")).map(it -> serialization.<Boolean>deserializeParam(it, Wirespec.getType(Boolean.class, false)))
+            |        serialization.deserializeParam(request.queries().getOrDefault("done", java.util.Collections.emptyList()), Wirespec.getType(Boolean.class, java.util.Optional.class))
             |      );
             |    }
             |
             |    static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-            |      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Map.ofEntries(java.util.Map.entry("total", serialization.serializeParam(r.getHeaders().total(), Wirespec.getType(Long.class, false)))), serialization.serialize(r.body, Wirespec.getType(TodoDto.class, true))); }
-            |      if (response instanceof Response500 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Error.class, false))); }
+            |      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Map.ofEntries(java.util.Map.entry("total", serialization.serializeParam(r.getHeaders().total(), Wirespec.getType(Long.class, null)))), serialization.serialize(r.body, Wirespec.getType(TodoDto.class, java.util.List.class))); }
+            |      if (response instanceof Response500 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Error.class, null))); }
             |      else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
             |    }
             |
             |    static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
             |      switch (response.statusCode()) {
             |        case 200: return new Response200(
-            |        java.util.Optional.ofNullable(response.headers().get("total")).map(it -> serialization.<Long>deserializeParam(it, Wirespec.getType(Long.class, false))).get(),
-            |        serialization.deserialize(response.body(), Wirespec.getType(TodoDto.class, true))
+            |        serialization.deserializeParam(response.headers().getOrDefault("total", java.util.Collections.emptyList()), Wirespec.getType(Long.class, null)),
+            |        serialization.deserialize(response.body(), Wirespec.getType(TodoDto.class, java.util.List.class))
             |      );
             |        case 500: return new Response500(
-            |        serialization.deserialize(response.body(), Wirespec.getType(Error.class, false))
+            |        serialization.deserialize(response.body(), Wirespec.getType(Error.class, null))
             |      );
             |        default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());
             |      }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/AddPet.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/AddPet.java
@@ -58,18 +58,18 @@ public interface AddPet extends Wirespec.Endpoint {
         java.util.List.of("pet"),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Pet.class, false))
+        serialization.serialize(request.getBody(), Wirespec.getType(Pet.class, null))
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.deserialize(request.body(), Wirespec.getType(Pet.class, false))
+        serialization.deserialize(request.body(), Wirespec.getType(Pet.class, null))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, null))); }
       if (response instanceof Response405 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
@@ -77,7 +77,7 @@ public interface AddPet extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, false))
+        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, null))
       );
         case 405: return new Response405();
         default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/CreateUser.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/CreateUser.java
@@ -50,18 +50,18 @@ public interface CreateUser extends Wirespec.Endpoint {
         java.util.List.of("user"),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(User.class, false))
+        serialization.serialize(request.getBody(), Wirespec.getType(User.class, null))
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.deserialize(request.body(), Wirespec.getType(User.class, false))
+        serialization.deserialize(request.body(), Wirespec.getType(User.class, null))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof ResponseDefault r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(User.class, false))); }
+      if (response instanceof ResponseDefault r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(User.class, null))); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
 

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/CreateUsersWithListInput.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/CreateUsersWithListInput.java
@@ -58,18 +58,18 @@ public interface CreateUsersWithListInput extends Wirespec.Endpoint {
         java.util.List.of("user", "createWithList"),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(User.class, true))
+        serialization.serialize(request.getBody(), Wirespec.getType(User.class, java.util.List.class))
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.deserialize(request.body(), Wirespec.getType(User.class, true))
+        serialization.deserialize(request.body(), Wirespec.getType(User.class, java.util.List.class))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(User.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(User.class, null))); }
       if (response instanceof ResponseDefault r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
@@ -77,7 +77,7 @@ public interface CreateUsersWithListInput extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(User.class, false))
+        serialization.deserialize(response.body(), Wirespec.getType(User.class, null))
       );
         default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());
       }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/DeleteOrder.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/DeleteOrder.java
@@ -55,16 +55,16 @@ public interface DeleteOrder extends Wirespec.Endpoint {
     static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
       return new Wirespec.RawRequest(
         request.method.name(),
-        java.util.List.of("store", "order", serialization.serialize(request.path.orderId, Wirespec.getType(Long.class, false))),
+        java.util.List.of("store", "order", serialization.serialize(request.path.orderId, Wirespec.getType(Long.class, null))),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.<Long>deserialize(request.path().get(2), Wirespec.getType(Long.class, false))
+        serialization.deserialize(request.path().get(2), Wirespec.getType(Long.class, null))
       );
     }
 

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/DeletePet.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/DeletePet.java
@@ -51,17 +51,17 @@ public interface DeletePet extends Wirespec.Endpoint {
     static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
       return new Wirespec.RawRequest(
         request.method.name(),
-        java.util.List.of("pet", serialization.serialize(request.path.petId, Wirespec.getType(Long.class, false))),
+        java.util.List.of("pet", serialization.serialize(request.path.petId, Wirespec.getType(Long.class, null))),
         java.util.Collections.emptyMap(),
-        java.util.Map.ofEntries(java.util.Map.entry("api_key", serialization.serializeParam(request.headers.api_key, Wirespec.getType(String.class, false)))),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        java.util.Map.ofEntries(java.util.Map.entry("api_key", serialization.serializeParam(request.headers.api_key, Wirespec.getType(String.class, java.util.Optional.class)))),
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.<Long>deserialize(request.path().get(1), Wirespec.getType(Long.class, false)),
-        java.util.Optional.ofNullable(request.headers().get("api_key")).map(it -> serialization.<String>deserializeParam(it, Wirespec.getType(String.class, false)))
+        serialization.deserialize(request.path().get(1), Wirespec.getType(Long.class, null)),
+        serialization.deserializeParam(request.headers().getOrDefault("api_key", java.util.Collections.emptyList()), Wirespec.getType(String.class, java.util.Optional.class))
       );
     }
 

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/DeleteUser.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/DeleteUser.java
@@ -55,16 +55,16 @@ public interface DeleteUser extends Wirespec.Endpoint {
     static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
       return new Wirespec.RawRequest(
         request.method.name(),
-        java.util.List.of("user", serialization.serialize(request.path.username, Wirespec.getType(String.class, false))),
+        java.util.List.of("user", serialization.serialize(request.path.username, Wirespec.getType(String.class, null))),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.<String>deserialize(request.path().get(1), Wirespec.getType(String.class, false))
+        serialization.deserialize(request.path().get(1), Wirespec.getType(String.class, null))
       );
     }
 

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/FindPetsByStatus.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/FindPetsByStatus.java
@@ -59,20 +59,20 @@ public interface FindPetsByStatus extends Wirespec.Endpoint {
       return new Wirespec.RawRequest(
         request.method.name(),
         java.util.List.of("pet", "findByStatus"),
-        java.util.Map.ofEntries(java.util.Map.entry("status", serialization.serializeParam(request.queries.status, Wirespec.getType(FindPetsByStatusParameterStatus.class, false)))),
+        java.util.Map.ofEntries(java.util.Map.entry("status", serialization.serializeParam(request.queries.status, Wirespec.getType(FindPetsByStatusParameterStatus.class, java.util.Optional.class)))),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        java.util.Optional.ofNullable(request.queries().get("status")).map(it -> serialization.<FindPetsByStatusParameterStatus>deserializeParam(it, Wirespec.getType(FindPetsByStatusParameterStatus.class, false)))
+        serialization.deserializeParam(request.queries().getOrDefault("status", java.util.Collections.emptyList()), Wirespec.getType(FindPetsByStatusParameterStatus.class, java.util.Optional.class))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, true))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, java.util.List.class))); }
       if (response instanceof Response400 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
@@ -80,7 +80,7 @@ public interface FindPetsByStatus extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, true))
+        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, java.util.List.class))
       );
         case 400: return new Response400();
         default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/FindPetsByTags.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/FindPetsByTags.java
@@ -58,20 +58,20 @@ public interface FindPetsByTags extends Wirespec.Endpoint {
       return new Wirespec.RawRequest(
         request.method.name(),
         java.util.List.of("pet", "findByTags"),
-        java.util.Map.ofEntries(java.util.Map.entry("tags", serialization.serializeParam(request.queries.tags, Wirespec.getType(String.class, true)))),
+        java.util.Map.ofEntries(java.util.Map.entry("tags", serialization.serializeParam(request.queries.tags, Wirespec.getType(String.class, java.util.Optional.class)))),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        java.util.Optional.ofNullable(request.queries().get("tags")).map(it -> serialization.<java.util.List<String>>deserializeParam(it, Wirespec.getType(String.class, true)))
+        serialization.deserializeParam(request.queries().getOrDefault("tags", java.util.Collections.emptyList()), Wirespec.getType(String.class, java.util.Optional.class))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, true))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, java.util.List.class))); }
       if (response instanceof Response400 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
@@ -79,7 +79,7 @@ public interface FindPetsByTags extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, true))
+        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, java.util.List.class))
       );
         case 400: return new Response400();
         default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/GetInventory.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/GetInventory.java
@@ -50,7 +50,7 @@ public interface GetInventory extends Wirespec.Endpoint {
         java.util.List.of("store", "inventory"),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
@@ -59,14 +59,14 @@ public interface GetInventory extends Wirespec.Endpoint {
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Integer.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Integer.class, null))); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
 
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(Integer.class, false))
+        serialization.deserialize(response.body(), Wirespec.getType(Integer.class, null))
       );
         default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());
       }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/GetOrderById.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/GetOrderById.java
@@ -63,21 +63,21 @@ public interface GetOrderById extends Wirespec.Endpoint {
     static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
       return new Wirespec.RawRequest(
         request.method.name(),
-        java.util.List.of("store", "order", serialization.serialize(request.path.orderId, Wirespec.getType(Long.class, false))),
+        java.util.List.of("store", "order", serialization.serialize(request.path.orderId, Wirespec.getType(Long.class, null))),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.<Long>deserialize(request.path().get(2), Wirespec.getType(Long.class, false))
+        serialization.deserialize(request.path().get(2), Wirespec.getType(Long.class, null))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Order.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Order.class, null))); }
       if (response instanceof Response400 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       if (response instanceof Response404 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
@@ -86,7 +86,7 @@ public interface GetOrderById extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(Order.class, false))
+        serialization.deserialize(response.body(), Wirespec.getType(Order.class, null))
       );
         case 400: return new Response400();
         case 404: return new Response404();

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/GetPetById.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/GetPetById.java
@@ -63,21 +63,21 @@ public interface GetPetById extends Wirespec.Endpoint {
     static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
       return new Wirespec.RawRequest(
         request.method.name(),
-        java.util.List.of("pet", serialization.serialize(request.path.petId, Wirespec.getType(Long.class, false))),
+        java.util.List.of("pet", serialization.serialize(request.path.petId, Wirespec.getType(Long.class, null))),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.<Long>deserialize(request.path().get(1), Wirespec.getType(Long.class, false))
+        serialization.deserialize(request.path().get(1), Wirespec.getType(Long.class, null))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, null))); }
       if (response instanceof Response400 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       if (response instanceof Response404 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
@@ -86,7 +86,7 @@ public interface GetPetById extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, false))
+        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, null))
       );
         case 400: return new Response400();
         case 404: return new Response404();

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/GetUserByName.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/GetUserByName.java
@@ -63,21 +63,21 @@ public interface GetUserByName extends Wirespec.Endpoint {
     static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
       return new Wirespec.RawRequest(
         request.method.name(),
-        java.util.List.of("user", serialization.serialize(request.path.username, Wirespec.getType(String.class, false))),
+        java.util.List.of("user", serialization.serialize(request.path.username, Wirespec.getType(String.class, null))),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.<String>deserialize(request.path().get(1), Wirespec.getType(String.class, false))
+        serialization.deserialize(request.path().get(1), Wirespec.getType(String.class, null))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(User.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(User.class, null))); }
       if (response instanceof Response400 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       if (response instanceof Response404 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
@@ -86,7 +86,7 @@ public interface GetUserByName extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(User.class, false))
+        serialization.deserialize(response.body(), Wirespec.getType(User.class, null))
       );
         case 400: return new Response400();
         case 404: return new Response404();

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/LoginUser.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/LoginUser.java
@@ -62,20 +62,21 @@ public interface LoginUser extends Wirespec.Endpoint {
       return new Wirespec.RawRequest(
         request.method.name(),
         java.util.List.of("user", "login"),
-        java.util.Map.ofEntries(java.util.Map.entry("username", serialization.serializeParam(request.queries.username, Wirespec.getType(String.class, false))), java.util.Map.entry("password", serialization.serializeParam(request.queries.password, Wirespec.getType(String.class, false)))),
+        java.util.Map.ofEntries(java.util.Map.entry("username", serialization.serializeParam(request.queries.username, Wirespec.getType(String.class, java.util.Optional.class))), java.util.Map.entry("password", serialization.serializeParam(request.queries.password, Wirespec.getType(String.class, java.util.Optional.class)))),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        java.util.Optional.ofNullable(request.queries().get("username")).map(it -> serialization.<String>deserializeParam(it, Wirespec.getType(String.class, false))),         java.util.Optional.ofNullable(request.queries().get("password")).map(it -> serialization.<String>deserializeParam(it, Wirespec.getType(String.class, false)))
+        serialization.deserializeParam(request.queries().getOrDefault("username", java.util.Collections.emptyList()), Wirespec.getType(String.class, java.util.Optional.class)),
+        serialization.deserializeParam(request.queries().getOrDefault("password", java.util.Collections.emptyList()), Wirespec.getType(String.class, java.util.Optional.class))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Map.ofEntries(java.util.Map.entry("X-Rate-Limit", serialization.serializeParam(r.getHeaders().XRateLimit(), Wirespec.getType(Integer.class, false))), java.util.Map.entry("X-Expires-After", serialization.serializeParam(r.getHeaders().XExpiresAfter(), Wirespec.getType(String.class, false)))), serialization.serialize(r.body, Wirespec.getType(String.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Map.ofEntries(java.util.Map.entry("X-Rate-Limit", serialization.serializeParam(r.getHeaders().XRateLimit(), Wirespec.getType(Integer.class, java.util.Optional.class))), java.util.Map.entry("X-Expires-After", serialization.serializeParam(r.getHeaders().XExpiresAfter(), Wirespec.getType(String.class, java.util.Optional.class)))), serialization.serialize(r.body, Wirespec.getType(String.class, null))); }
       if (response instanceof Response400 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
@@ -83,8 +84,9 @@ public interface LoginUser extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        java.util.Optional.ofNullable(response.headers().get("X-Rate-Limit")).map(it -> serialization.<Integer>deserializeParam(it, Wirespec.getType(Integer.class, false))),         java.util.Optional.ofNullable(response.headers().get("X-Expires-After")).map(it -> serialization.<String>deserializeParam(it, Wirespec.getType(String.class, false))),
-        serialization.deserialize(response.body(), Wirespec.getType(String.class, false))
+        serialization.deserializeParam(response.headers().getOrDefault("X-Rate-Limit", java.util.Collections.emptyList()), Wirespec.getType(Integer.class, java.util.Optional.class)),
+        serialization.deserializeParam(response.headers().getOrDefault("X-Expires-After", java.util.Collections.emptyList()), Wirespec.getType(String.class, java.util.Optional.class)),
+        serialization.deserialize(response.body(), Wirespec.getType(String.class, null))
       );
         case 400: return new Response400();
         default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/LogoutUser.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/LogoutUser.java
@@ -50,7 +50,7 @@ public interface LogoutUser extends Wirespec.Endpoint {
         java.util.List.of("user", "logout"),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/PlaceOrder.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/PlaceOrder.java
@@ -58,18 +58,18 @@ public interface PlaceOrder extends Wirespec.Endpoint {
         java.util.List.of("store", "order"),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Order.class, false))
+        serialization.serialize(request.getBody(), Wirespec.getType(Order.class, null))
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.deserialize(request.body(), Wirespec.getType(Order.class, false))
+        serialization.deserialize(request.body(), Wirespec.getType(Order.class, null))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Order.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Order.class, null))); }
       if (response instanceof Response405 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
@@ -77,7 +77,7 @@ public interface PlaceOrder extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(Order.class, false))
+        serialization.deserialize(response.body(), Wirespec.getType(Order.class, null))
       );
         case 405: return new Response405();
         default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/UpdatePet.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/UpdatePet.java
@@ -70,18 +70,18 @@ public interface UpdatePet extends Wirespec.Endpoint {
         java.util.List.of("pet"),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Pet.class, false))
+        serialization.serialize(request.getBody(), Wirespec.getType(Pet.class, null))
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.deserialize(request.body(), Wirespec.getType(Pet.class, false))
+        serialization.deserialize(request.body(), Wirespec.getType(Pet.class, null))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(Pet.class, null))); }
       if (response instanceof Response400 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       if (response instanceof Response404 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       if (response instanceof Response405 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
@@ -91,7 +91,7 @@ public interface UpdatePet extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, false))
+        serialization.deserialize(response.body(), Wirespec.getType(Pet.class, null))
       );
         case 400: return new Response400();
         case 404: return new Response404();

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/UpdatePetWithForm.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/UpdatePetWithForm.java
@@ -52,17 +52,18 @@ public interface UpdatePetWithForm extends Wirespec.Endpoint {
     static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
       return new Wirespec.RawRequest(
         request.method.name(),
-        java.util.List.of("pet", serialization.serialize(request.path.petId, Wirespec.getType(Long.class, false))),
-        java.util.Map.ofEntries(java.util.Map.entry("name", serialization.serializeParam(request.queries.name, Wirespec.getType(String.class, false))), java.util.Map.entry("status", serialization.serializeParam(request.queries.status, Wirespec.getType(String.class, false)))),
+        java.util.List.of("pet", serialization.serialize(request.path.petId, Wirespec.getType(Long.class, null))),
+        java.util.Map.ofEntries(java.util.Map.entry("name", serialization.serializeParam(request.queries.name, Wirespec.getType(String.class, java.util.Optional.class))), java.util.Map.entry("status", serialization.serializeParam(request.queries.status, Wirespec.getType(String.class, java.util.Optional.class)))),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(Void.class, false))
+        serialization.serialize(request.getBody(), null)
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.<Long>deserialize(request.path().get(1), Wirespec.getType(Long.class, false)),
-        java.util.Optional.ofNullable(request.queries().get("name")).map(it -> serialization.<String>deserializeParam(it, Wirespec.getType(String.class, false))),         java.util.Optional.ofNullable(request.queries().get("status")).map(it -> serialization.<String>deserializeParam(it, Wirespec.getType(String.class, false)))
+        serialization.deserialize(request.path().get(1), Wirespec.getType(Long.class, null)),
+        serialization.deserializeParam(request.queries().getOrDefault("name", java.util.Collections.emptyList()), Wirespec.getType(String.class, java.util.Optional.class)),
+        serialization.deserializeParam(request.queries().getOrDefault("status", java.util.Collections.emptyList()), Wirespec.getType(String.class, java.util.Optional.class))
       );
     }
 

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/UpdateUser.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/UpdateUser.java
@@ -49,17 +49,17 @@ public interface UpdateUser extends Wirespec.Endpoint {
     static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
       return new Wirespec.RawRequest(
         request.method.name(),
-        java.util.List.of("user", serialization.serialize(request.path.username, Wirespec.getType(String.class, false))),
+        java.util.List.of("user", serialization.serialize(request.path.username, Wirespec.getType(String.class, null))),
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(User.class, false))
+        serialization.serialize(request.getBody(), Wirespec.getType(User.class, null))
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.<String>deserialize(request.path().get(1), Wirespec.getType(String.class, false)),
-        serialization.deserialize(request.body(), Wirespec.getType(User.class, false))
+        serialization.deserialize(request.path().get(1), Wirespec.getType(String.class, null)),
+        serialization.deserialize(request.body(), Wirespec.getType(User.class, null))
       );
     }
 

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/UploadFile.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/UploadFile.java
@@ -51,30 +51,30 @@ public interface UploadFile extends Wirespec.Endpoint {
     static Wirespec.RawRequest toRequest(Wirespec.Serializer<String> serialization, Request request) {
       return new Wirespec.RawRequest(
         request.method.name(),
-        java.util.List.of("pet", serialization.serialize(request.path.petId, Wirespec.getType(Long.class, false)), "uploadImage"),
-        java.util.Map.ofEntries(java.util.Map.entry("additionalMetadata", serialization.serializeParam(request.queries.additionalMetadata, Wirespec.getType(String.class, false)))),
+        java.util.List.of("pet", serialization.serialize(request.path.petId, Wirespec.getType(Long.class, null)), "uploadImage"),
+        java.util.Map.ofEntries(java.util.Map.entry("additionalMetadata", serialization.serializeParam(request.queries.additionalMetadata, Wirespec.getType(String.class, java.util.Optional.class)))),
         java.util.Collections.emptyMap(),
-        serialization.serialize(request.getBody(), Wirespec.getType(String.class, false))
+        serialization.serialize(request.getBody(), Wirespec.getType(String.class, null))
       );
     }
 
     static Request fromRequest(Wirespec.Deserializer<String> serialization, Wirespec.RawRequest request) {
       return new Request(
-        serialization.<Long>deserialize(request.path().get(1), Wirespec.getType(Long.class, false)),
-        java.util.Optional.ofNullable(request.queries().get("additionalMetadata")).map(it -> serialization.<String>deserializeParam(it, Wirespec.getType(String.class, false))),
-        serialization.deserialize(request.body(), Wirespec.getType(String.class, false))
+        serialization.deserialize(request.path().get(1), Wirespec.getType(Long.class, null)),
+        serialization.deserializeParam(request.queries().getOrDefault("additionalMetadata", java.util.Collections.emptyList()), Wirespec.getType(String.class, java.util.Optional.class)),
+        serialization.deserialize(request.body(), Wirespec.getType(String.class, null))
       );
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer<String> serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(ApiResponse.class, false))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serialize(r.body, Wirespec.getType(ApiResponse.class, null))); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
 
     static Response<?> fromResponse(Wirespec.Deserializer<String> serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
-        serialization.deserialize(response.body(), Wirespec.getType(ApiResponse.class, false))
+        serialization.deserialize(response.body(), Wirespec.getType(ApiResponse.class, null))
       );
         default: throw new IllegalStateException("Cannot match response with status: " + response.statusCode());
       }

--- a/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
+++ b/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
@@ -1,7 +1,7 @@
 package community.flock.wirespec.java;
 
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.Map;
 
@@ -42,14 +42,14 @@ public interface Wirespec {
     interface Deserializer<RAW> extends ParamDeserializer { <T> T deserialize(RAW raw, Type type); }
     record RawRequest(String method, List<String> path, Map<String, List<String>> queries, Map<String, List<String>> headers, String body) {}
     record RawResponse(int statusCode, Map<String, List<String>> headers, String body) {}
-    static Type getType(final Class<?> type, final boolean isIterable) {
-        if(isIterable) {
+    static Type getType(final Class<?> actualTypeArguments, final Class<?> rawType) {
+        if(rawType != null) {
             return new ParameterizedType() {
-                public Type getRawType() { return java.util.List.class; }
-                public Type[] getActualTypeArguments() { return new Class<?>[]{type}; }
+                public Type getRawType() { return rawType; }
+                public Type[] getActualTypeArguments() { return new Class<?>[]{actualTypeArguments}; }
                 public Type getOwnerType() { return null; }
             };
         }
-        else { return type; }
+        else { return actualTypeArguments; }
     }
 }

--- a/src/integration/wirespec/src/jvmTest/java/community/flock/wirespec/java/serde/DefaultParamSerializationTest.java
+++ b/src/integration/wirespec/src/jvmTest/java/community/flock/wirespec/java/serde/DefaultParamSerializationTest.java
@@ -1,0 +1,92 @@
+package community.flock.wirespec.java.serde;
+
+import community.flock.wirespec.java.Wirespec;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultParamSerializationTest {
+
+    private final DefaultParamSerialization serde = DefaultParamSerialization.create();
+    @Test
+    public void shouldSerializePrimitiveTypesCorrectly() {
+        primitiveTestCases().forEach(testCase ->
+                assertEquals(testCase.expected, serde.serializeParam(testCase.value, testCase.type))
+        );
+    }
+
+    record PrimitiveTestCase(
+            String name,
+            Object value,
+            Type type,
+            List<String> expected
+    ){}
+
+    public static List<PrimitiveTestCase> primitiveTestCases() {
+        return Arrays.asList(
+                new PrimitiveTestCase(
+                        "string",
+                        "test",
+                        String.class,
+                        List.of("test")
+                ),
+                new PrimitiveTestCase(
+                        "int",
+                        42,
+                        Integer.class,
+                        List.of("42")
+                ),
+                new PrimitiveTestCase(
+                        "long",
+                        42L,
+                        Long.class,
+                        List.of("42")
+                ),
+                new PrimitiveTestCase(
+                        "double",
+                        42.0,
+                        Double.class,
+                        List.of("42.0")
+                ),
+                new PrimitiveTestCase(
+                        "float",
+                        42.0f,
+                        Float.class,
+                        List.of("42.0")
+                ),
+                new PrimitiveTestCase(
+                        "boolean",
+                        true,
+                        Boolean.class,
+                        List.of("true")
+                ),
+                new PrimitiveTestCase(
+                        "char",
+                        'a',
+                        Character.class,
+                        List.of("a")
+                ),
+                new PrimitiveTestCase(
+                        "byte",
+                        (byte) 42,
+                        Byte.class,
+                        List.of("42")
+                ),
+                new PrimitiveTestCase(
+                        "short",
+                        (short) 42,
+                        Short.class,
+                        List.of("42")
+                )
+        );
+    }
+
+
+
+
+}
+


### PR DESCRIPTION
Replaced raw type handling with a new emitGetType() method to streamline serialization and deserialization logic. Improved support for java.util.Optional and adjusted handling for parameterized types in Wirespec.java. These changes enhance code readability, maintainability, and extend support for nullable types.

## Description
<!-- Provide a clear and concise description of the changes you've made -->

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
