### PR TITLE
Chore/example npm install duplicate

### DIFF
--- a/examples/npm-typescript/package.json
+++ b/examples/npm-typescript/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "build": "npm install && npm run generate && npm run compile && npm test",
+    "build": "npm run generate && npm run compile && npm test",
     "clean": "npm run clean:node_modules && npm run clean:generated",
     "clean:wirespec": "npx --yes rimraf node_modules/.bin/wirespec",
     "clean:node_modules": "npx --yes rimraf ./node_modules",


### PR DESCRIPTION
## Description
chore: remove install from build run-script
    - the install is already triggered by the makefile build of the examples
    therefore this step is a duplicate and deemed unnecessary

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [x] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
