### PR TITLE
Align additional properties checks for v3 and v2 parsers

### DIFF
--- a/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3Parser.kt
+++ b/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3Parser.kt
@@ -487,7 +487,7 @@ private fun OpenAPIV3Model.flatten(schemaOrReference: OpenAPIV3SchemaOrReference
 
 private fun OpenAPIV3Model.toReference(reference: OpenAPIV3Reference, isNullable: Boolean): Reference = resolveOpenAPIV3Schema(reference).let { (referencingObject, schema) ->
     when {
-        schema.additionalProperties != null -> when (val additionalProperties = schema.additionalProperties!!) {
+        schema.additionalProperties.exists() -> when (val additionalProperties = schema.additionalProperties!!) {
             is BooleanValue -> Reference.Dict(
                 reference = Reference.Any(isNullable = isNullable),
                 isNullable = false,

--- a/src/converter/openapi/src/commonTest/resources/v3/oneof.json
+++ b/src/converter/openapi/src/commonTest/resources/v3/oneof.json
@@ -52,6 +52,7 @@
   "schemas": {
     "Foo": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "a": {
           "type": "string"


### PR DESCRIPTION
## Description
For the OAS V3 parser I experience problems when using `"additionalProperties": false,` in combination with `oneOf`. Upon investigation I saw there is a difference between the V2 and V3 parsers. V2 is using `.exists()` whilst V3 does `... != null`. 

Using the same approach in the V3 parsers seems to fix the issue.

The difference between the V2 and V3 checks where introduced in this PR: https://github.com/flock-community/wirespec/pull/568/files

However, it's hard for me to determine if this was done on purpose or not. Please check carefully. 🤓 

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
- [x] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [x] I have written tests for my changes
- [x] I have updated the documentation if necessary
- [x] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
None
