### PR TITLE
Remove non primitive type from union example

### DIFF
--- a/src/site/docs/docs/language/types.mdx
+++ b/src/site/docs/docs/language/types.mdx
@@ -181,10 +181,10 @@ type Result = Win | Loss
 
 type Win {
     points: Integer,
-    nextOpponent: User
+    nextOpponent: String
 }
 
 type Loss {
-   points: Integer,
+   points: Integer
 }
 ```


### PR DESCRIPTION
The `User` type is not defined in the example, by using a primitive instead of a custom type we get a minimal "self-contained" working example.

## Description
<!-- Provide a clear and concise description of the changes you've made -->

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [x] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [x] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
