### PR TITLE
Propagate headers to Spring ServerHttpResponse

### DIFF
--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/java/web/WirespecResponseBodyAdvice.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/java/web/WirespecResponseBodyAdvice.kt
@@ -37,6 +37,7 @@ class WirespecResponseBodyAdvice(
             is Wirespec.Response<*> -> {
                 val rawResponse = server.to(body)
                 response.setStatusCode(HttpStatusCode.valueOf(rawResponse.statusCode))
+                response.headers.putAll(rawResponse.headers)
                 rawResponse.body?.let { objectMapper.readTree(it) }
             }
             else -> body

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecResponseBodyAdvice.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecResponseBodyAdvice.kt
@@ -40,6 +40,7 @@ class WirespecResponseBodyAdvice(
             is Wirespec.Response<*> -> {
                 val rawResponse = server.to(body)
                 response.setStatusCode(HttpStatusCode.valueOf(rawResponse.statusCode))
+                response.headers.putAll(rawResponse.headers)
                 if (rawResponse.body == null) {
                     Unit
                 } else {

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/AddPet.java
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/java/generated/endpoint/AddPet.java
@@ -37,11 +37,13 @@ public interface AddPet extends Wirespec.Endpoint {
   sealed interface ResponsePet extends Response<Pet> {}
   sealed interface ResponseVoid extends Response<Void> {}
 
-  record Response200(Pet body) implements Response2XX<Pet>, ResponsePet {
+  record Response200(java.util.Optional<Integer> XRateLimit, Pet body) implements Response2XX<Pet>, ResponsePet {
     @Override public int getStatus() { return 200; }
-    @Override public Headers getHeaders() { return new Headers(); }
+    @Override public Headers getHeaders() { return new Headers(XRateLimit); }
     @Override public Pet getBody() { return body; }
-    class Headers implements Wirespec.Response.Headers {}
+    public record Headers(
+    java.util.Optional<Integer> XRateLimit
+  ) implements Wirespec.Response.Headers {}
   }
   record Response405() implements Response4XX<Void>, ResponseVoid {
     @Override public int getStatus() { return 405; }
@@ -69,7 +71,7 @@ public interface AddPet extends Wirespec.Endpoint {
     }
 
     static Wirespec.RawResponse toResponse(Wirespec.Serializer serialization, Response<?> response) {
-      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), serialization.serializeBody(r.body, Wirespec.getType(Pet.class, null))); }
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Map.ofEntries(java.util.Map.entry("X-Rate-Limit", serialization.serializeParam(r.getHeaders().XRateLimit(), Wirespec.getType(Integer.class, java.util.Optional.class)))), serialization.serializeBody(r.body, Wirespec.getType(Pet.class, null))); }
       if (response instanceof Response405 r) { return new Wirespec.RawResponse(r.getStatus(), java.util.Collections.emptyMap(), null); }
       else { throw new IllegalStateException("Cannot match response with status: " + response.getStatus());}
     }
@@ -77,6 +79,7 @@ public interface AddPet extends Wirespec.Endpoint {
     static Response<?> fromResponse(Wirespec.Deserializer serialization, Wirespec.RawResponse response) {
       switch (response.statusCode()) {
         case 200: return new Response200(
+        serialization.deserializeParam(response.headers().getOrDefault("X-Rate-Limit", java.util.Collections.emptyList()), Wirespec.getType(Integer.class, java.util.Optional.class)),
         serialization.deserializeBody(response.body(), Wirespec.getType(Pet.class, null))
       );
         case 405: return new Response405();

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/application/Controller.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/application/Controller.kt
@@ -18,7 +18,7 @@ class Controller(
 
     override suspend fun addPet(request: AddPet.Request): AddPet.Response<*> {
         service.create(request.body)
-        return AddPet.Response200(request.body)
+        return AddPet.Response200(request.body, 100)
     }
 
     override suspend fun getPetById(request: GetPetById.Request): GetPetById.Response<*> = service.list.find { it.id == request.path.petId }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/generated/endpoint/AddPet.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/generated/endpoint/AddPet.kt
@@ -43,10 +43,12 @@ object AddPet : Wirespec.Endpoint {
   sealed interface ResponsePet : Response<Pet>
   sealed interface ResponseUnit : Response<Unit>
 
-  data class Response200(override val body: Pet) : Response2XX<Pet>, ResponsePet {
+  data class Response200(override val body: Pet, val XRateLimit: Int?) : Response2XX<Pet>, ResponsePet {
     override val status = 200
-    override val headers = ResponseHeaders
-    data object ResponseHeaders : Wirespec.Response.Headers
+    override val headers = ResponseHeaders(XRateLimit)
+    data class ResponseHeaders(
+      val XRateLimit: Int?,
+    ) : Wirespec.Response.Headers
   }
 
   data class Response405(override val body: Unit) : Response4XX<Unit>, ResponseUnit {
@@ -59,7 +61,7 @@ object AddPet : Wirespec.Endpoint {
     when(response) {
       is Response200 -> Wirespec.RawResponse(
         statusCode = response.status,
-        headers = emptyMap(),
+        headers = (mapOf("X-Rate-Limit" to (response.headers.XRateLimit?.let{ serialization.serializeParam(it, typeOf<Int?>()) } ?: emptyList()))),
         body = serialization.serializeBody(response.body, typeOf<Pet>()),
       )
       is Response405 -> Wirespec.RawResponse(
@@ -73,6 +75,7 @@ object AddPet : Wirespec.Endpoint {
     when (response.statusCode) {
       200 -> Response200(
         body = serialization.deserializeBody(requireNotNull(response.body) { "body is null" }, typeOf<Pet>()),
+        XRateLimit = response.headers["X-Rate-Limit"]?.let{ serialization.deserializeParam(it, typeOf<Int?>()) }
       )
       405 -> Response405(
         body = Unit,

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/it/client/WebClientIntegrationTest.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/it/client/WebClientIntegrationTest.kt
@@ -33,7 +33,7 @@ class WebClientIntegrationTest {
             )
 
         val addPetResponse = wirespecPetstoreWebClient.addPet(AddPet.Request(pet))
-        assertEquals(AddPet.Response200(pet), addPetResponse)
+        assertEquals(AddPet.Response200(pet, 100), addPetResponse)
 
         val updatedPet = pet.copy(name = "Cat")
         val updatePetResponse = wirespecPetstoreWebClient.updatePet(UpdatePet.Request(updatedPet))

--- a/src/integration/spring/src/jvmTest/resources/petstore.json
+++ b/src/integration/spring/src/jvmTest/resources/petstore.json
@@ -127,6 +127,15 @@
         "responses": {
           "200": {
             "description": "Successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
             "content": {
               "application/xml": {
                 "schema": {


### PR DESCRIPTION
## Description
The `WirespecResponseBodyAdvice` in the Spring integration did not propagate headers to the `ServerHttpResponse`. This commit fixes that. 

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [x] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [x] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [x] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
