### PR TITLE
TypeScript emitter to handle nullable parameters properly

### DIFF
--- a/examples/npm-typescript/src/clientProxy.ts
+++ b/examples/npm-typescript/src/clientProxy.ts
@@ -67,7 +67,7 @@ const webClient: WebClient = (...apis) => {
 const api = webClient(PostTodo.api, GetTodos.api, GetTodoById.api, GetUsers.api)
 
 const testGetTodos = async () => {
-    const request: GetTodos.Request = GetTodos.request({done: true});
+    const request: GetTodos.Request = GetTodos.request({});
     const response = await api.getTodos(request);
     const expected = {status: 200, headers: {total: 2}, body};
     assert.deepEqual(response, expected);

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/TypeScriptEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/TypeScriptEmitter.kt
@@ -197,7 +197,7 @@ open class TypeScriptEmitter(val emitShared: EmitShared = EmitShared()) : Emitte
     private fun <T> Iterable<T>.joinToObject(transform: ((T) -> CharSequence)) =
         joinToString(", ", "{", "}", transform = transform)
 
-    private fun Param.emit() = "${emit(identifier)}: ${reference.emit()}"
+    private fun Param.emit() = "${emit(identifier)}${if(reference.isNullable) "?" else ""}: ${reference.copy(isNullable = false).emit()}"
 
     private fun Endpoint.Response.emitName() = "Response" + status.firstToUpper()
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Node.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Node.kt
@@ -44,7 +44,7 @@ sealed interface Reference : Value<String> {
         is Custom -> copy(isNullable = isNullable ?: this.isNullable)
         is Dict -> copy(isNullable = isNullable ?: this.isNullable)
         is Iterable -> copy(isNullable = isNullable ?: this.isNullable)
-        is Primitive ->copy(isNullable = isNullable ?: this.isNullable)
+        is Primitive -> copy(isNullable = isNullable ?: this.isNullable)
         is Unit -> copy(isNullable = isNullable ?: this.isNullable)
     }
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Node.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Node.kt
@@ -39,6 +39,15 @@ data class Type(
 sealed interface Reference : Value<String> {
     val isNullable: Boolean
 
+    fun copy(isNullable: Boolean? = null) = when (this) {
+        is Any -> copy(isNullable = isNullable ?: this.isNullable)
+        is Custom -> copy(isNullable = isNullable ?: this.isNullable)
+        is Dict -> copy(isNullable = isNullable ?: this.isNullable)
+        is Iterable -> copy(isNullable = isNullable ?: this.isNullable)
+        is Primitive ->copy(isNullable = isNullable ?: this.isNullable)
+        is Unit -> copy(isNullable = isNullable ?: this.isNullable)
+    }
+
     data class Any(
         override val isNullable: Boolean,
     ) : Reference {

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileFullEndpointTest.kt
@@ -462,7 +462,7 @@ class CompileFullEndpointTest {
             |    body: Error
             |  }
             |  export type Response = Response200 | Response201 | Response500
-            |  export const request = (props: {"id": string, "done": boolean, "name": string | undefined, "token": Token, "refreshToken": Token | undefined, "body": PotentialTodoDto}): Request => ({
+            |  export const request = (props: {"id": string, "done": boolean, "name"?: string, "token": Token, "refreshToken"?: Token, "body": PotentialTodoDto}): Request => ({
             |    path: {"id": props["id"]},
             |    method: "PUT",
             |    queries: {"done": props["done"], "name": props["name"]},
@@ -474,7 +474,7 @@ class CompileFullEndpointTest {
             |    headers: {},
             |    body: props.body,
             |  })
-            |  export const response201 = (props: {"token": Token, "refreshToken": Token | undefined, "body": TodoDto}): Response201 => ({
+            |  export const response201 = (props: {"token": Token, "refreshToken"?: Token, "body": TodoDto}): Response201 => ({
             |    status: 201,
             |    headers: {"token": props["token"], "refreshToken": props["refreshToken"]},
             |    body: props.body,


### PR DESCRIPTION
## Description
This MR updates the **TypeScript type definitions** for function parameters by switching from the explicit union with `undefined` (e.g., `string | undefined`) to the **optional property syntax** using `?` (e.g., `name?: string`). This change affects how these functions are called and how TypeScript type-checks them.

### Before (old version)
```ts
{name: string | undefined, refreshToken: Token | undefined}
```
- **Caller must provide these properties**, but the value can be `undefined`.
- Example: `request({name: undefined, ...})` is required; omitting `name` would be a type error.

### After (new version)
```ts
{name?: string, refreshToken?: Token}
```
- **Caller can omit these properties entirely**; they are optional.
- Example: `request({...})` is valid, and `name` or `refreshToken` can be left out.

### Functional Difference
- **Old:** Property must be present in the argument object, but its value can be `undefined`.
- **New:** Property can be omitted from the argument object; if it's present, it must match the given type.

#### In summary:
- The new version makes `name` and `refreshToken` truly optional properties, so callers are not required to provide them at all. This is the idiomatic way to represent optional properties in TypeScript.

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
