### PR TITLE
Handle blank joinToString case in PythonEmitter emit logic

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/PythonEmitter.kt
@@ -290,7 +290,7 @@ open class PythonEmitter(
         endpoint.queries.joinToString(",\n") { it.emitDeserializedParams("request", "queries") }.orNull(),
         endpoint.headers.joinToString(",\n") { it.emitDeserializedParams("request", "headers") }.orNull(),
         content?.let { """${Spacer(3)}body = serialization.deserialize(request.body, ${it.reference.emitType()}),""" }
-    ).joinToString(",\n").let { if (it.isBlank()) "" else "(\n$it\n)" }
+    ).joinToString(",\n").let { if (it.isBlank()) "()" else "(\n$it\n)" }
 
     private fun IndexedValue<Endpoint.Segment.Param>.emitDeserialized() =
         """${Spacer(3)}${emit(value.identifier)} = serialization.deserialize(request.path[${index}], ${value.reference.emitType()})"""

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/CompileMinimalEndpointTest.kt
@@ -333,7 +333,7 @@ class CompileMinimalEndpointTest {
             |
             |    @staticmethod
             |    def from_raw_request(serialization: Wirespec.Deserializer, request: Wirespec.RawRequest) -> 'GetTodos.Request':
-            |      return GetTodos.Request
+            |      return GetTodos.Request()
             |
             |    @staticmethod
             |    def to_raw_response(serialization: Wirespec.Serializer, response: 'GetTodos.Response') -> Wirespec.RawResponse:


### PR DESCRIPTION
Changed `joinToString` handling in `PythonEmitter` to return `"()"` instead of an empty string when the result is blank.

## Description
<!-- Provide a clear and concise description of the changes you've made -->

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
