### PR TITLE
client interface emitter will now remove hyphens for function arguments

### DIFF
--- a/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaEmitterTest.kt
+++ b/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaEmitterTest.kt
@@ -148,7 +148,7 @@ class JavaEmitterTest {
             |
             |  public record RequestHeaders(
             |    Token token,
-            |    java.util.Optional<Token> refreshToken
+            |    java.util.Optional<Token> RefreshToken
             |  ) implements Wirespec.Request.Headers {}
             |
             |  class Request implements Wirespec.Request<PotentialTodoDto> {
@@ -157,11 +157,11 @@ class JavaEmitterTest {
             |    private final Queries queries;
             |    private final RequestHeaders headers;
             |    private final PotentialTodoDto body;
-            |    public Request(String id, Boolean done, java.util.Optional<String> name, Token token, java.util.Optional<Token> refreshToken, PotentialTodoDto body) {
+            |    public Request(String id, Boolean done, java.util.Optional<String> name, Token token, java.util.Optional<Token> RefreshToken, PotentialTodoDto body) {
             |      this.path = new Path(id);
             |      this.method = Wirespec.Method.PUT;
             |      this.queries = new Queries(done, name);
-            |      this.headers = new RequestHeaders(token, refreshToken);
+            |      this.headers = new RequestHeaders(token, RefreshToken);
             |      this.body = body;
             |    }
             |    @Override public Path getPath() { return path; }
@@ -206,7 +206,7 @@ class JavaEmitterTest {
             |        request.method.name(),
             |        java.util.List.of("todos", serialization.serializePath(request.path.id, Wirespec.getType(String.class, null))),
             |        java.util.Map.ofEntries(java.util.Map.entry("done", serialization.serializeParam(request.queries.done, Wirespec.getType(Boolean.class, null))), java.util.Map.entry("name", serialization.serializeParam(request.queries.name, Wirespec.getType(String.class, java.util.Optional.class)))),
-            |        java.util.Map.ofEntries(java.util.Map.entry("token", serialization.serializeParam(request.headers.token, Wirespec.getType(Token.class, null))), java.util.Map.entry("refreshToken", serialization.serializeParam(request.headers.refreshToken, Wirespec.getType(Token.class, java.util.Optional.class)))),
+            |        java.util.Map.ofEntries(java.util.Map.entry("token", serialization.serializeParam(request.headers.token, Wirespec.getType(Token.class, null))), java.util.Map.entry("Refresh-Token", serialization.serializeParam(request.headers.RefreshToken, Wirespec.getType(Token.class, java.util.Optional.class)))),
             |        serialization.serializeBody(request.getBody(), Wirespec.getType(PotentialTodoDto.class, null))
             |      );
             |    }
@@ -217,7 +217,7 @@ class JavaEmitterTest {
             |        serialization.deserializeParam(request.queries().getOrDefault("done", java.util.Collections.emptyList()), Wirespec.getType(Boolean.class, null)),
             |        serialization.deserializeParam(request.queries().getOrDefault("name", java.util.Collections.emptyList()), Wirespec.getType(String.class, java.util.Optional.class)),
             |        serialization.deserializeParam(request.headers().getOrDefault("token", java.util.Collections.emptyList()), Wirespec.getType(Token.class, null)),
-            |        serialization.deserializeParam(request.headers().getOrDefault("refreshToken", java.util.Collections.emptyList()), Wirespec.getType(Token.class, java.util.Optional.class)),
+            |        serialization.deserializeParam(request.headers().getOrDefault("Refresh-Token", java.util.Collections.emptyList()), Wirespec.getType(Token.class, java.util.Optional.class)),
             |        serialization.deserializeBody(request.body(), Wirespec.getType(PotentialTodoDto.class, null))
             |      );
             |    }

--- a/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEmitterTest.kt
+++ b/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEmitterTest.kt
@@ -172,19 +172,19 @@ class KotlinEmitterTest {
             |
             |  data class Headers(
             |    val token: Token,
-            |    val refreshToken: Token?,
+            |    val RefreshToken: Token?,
             |  ) : Wirespec.Request.Headers
             |
             |  class Request(
             |    id: String,
             |    done: Boolean,     name: String?,
-            |    token: Token,     refreshToken: Token?,
+            |    token: Token,     RefreshToken: Token?,
             |    override val body: PotentialTodoDto,
             |  ) : Wirespec.Request<PotentialTodoDto> {
             |    override val path = Path(id)
             |    override val method = Wirespec.Method.PUT
             |    override val queries = Queries(done, name)
-            |    override val headers = Headers(token, refreshToken)
+            |    override val headers = Headers(token, RefreshToken)
             |  }
             |
             |  fun toRequest(serialization: Wirespec.Serializer, request: Request): Wirespec.RawRequest =
@@ -192,7 +192,7 @@ class KotlinEmitterTest {
             |      path = listOf("todos", request.path.id.let{serialization.serializePath(it, typeOf<String>())}),
             |      method = request.method.name,
             |      queries = (mapOf("done" to (request.queries.done?.let{ serialization.serializeParam(it, typeOf<Boolean>()) } ?: emptyList()))) + (mapOf("name" to (request.queries.name?.let{ serialization.serializeParam(it, typeOf<String?>()) } ?: emptyList()))),
-            |      headers = (mapOf("token" to (request.headers.token?.let{ serialization.serializeParam(it, typeOf<Token>()) } ?: emptyList()))) + (mapOf("refreshToken" to (request.headers.refreshToken?.let{ serialization.serializeParam(it, typeOf<Token?>()) } ?: emptyList()))),
+            |      headers = (mapOf("token" to (request.headers.token?.let{ serialization.serializeParam(it, typeOf<Token>()) } ?: emptyList()))) + (mapOf("Refresh-Token" to (request.headers.RefreshToken?.let{ serialization.serializeParam(it, typeOf<Token?>()) } ?: emptyList()))),
             |      body = serialization.serializeBody(request.body, typeOf<PotentialTodoDto>()),
             |    )
             |
@@ -200,7 +200,7 @@ class KotlinEmitterTest {
             |    Request(
             |      id = serialization.deserializePath(request.path[1], typeOf<String>()),
             |      done = serialization.deserializeParam(requireNotNull(request.queries["done"]) { "done is null" }, typeOf<Boolean>()),       name = request.queries["name"]?.let{ serialization.deserializeParam(it, typeOf<String?>()) },
-            |      token = serialization.deserializeParam(requireNotNull(request.headers["token"]) { "token is null" }, typeOf<Token>()),       refreshToken = request.headers["refreshToken"]?.let{ serialization.deserializeParam(it, typeOf<Token?>()) },
+            |      token = serialization.deserializeParam(requireNotNull(request.headers["token"]) { "token is null" }, typeOf<Token>()),       RefreshToken = request.headers["Refresh-Token"]?.let{ serialization.deserializeParam(it, typeOf<Token?>()) },
             |      body = serialization.deserializeBody(requireNotNull(request.body) { "body is null" }, typeOf<PotentialTodoDto>()),
             |    )
             |

--- a/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonEmitterTest.kt
+++ b/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonEmitterTest.kt
@@ -98,7 +98,7 @@ class PythonEmitterTest {
         |    @dataclass
         |    class Headers (Wirespec.Request.Headers):
         |        token: 'Token'
-        |        refreshToken: 'Optional[Token]'
+        |        RefreshToken: 'Optional[Token]'
         |
         |    @property
         |    def body(self) -> PotentialTodoDto:
@@ -122,12 +122,12 @@ class PythonEmitterTest {
         |    _path: Path
         |    method: Wirespec.Method = Wirespec.Method.PUT
         |
-        |    def __init__(self, id: str, done: bool, name: Optional[str], token: Token, refreshToken: Optional[Token], body: PotentialTodoDto):
+        |    def __init__(self, id: str, done: bool, name: Optional[str], token: Token, RefreshToken: Optional[Token], body: PotentialTodoDto):
         |      self._path = PutTodo.Request.Path(id = id)
         |      self._queries =PutTodo.Request.Queries(  done = done,
         |        name = name)
         |      self._headers = PutTodo.Request.Headers(  token = token,
-        |        refreshToken = refreshToken)
+        |        RefreshToken = RefreshToken)
         |      self._body = body
         |
         |  @dataclass
@@ -211,7 +211,7 @@ class PythonEmitterTest {
         |        queries = {"done": serialization.serialize_param(request.queries.done, bool),
         |    "name": serialization.serialize_param(request.queries.name, str)},
         |        headers = {"token": serialization.serialize_param(request.headers.token, Token),
-        |    "refreshToken": serialization.serialize_param(request.headers.refreshToken, Token)},
+        |    "Refresh-Token": serialization.serialize_param(request.headers.RefreshToken, Token)},
         |        body = serialization.serialize(request.body, PotentialTodoDto),
         |      )
         |
@@ -222,7 +222,7 @@ class PythonEmitterTest {
         |    done = serialization.deserialize_param(request.queries.get("done".lower()), bool),
         |    name = serialization.deserialize_param(request.queries.get("name".lower()), str),
         |    token = serialization.deserialize_param(request.headers.get("token".lower()), Token),
-        |    refreshToken = serialization.deserialize_param(request.headers.get("refreshToken".lower()), Token),
+        |    RefreshToken = serialization.deserialize_param(request.headers.get("Refresh-Token".lower()), Token),
         |          body = serialization.deserialize(request.body, PotentialTodoDto),
         |    )
         |

--- a/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptClientEmitter.kt
+++ b/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptClientEmitter.kt
@@ -29,7 +29,7 @@ interface TypeScriptClientEmitter: ClientEmitter, TypeScriptTypeDefinitionEmitte
     private fun Endpoint.Request.emitClientInterface(endpoint: Endpoint) =
         paramList(endpoint)
             .takeIf { it.isNotEmpty() }
-            ?.joinToString(", ") { "${it.identifier.value.sanitizeSymbol()}: ${it.reference.emit()}" }
+            ?.joinToString(", ") { "${emit(it.identifier)}: ${it.reference.emit()}" }
             ?.let { "params: {${it}}" }
             .orEmpty()
     private fun emitFunction(endpoint: Endpoint, request: Endpoint.Request) = """

--- a/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptTypeDefinitionEmitter.kt
+++ b/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptTypeDefinitionEmitter.kt
@@ -14,7 +14,7 @@ interface TypeScriptTypeDefinitionEmitter: TypeDefinitionEmitter, TypeScriptIden
     fun Identifier.sanitizeSymbol() = value.sanitizeSymbol()
 
     fun String.sanitizeSymbol() = asSequence()
-        .filter { it.isLetterOrDigit() || it in listOf('_', '-') }
+        .filter { it.isLetterOrDigit() || it in listOf('_') }
         .joinToString("")
 
     override fun emit(type: Type, module: Module):String =

--- a/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEmitterTest.kt
+++ b/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptEmitterTest.kt
@@ -31,7 +31,7 @@ class TypeScriptEmitterTest {
             |  }
             |  type Headers = {
             |    "token": Token,
-            |    "refreshToken": Token | undefined,
+            |    "Refresh-Token": Token | undefined,
             |  }
             |  export type Request = {
             |    path: Path
@@ -56,12 +56,12 @@ class TypeScriptEmitterTest {
             |    body: Error
             |  }
             |  export type Response = Response200 | Response201 | Response500
-            |  export type RequestParams = {"id": string, "done": boolean, "name"?: string, "token": Token, "refreshToken"?: Token, "body": PotentialTodoDto}
+            |  export type RequestParams = {"id": string, "done": boolean, "name"?: string, "token": Token, "Refresh-Token"?: Token, "body": PotentialTodoDto}
             |  export const request = (params: RequestParams): Request => ({
             |    path: {"id": params["id"]},
             |    method: "PUT",
             |    queries: {"done": params["done"], "name": params["name"]},
-            |    headers: {"token": params["token"], "refreshToken": params["refreshToken"]},
+            |    headers: {"token": params["token"], "Refresh-Token": params["Refresh-Token"]},
             |    body: params.body,
             |  })
             |  export type Response200Params = {"body": TodoDto}
@@ -90,7 +90,7 @@ class TypeScriptEmitterTest {
             |      method: "PUT",
             |      path: ["todos", serialization.serialize(it.path["id"])],
             |      queries: {"done": serialization.serialize(it.queries["done"]), "name": serialization.serialize(it.queries["name"])},
-            |      headers: {"token": serialization.serialize(it.headers["token"]), "refreshToken": serialization.serialize(it.headers["refreshToken"])},
+            |      headers: {"token": serialization.serialize(it.headers["token"]), "Refresh-Token": serialization.serialize(it.headers["Refresh-Token"])},
             |      body: serialization.serialize(it.body)
             |    }),
             |    from: (it) => {
@@ -129,7 +129,7 @@ class TypeScriptEmitterTest {
             |          "done": serialization.deserialize(it.queries["done"]),      "name": serialization.deserialize(it.queries["name"])
             |        },
             |        headers: {
-            |          "token": serialization.deserialize(Object.entries(it.headers).find(([key]) => key.toLowerCase() === "token")?.[1]),      "refreshToken": serialization.deserialize(Object.entries(it.headers).find(([key]) => key.toLowerCase() === "refreshtoken")?.[1])
+            |          "token": serialization.deserialize(Object.entries(it.headers).find(([key]) => key.toLowerCase() === "token")?.[1]),      "Refresh-Token": serialization.deserialize(Object.entries(it.headers).find(([key]) => key.toLowerCase() === "refresh-token")?.[1])
             |        },
             |        body: serialization.deserialize(it.body)
             |      }
@@ -210,7 +210,7 @@ class TypeScriptEmitterTest {
             |type RawHandler = (req: Wirespec.RawRequest) => Promise<Wirespec.RawResponse>
             |
             |export const client = (serialization: Wirespec.Serialization, handler: RawHandler) => ({
-            |  PutTodo: async (params: {id: string, done: boolean, name: string | undefined, token: Token, refreshToken: Token | undefined, body: PotentialTodoDto}) => {
+            |  PutTodo: async (params: {"id": string, "done": boolean, "name": string | undefined, "token": Token, "Refresh-Token": Token | undefined, "body": PotentialTodoDto}) => {
             |    const req = PutTodo.request(params)
             |    const rawRequest = PutTodo.client(serialization).to(req)
             |    const rawResponse = await handler(rawRequest)

--- a/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
+++ b/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
@@ -15,7 +15,7 @@ class WirespecEmitterTest {
     @Test
     fun compileFullEndpointTest() {
         val wirespec = """
-            |endpoint PutTodo PUT PotentialTodoDto /todos/{id: String} ?{done: Boolean,name: String?} #{token: Token,refreshToken: Token?} -> {
+            |endpoint PutTodo PUT PotentialTodoDto /todos/{id: String} ?{done: Boolean,name: String?} #{token: Token,`Refresh-Token`: Token?} -> {
             |  200 -> TodoDto
             |  201 -> TodoDto #{token: Token,refreshToken: Token?}
             |  500 -> Error

--- a/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileFullEndpointTest.kt
+++ b/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileFullEndpointTest.kt
@@ -7,7 +7,7 @@ object CompileFullEndpointTest {
         """
         |endpoint PutTodo PUT PotentialTodoDto /todos/{id: String}
         |    ?{done: Boolean, name: String?}
-        |    #{token: Token, refreshToken: Token?} -> {
+        |    #{token: Token, `Refresh-Token`: Token?} -> {
         |    200 -> TodoDto
         |    201 -> TodoDto #{token: Token, refreshToken: Token?}
         |    500 -> Error


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes you've made -->
The typescript emitter did not correctly emit function arguments. If for example a header name with a hyphen in it is created by using backticks, this ends up in invalid typescript.

Previously:
``endpoint GetTodos GET /todos # {`Authorization`: String, `Content-Type` : String} -> {
    200 -> Todo # {`Location`: String}
}``

Created :
`  GetTodos: async (params: {Authorization: string, Content-Type: string) => {
    const req = GetTodos.request(params)
    const rawRequest = GetTodos.client(serialization).to(req)
    const rawResponse = await handler(rawRequest)
    return GetTodos.client(serialization).from(rawResponse)
  },`


Now it creates (note the removal of the hyphen character in ContentType):
`  GetTodos: async (params: {Authorization: string, ContentType: string) => {
    const req = GetTodos.request(params)
    const rawRequest = GetTodos.client(serialization).to(req)
    const rawResponse = await handler(rawRequest)
    return GetTodos.client(serialization).from(rawResponse)
  },`

## Type of Change
<!-- Please check the option that best describes your PR -->
- [ ] Feature
- [ X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
<!-- Please check all that apply -->
- [ ] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
<!-- List any breaking changes and migration steps if applicable -->
