### PR TITLE
Validate AST statements during compilation in plugins

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Parser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Parser.kt
@@ -70,7 +70,7 @@ object Parser {
         }
     }
 
-    private fun validate(options: ParseOptions): (Statements) -> EitherNel<WirespecException, Statements> = { defs: Statements ->
+    fun validate(options: ParseOptions): (Statements) -> EitherNel<WirespecException, Statements> = { defs: Statements ->
         defs.runOption(options.allowUnions) { fillExtendsClause() }
     }
 

--- a/src/converter/openapi/src/commonTest/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3ParserTest.kt
+++ b/src/converter/openapi/src/commonTest/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3ParserTest.kt
@@ -12,6 +12,7 @@ import community.flock.wirespec.compiler.core.parse.Reference.Custom
 import community.flock.wirespec.compiler.core.parse.Reference.Primitive
 import community.flock.wirespec.compiler.core.parse.Type
 import community.flock.wirespec.compiler.core.parse.Type.Shape
+import community.flock.wirespec.compiler.core.parse.Union
 import community.flock.wirespec.openapi.common.Ast
 import community.flock.wirespec.openapi.v3.OpenAPIV3Parser.parse
 import kotlinx.io.buffered
@@ -1151,6 +1152,80 @@ class OpenAPIV3ParserTest {
                                     type = Primitive.Type.String,
                                     isNullable = false,
                                 ),
+                                isNullable = false,
+                            ),
+                        ),
+                    ),
+                ),
+                extends = emptyList(),
+            ),
+        )
+        assertEquals(expected, ast)
+    }@Test
+
+    fun componentsResponses() {
+        val path = Path("src/commonTest/resources/v3/components-responses.json")
+        val json = SystemFileSystem.source(path).buffered().readString()
+
+        val openApi = OpenAPI.decodeFromString(json)
+        val ast = openApi.parse()
+
+        val expected = nonEmptyListOf(
+            Endpoint(
+                comment=null,
+                identifier=DefinitionIdentifier(name="OneofGET"),
+                method= Endpoint.Method.GET, path=listOf(
+                    Endpoint.Segment.Literal(value = "oneof")
+                ),
+                queries=emptyList(),
+                headers=emptyList(),
+                requests=listOf(
+                    Endpoint.Request(content = null)
+                ),
+                responses=listOf(
+                    Endpoint.Response(
+                        status = "200",
+                        headers = emptyList(),
+                        content = Endpoint.Content(
+                            type = "application/json",
+                            reference = Custom(value = "OneofGET200ResponseBody", isNullable = false)
+                        )
+                    )
+                )
+            ),
+            Union(
+                comment = null,
+                identifier = DefinitionIdentifier(name = "OneofGET200ResponseBody"),
+                entries = setOf(
+                    Custom(value = "Foo", isNullable = false),
+                    Custom(value = "Bar", isNullable = false)
+                )
+            ),
+            Type(
+                comment = null,
+                identifier = DefinitionIdentifier("Foo"),
+                shape = Type.Shape(
+                    value = listOf(
+                        Field(
+                            identifier = FieldIdentifier("a"),
+                            reference = Reference.Primitive(
+                                type = Reference.Primitive.Type.String,
+                                isNullable = true,
+                            ),
+                        ),
+                    ),
+                ),
+                extends = emptyList(),
+            ),
+            Type(
+                comment = null,
+                identifier = DefinitionIdentifier("Bar"),
+                shape = Type.Shape(
+                    value = listOf(
+                        Field(
+                            identifier = FieldIdentifier("b"),
+                            reference = Reference.Primitive(
+                                type = Reference.Primitive.Type.String,
                                 isNullable = false,
                             ),
                         ),

--- a/src/converter/openapi/src/commonTest/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3ParserTest.kt
+++ b/src/converter/openapi/src/commonTest/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3ParserTest.kt
@@ -1161,8 +1161,9 @@ class OpenAPIV3ParserTest {
             ),
         )
         assertEquals(expected, ast)
-    }@Test
+    }
 
+    @Test
     fun componentsResponses() {
         val path = Path("src/commonTest/resources/v3/components-responses.json")
         val json = SystemFileSystem.source(path).buffered().readString()
@@ -1172,34 +1173,35 @@ class OpenAPIV3ParserTest {
 
         val expected = nonEmptyListOf(
             Endpoint(
-                comment=null,
-                identifier=DefinitionIdentifier(name="OneofGET"),
-                method= Endpoint.Method.GET, path=listOf(
-                    Endpoint.Segment.Literal(value = "oneof")
+                comment = null,
+                identifier = DefinitionIdentifier(name = "OneofGET"),
+                method = Endpoint.Method.GET,
+                path = listOf(
+                    Endpoint.Segment.Literal(value = "oneof"),
                 ),
-                queries=emptyList(),
-                headers=emptyList(),
-                requests=listOf(
-                    Endpoint.Request(content = null)
+                queries = emptyList(),
+                headers = emptyList(),
+                requests = listOf(
+                    Endpoint.Request(content = null),
                 ),
-                responses=listOf(
+                responses = listOf(
                     Endpoint.Response(
                         status = "200",
                         headers = emptyList(),
                         content = Endpoint.Content(
                             type = "application/json",
-                            reference = Custom(value = "OneofGET200ResponseBody", isNullable = false)
-                        )
-                    )
-                )
+                            reference = Custom(value = "OneofGET200ResponseBody", isNullable = false),
+                        ),
+                    ),
+                ),
             ),
             Union(
                 comment = null,
                 identifier = DefinitionIdentifier(name = "OneofGET200ResponseBody"),
                 entries = setOf(
                     Custom(value = "Foo", isNullable = false),
-                    Custom(value = "Bar", isNullable = false)
-                )
+                    Custom(value = "Bar", isNullable = false),
+                ),
             ),
             Type(
                 comment = null,

--- a/src/converter/openapi/src/commonTest/resources/v3/components-responses.json
+++ b/src/converter/openapi/src/commonTest/resources/v3/components-responses.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Object in response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/oneof": {
+      "get": {
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ContactResponse"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ContactResponse": {
+        "description": "Created contact",
+        "content": {
+          "application/json": {
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Foo"
+                },
+                {
+                  "$ref": "#/components/schemas/Bar"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        }
+      },
+      "Bar": {
+        "type": "object",
+        "required": [
+          "b"
+        ],
+        "properties": {
+          "b": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Wirespec.kt
+++ b/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Wirespec.kt
@@ -1,13 +1,21 @@
 package community.flock.wirespec.plugin
 
+import arrow.core.getOrElse
 import community.flock.wirespec.compiler.core.CompilationContext
 import community.flock.wirespec.compiler.core.ModuleContent
 import community.flock.wirespec.compiler.core.compile
 import community.flock.wirespec.compiler.core.exceptions.WirespecException
+import community.flock.wirespec.compiler.core.parse.ParseOptions
+import community.flock.wirespec.compiler.core.parse.Parser.validate
 import community.flock.wirespec.converter.avro.AvroParser
 import community.flock.wirespec.converter.common.Parser
 import community.flock.wirespec.openapi.v2.OpenAPIV2Parser
 import community.flock.wirespec.openapi.v3.OpenAPIV3Parser
+
+fun ConverterArguments.parseOptions() = ParseOptions(
+    strict = strict,
+    allowUnions = true
+)
 
 fun compile(arguments: CompilerArguments) {
     val ctx = object : CompilationContext {
@@ -26,10 +34,19 @@ fun convert(arguments: ConverterArguments) {
         Format.OpenAPIV3 -> OpenAPIV3Parser
         Format.Avro -> AvroParser
     }
-
+    val options = arguments.parseOptions()
     arguments.input
         .map { ModuleContent(it.name.value, it.content) }
         .map { moduleContent -> parser.parse(moduleContent, arguments.strict) }
+        .map { ast ->
+            ast.copy(
+                modules = ast.modules.map {module ->
+                    module.copy(
+                        statements = validate(options)(module.statements).getOrElse { error("Invalid statements") }
+                    )
+                }
+            )
+        }
         .flatMap { ast ->
             arguments.emitters.flatMap {
                 it.emit(ast, arguments.logger)

--- a/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Wirespec.kt
+++ b/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Wirespec.kt
@@ -14,7 +14,7 @@ import community.flock.wirespec.openapi.v3.OpenAPIV3Parser
 
 fun ConverterArguments.parseOptions() = ParseOptions(
     strict = strict,
-    allowUnions = true
+    allowUnions = true,
 )
 
 fun compile(arguments: CompilerArguments) {
@@ -40,11 +40,11 @@ fun convert(arguments: ConverterArguments) {
         .map { moduleContent -> parser.parse(moduleContent, arguments.strict) }
         .map { ast ->
             ast.copy(
-                modules = ast.modules.map {module ->
+                modules = ast.modules.map { module ->
                     module.copy(
-                        statements = validate(options)(module.statements).getOrElse { error("Invalid statements") }
+                        statements = validate(options)(module.statements).getOrElse { error("Invalid statements") },
                     )
-                }
+                },
             )
         }
         .flatMap { ast ->


### PR DESCRIPTION
Added validation of AST module statements using `Parser.validate` with strict parsing options. Ensures invalid statements are caught during compilation.

## Description
<!-- Provide a clear and concise description of the changes you've made -->

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
