### PR TITLE
Update JavaEmitter and extend UserDto with authentication union type

### DIFF
--- a/examples/maven-spring-compile/src/main/java/community/flock/wirespec/example/maven/custom/app/user/User.java
+++ b/examples/maven-spring-compile/src/main/java/community/flock/wirespec/example/maven/custom/app/user/User.java
@@ -1,4 +1,4 @@
 package community.flock.wirespec.example.maven.custom.app.user;
 
-public record User(String name) {
+public record User(String name, String password) {
 }

--- a/examples/maven-spring-compile/src/main/java/community/flock/wirespec/example/maven/custom/app/user/UserConverter.java
+++ b/examples/maven-spring-compile/src/main/java/community/flock/wirespec/example/maven/custom/app/user/UserConverter.java
@@ -1,6 +1,8 @@
 package community.flock.wirespec.example.maven.custom.app.user;
 
 import community.flock.wirespec.example.maven.custom.app.common.Converter;
+import community.flock.wirespec.generated.java.model.AuthenticationPassword;
+import community.flock.wirespec.generated.java.model.AuthenticationToken;
 import community.flock.wirespec.generated.java.model.UserDto;
 import org.springframework.stereotype.Component;
 
@@ -8,11 +10,16 @@ import org.springframework.stereotype.Component;
 public class UserConverter implements Converter<User, UserDto> {
     @Override
     public User internalize(final UserDto userDto) {
-        return new User(userDto.name());
+        return switch (userDto.authentication()) {
+            case AuthenticationPassword password -> new User(userDto.name(), password.secret());
+            case AuthenticationToken token -> throw new UnsupportedOperationException("Token authentication not yet supported.");
+            case null -> throw new IllegalStateException("Authentication cannot be null");
+        };
     }
+
 
     @Override
     public UserDto externalize(final User user) {
-        return new UserDto(user.name());
+        return new UserDto(user.name(), new AuthenticationPassword(user.password()));
     }
 }

--- a/examples/maven-spring-compile/src/main/wirespec/users.ws
+++ b/examples/maven-spring-compile/src/main/wirespec/users.ws
@@ -1,5 +1,16 @@
 type UserDto {
-    name: String
+    name: String,
+    authentication: Authentication
+}
+
+type Authentication = AuthenticationPassword | AuthenticationToken
+
+type AuthenticationPassword {
+    secret: String
+}
+
+type AuthenticationToken {
+    token: String
 }
 
 endpoint GetUsers GET /api/users

--- a/examples/maven-spring-compile/src/test/java/community/flock/wirespec/example/maven/custom/app/user/TestUserClient.java
+++ b/examples/maven-spring-compile/src/test/java/community/flock/wirespec/example/maven/custom/app/user/TestUserClient.java
@@ -5,6 +5,7 @@ import community.flock.wirespec.generated.java.endpoint.GetUserByName;
 import community.flock.wirespec.generated.java.endpoint.GetUsers;
 import community.flock.wirespec.generated.java.endpoint.PostUser;
 import community.flock.wirespec.generated.java.endpoint.UploadImage;
+import community.flock.wirespec.generated.java.model.AuthenticationPassword;
 import community.flock.wirespec.generated.java.model.UserDto;
 
 import java.util.HashMap;
@@ -19,8 +20,8 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 public class TestUserClient implements UserClient {
 
     public static final Set<UserDto> users = new HashSet<>(Set.of(
-            new UserDto("name"),
-            new UserDto("other name")
+            new UserDto("name", new AuthenticationPassword("secret")),
+            new UserDto("other name", new AuthenticationPassword("secret"))
     ));
 
     public static final Map<String, byte[]> images = new HashMap<>();

--- a/examples/maven-spring-compile/src/test/java/community/flock/wirespec/example/maven/custom/app/user/UserTest.java
+++ b/examples/maven-spring-compile/src/test/java/community/flock/wirespec/example/maven/custom/app/user/UserTest.java
@@ -1,5 +1,6 @@
 package community.flock.wirespec.example.maven.custom.app.user;
 
+import community.flock.wirespec.generated.java.model.AuthenticationPassword;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
@@ -34,7 +35,7 @@ class UserTest {
     @Test
     void testPostUser() {
         testContext(it -> {
-            var user = saveUser(it, new User("newName"));
+            var user = saveUser(it, new User("newName","secret"));
             assertEquals("newName", user.name());
         });
     }
@@ -42,7 +43,7 @@ class UserTest {
     @Test
     void testDeleteUser() {
         testContext(it -> {
-            saveUser(it, new User("newName"));
+            saveUser(it, new User("newName", "secret"));
             var user = deleteUserByName(it, "newName");
             assertEquals("newName", user.name());
         });

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaEmitter.kt
@@ -77,7 +77,7 @@ open class JavaEmitter(
         .filter { union -> union.entries.filterIsInstance<Reference.Custom>().any { it.value == identifier.value } }
         .map { it.identifier.value }
         .takeIf { it.isNotEmpty() }
-        ?.joinToString(", ", "implements ")
+        ?.joinToString(", ", " implements ")
         .orEmpty()
 
     override fun Type.Shape.emit() = value.joinToString("\n") { "${Spacer}${it.emit()}," }.dropLast(1)

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaEmitter.kt
@@ -67,18 +67,10 @@ open class JavaEmitter(
     override fun emit(type: Type, module: Module) = """
         |public record ${emit(type.identifier)} (
         |${type.shape.emit()}
-        |)${type.extends.run { if (isEmpty()) "" else " extends ${joinToString(", ") { it.emit() }}" }}${type.emitUnion(module)} {
+        |)${type.extends.run { if (isEmpty()) "" else " implements ${joinToString(", ") { it.emit() }}" }} {
         |};
         |
     """.trimMargin()
-
-    fun Type.emitUnion(module: Module) = module.statements
-        .filterIsInstance<Union>()
-        .filter { union -> union.entries.filterIsInstance<Reference.Custom>().any { it.value == identifier.value } }
-        .map { it.identifier.value }
-        .takeIf { it.isNotEmpty() }
-        ?.joinToString(", ", " implements ")
-        .orEmpty()
 
     override fun Type.Shape.emit() = value.joinToString("\n") { "${Spacer}${it.emit()}," }.dropLast(1)
 

--- a/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaEmitterTest.kt
+++ b/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaEmitterTest.kt
@@ -499,14 +499,14 @@ class JavaEmitterTest {
             |public record UserAccountPassword (
             |  String username,
             |  String password
-            |) extends UserAccountimplements UserAccount {
+            |) implements UserAccount {
             |};
             |
             |package community.flock.wirespec.generated.model;
             |
             |public record UserAccountToken (
             |  String token
-            |) extends UserAccountimplements UserAccount {
+            |) implements UserAccount {
             |};
             |
             |package community.flock.wirespec.generated.model;

--- a/src/integration/avro/src/jvmMain/kotlin/community/flock/wirespec/integration/avro/java/emit/AvroEmitter.kt
+++ b/src/integration/avro/src/jvmMain/kotlin/community/flock/wirespec/integration/avro/java/emit/AvroEmitter.kt
@@ -24,7 +24,7 @@ class AvroEmitter(private val packageName: PackageName, emitShared: EmitShared) 
     override fun emit(type: Type, module: Module) = """
         |public record ${emit(type.identifier)} (
         |${type.shape.emit()}
-        |)${type.extends.run { if (isEmpty()) "" else " extends ${joinToString(", ") { it.emit() }}" }}${type.emitUnion(module)} {
+        |)${type.extends.run { if (isEmpty()) "" else " implements ${joinToString(", ") { it.emit() }}" }} {
         |${emitTypeFunctionBody(type, module)}
         |};
         |


### PR DESCRIPTION
Adjusted spacing in `JavaEmitter` for consistency and added `Authentication` with subtypes to the `UserDto` in the `users.ws` example.

## Description
<!-- Provide a clear and concise description of the changes you've made -->

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
