### PR TITLE
chore(naming): consistent renaming of wirespec dependency

### DIFF
--- a/examples/npm-typescript/package-lock.json
+++ b/examples/npm-typescript/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@flock/wirespec": "file://../../src/plugin/npm/build/dist/js/productionLibrary",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.2",
-        "vitest": "^3.2.4",
-        "wirespec": "file://../../src/plugin/npm/build/dist/js/productionLibrary"
+        "vitest": "^3.2.4"
       }
     },
     "../../src/plugin/npm/build/dist/js/productionLibrary": {
@@ -485,6 +485,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@flock/wirespec": {
+      "resolved": "../../src/plugin/npm/build/dist/js/productionLibrary",
+      "link": true
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -1724,10 +1728,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/wirespec": {
-      "resolved": "../../src/plugin/npm/build/dist/js/productionLibrary",
-      "link": true
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/examples/npm-typescript/package.json
+++ b/examples/npm-typescript/package.json
@@ -20,9 +20,9 @@
   "license": "Apache-2.0",
   "description": "",
   "devDependencies": {
+    "@flock/wirespec": "file://../../src/plugin/npm/build/dist/js/productionLibrary",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2",
-    "vitest": "^3.2.4",
-    "wirespec": "file://../../src/plugin/npm/build/dist/js/productionLibrary"
+    "vitest": "^3.2.4"
   }
 }

--- a/examples/npm-typescript/src/client.test.ts
+++ b/examples/npm-typescript/src/client.test.ts
@@ -1,7 +1,7 @@
-import { wirespecFetch, HandleFetch } from "wirespec/fetch";
-import { wirespecSerialization } from "wirespec/serialization";
-import {expect, test, vi} from "vitest";
-import {client} from "./gen/client";
+import { HandleFetch, wirespecFetch } from "@flock/wirespec/fetch";
+import { wirespecSerialization } from "@flock/wirespec/serialization";
+import { expect, test, vi } from "vitest";
+import { client } from "./gen/client";
 
 test("testGetTodoById", async () => {
   // @ts-ignore

--- a/examples/npm-typescript/src/clientProxy.test.ts
+++ b/examples/npm-typescript/src/clientProxy.test.ts
@@ -1,9 +1,9 @@
-import {GetTodoById, GetTodos, GetUsers, PostTodo} from "./gen/endpoint";
-import {Wirespec} from "./gen/Wirespec";
+import { wirespecSerialization } from "@flock/wirespec/serialization";
 import * as assert from "node:assert";
-import {expect, test} from "vitest";
+import { expect, test } from "vitest";
+import { Wirespec } from "./gen/Wirespec";
+import { GetTodoById, GetTodos, GetUsers, PostTodo } from "./gen/endpoint";
 
-import {wirespecSerialization} from 'wirespec/serialization'
 const body = [
   { id: "1", name: "Do it now", done: true },
   { id: "2", name: "Do it tomorrow", done: false },

--- a/examples/npm-typescript/src/clientSimple.test.ts
+++ b/examples/npm-typescript/src/clientSimple.test.ts
@@ -1,7 +1,7 @@
-import { GetTodoById, GetTodos, PostTodo } from "./gen/endpoint";
+import { wirespecSerialization } from "@flock/wirespec/serialization";
+import { expect, test } from "vitest";
 import { Wirespec } from "./gen/Wirespec";
-import { test, expect } from "vitest";
-import { wirespecSerialization } from 'wirespec/serialization'
+import { GetTodoById, GetTodos, PostTodo } from "./gen/endpoint";
 
 const body = [
   { id: "1", name: "Do it now", done: true },

--- a/examples/npm-typescript/src/fetch.test.ts
+++ b/examples/npm-typescript/src/fetch.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, vi } from 'vitest'
-import {Wirespec} from "./gen/Wirespec";
-import { wirespecFetch, HandleFetch } from "wirespec/fetch";
+import { HandleFetch, wirespecFetch } from "@flock/wirespec/fetch";
+import { expect, test, vi } from "vitest";
+import { Wirespec } from "./gen/Wirespec";
 
 // @ts-ignore
 const mockHandler = vi.fn<HandleFetch>(() =>

--- a/examples/npm-typescript/src/server.test.ts
+++ b/examples/npm-typescript/src/server.test.ts
@@ -1,7 +1,7 @@
-import {GetTodoById, GetTodos, PostTodo} from "./gen/endpoint";
-import {Wirespec} from "./gen/Wirespec";
-import {expect, test} from "vitest";
-import {wirespecSerialization} from 'wirespec/serialization'
+import { wirespecSerialization } from "@flock/wirespec/serialization";
+import { expect, test } from "vitest";
+import { Wirespec } from "./gen/Wirespec";
+import { GetTodoById, GetTodos, PostTodo } from "./gen/endpoint";
 
 const body = [
   { id: "1", name: "Do it now", done: true },


### PR DESCRIPTION
- wirespec npm package is named `@flock/wirespec` to prevent confusion renaming the example to be inline with the npm package name, so that c&p of the example code just works (TM).

## Description
<!-- Provide a clear and concise description of the changes you've made -->

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [x] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
