### PR TITLE
Refactor `emitServerTo` to support status-specific response handling …

### DIFF
--- a/examples/npm-typescript/src/server.test.ts
+++ b/examples/npm-typescript/src/server.test.ts
@@ -1,13 +1,11 @@
-import { GetTodoById} from "./gen/endpoint";
-import { GetTodos} from "./gen/endpoint";
-import { PostTodo } from "./gen/endpoint";
-import { Wirespec } from "./gen/Wirespec";
-import { expect, test } from "vitest";
-import { wirespecSerialization } from 'wirespec/serialization'
+import {GetTodoById, GetTodos, PostTodo} from "./gen/endpoint";
+import {Wirespec} from "./gen/Wirespec";
+import {expect, test} from "vitest";
+import {wirespecSerialization} from 'wirespec/serialization'
 
 const body = [
-    { id: "1", name: "Do it now", done: true },
-    { id: "2", name: "Do it tomorrow", done: false }
+    {id: "1", name: "Do it now", done: true},
+    {id: "2", name: "Do it tomorrow", done: false}
 ];
 
 type Api =
@@ -25,10 +23,10 @@ const api: Api = {
         }));
     },
     getTodos(_: GetTodos.Request): Promise<GetTodos.Response> {
-        return Promise.resolve(GetTodos.response200({ total: 2, body}));
+        return Promise.resolve(GetTodos.response200({total: 2, body}));
     },
     getTodoById(_: GetTodoById.Request): Promise<GetTodoById.Response> {
-        return Promise.resolve(GetTodoById.response200({ body: body[0] }));
+        return Promise.resolve(GetTodoById.response200({body: body[0]}));
     }
 };
 
@@ -43,7 +41,7 @@ test('testGetTodos', async () => {
     const request = server.from(rawRequest);
     const response = await api.getTodos(request);
     const rawResponse = server.to(response);
-    const expected = { status: 200, headers: {}, body: JSON.stringify(body) };
+    const expected = {status: 200, headers: {total: "2"}, body: JSON.stringify(body)};
     expect(rawResponse).toEqual(expected)
 });
 
@@ -59,7 +57,7 @@ test('testGetTodoById', async () => {
     const request = server.from(rawRequest);
     const response = await api.getTodoById(request);
     const rawResponse = server.to(response);
-    const expected = { status: 200, headers: {}, body: JSON.stringify(body[0]) };
+    const expected = {status: 200, headers: {}, body: JSON.stringify(body[0])};
     expect(rawResponse).toEqual(expected)
 });
 
@@ -69,12 +67,12 @@ test('testPostTodo', async () => {
         path: ["todos"],
         queries: {},
         headers: {},
-        body: JSON.stringify({ name: "Do it later", done: false })
+        body: JSON.stringify({name: "Do it later", done: false})
     };
     const server = PostTodo.server(wirespecSerialization);
     const request = server.from(rawRequest);
     const response = await api.postTodo(request);
     const rawResponse = server.to(response);
-    const expected = { status: 200, headers: {}, body: JSON.stringify({ id: "3", name: "Do it later", done: false }) };
+    const expected = {status: 200, headers: {}, body: JSON.stringify({id: "3", name: "Do it later", done: false})};
     expect(rawResponse).toEqual(expected)
 });

--- a/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEndpointDefinitionEmitter.kt
+++ b/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEndpointDefinitionEmitter.kt
@@ -114,8 +114,6 @@ interface TypeScriptEndpointDefinitionEmitter: EndpointDefinitionEmitter, TypeSc
         |to: (it) => {
         |${Spacer(1)}switch (it.status) {
         |${responses.distinctByStatus().joinToString("\n") { it.emitServerToResponse() }.prependIndent(Spacer(2))}
-        |${Spacer(2)}default:
-        |${Spacer(3)}throw new Error(`Cannot internalize response with status: ${'$'}{it.status}`);
         |${Spacer(1)}}
         |}
     """.trimMargin()

--- a/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEmitterTest.kt
+++ b/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEmitterTest.kt
@@ -284,6 +284,8 @@ class TypeScriptEmitterTest {
             |            headers: {},
             |            body: serialization.deserialize<TodoDto[]>(it.body)
             |          };
+            |        default:
+            |          throw new Error(`Cannot internalize response with status: ${'$'}{it.status}`);
             |      }
             |    }
             |  })
@@ -311,8 +313,6 @@ class TypeScriptEmitterTest {
             |            headers: {},
             |            body: serialization.serialize(it.body),
             |          };
-            |        default:
-            |          throw new Error(`Cannot internalize response with status: ${'$'}{it.status}`);
             |      }
             |    }
             |  })

--- a/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEmitterTest.kt
+++ b/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEmitterTest.kt
@@ -134,11 +134,30 @@ class TypeScriptEmitterTest {
             |        body: serialization.deserialize(it.body)
             |      }
             |    },
-            |    to: (it) => ({
-            |      status: it.status,
-            |      headers: {},
-            |      body: serialization.serialize(it.body),
-            |    })
+            |    to: (it) => {
+            |      switch (it.status) {
+            |        case 200:
+            |          return {
+            |            status: 200,
+            |            headers: {},
+            |            body: serialization.serialize(it.body),
+            |          };
+            |        case 201:
+            |          return {
+            |            status: 201,
+            |            headers: {"token": serialization.serialize(it.headers["token"]), "refreshToken": serialization.serialize(it.headers["refreshToken"])},
+            |            body: serialization.serialize(it.body),
+            |          };
+            |        case 500:
+            |          return {
+            |            status: 500,
+            |            headers: {},
+            |            body: serialization.serialize(it.body),
+            |          };
+            |        default:
+            |          throw new Error(`Cannot internalize response with status: ${'$'}{it.status}`);
+            |      }
+            |    }
             |  })
             |  export const api = {
             |    name: "putTodo",
@@ -288,11 +307,18 @@ class TypeScriptEmitterTest {
             |        body: serialization.deserialize(it.body)
             |      }
             |    },
-            |    to: (it) => ({
-            |      status: it.status,
-            |      headers: {},
-            |      body: serialization.serialize(it.body),
-            |    })
+            |    to: (it) => {
+            |      switch (it.status) {
+            |        case 200:
+            |          return {
+            |            status: 200,
+            |            headers: {},
+            |            body: serialization.serialize(it.body),
+            |          };
+            |        default:
+            |          throw new Error(`Cannot internalize response with status: ${'$'}{it.status}`);
+            |      }
+            |    }
             |  })
             |  export const api = {
             |    name: "getTodos",

--- a/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEmitterTest.kt
+++ b/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEmitterTest.kt
@@ -154,8 +154,6 @@ class TypeScriptEmitterTest {
             |            headers: {},
             |            body: serialization.serialize(it.body),
             |          };
-            |        default:
-            |          throw new Error(`Cannot internalize response with status: ${'$'}{it.status}`);
             |      }
             |    }
             |  })
@@ -286,8 +284,6 @@ class TypeScriptEmitterTest {
             |            headers: {},
             |            body: serialization.deserialize<TodoDto[]>(it.body)
             |          };
-            |        default:
-            |          throw new Error(`Cannot internalize response with status: ${'$'}{it.status}`);
             |      }
             |    }
             |  })


### PR DESCRIPTION
…and improve error handling for unmatched statuses.

## Description
<!-- Provide a clear and concise description of the changes you've made -->

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
