### PR TITLE
Make validate() a member function on Refined types

### DIFF
--- a/examples/gradle-ktor/src/main/kotlin/community/flock/wirespec/example/maven/custom/app/todo/TodoHandler.kt
+++ b/examples/gradle-ktor/src/main/kotlin/community/flock/wirespec/example/maven/custom/app/todo/TodoHandler.kt
@@ -7,7 +7,6 @@ import community.flock.wirespec.generated.kotlin.endpoint.DeleteTodoById
 import community.flock.wirespec.generated.kotlin.endpoint.GetTodoById
 import community.flock.wirespec.generated.kotlin.endpoint.GetTodos
 import community.flock.wirespec.generated.kotlin.endpoint.PostTodo
-import community.flock.wirespec.generated.kotlin.model.validate
 
 private interface TodoApi :
     GetTodos.Handler,

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaRefinedTypeDefinitionEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaRefinedTypeDefinitionEmitter.kt
@@ -11,7 +11,7 @@ interface JavaRefinedTypeDefinitionEmitter: RefinedTypeDefinitionEmitter, JavaTy
         |public record ${emit(refined.identifier)} (${refined.reference.emit()} value) implements Wirespec.Refined<${refined.reference.emit()}> {
         |${Spacer}@Override
         |${Spacer}public String toString() { return value.toString(); }
-        |${Spacer}public static boolean validate(${emit(refined.identifier)} record) {
+        |${Spacer}public boolean validate() {
         |${Spacer}${Spacer}${refined.emitValidator()}
         |${Spacer}}
         |${Spacer}@Override

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaTypeDefinitionEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaTypeDefinitionEmitter.kt
@@ -61,10 +61,10 @@ interface JavaTypeDefinitionEmitter: TypeDefinitionEmitter, IdentifierEmitter {
     }
 
     override fun Reference.Primitive.Type.Constraint.emit() = when(this){
-        is Reference.Primitive.Type.Constraint.RegExp -> """return java.util.regex.Pattern.compile("${expression.replace("\\", "\\\\")}").matcher(record.value).find();"""
+        is Reference.Primitive.Type.Constraint.RegExp -> """return java.util.regex.Pattern.compile("${expression.replace("\\", "\\\\")}").matcher(value).find();"""
         is Reference.Primitive.Type.Constraint.Bound -> {
-            val minCheck = min?.let { "$it < record.value" }
-            val maxCheck = max?.let { "record.value < $it" }
+            val minCheck = min?.let { "$it < value" }
+            val maxCheck = max?.let { "value < $it" }
             val checks = listOfNotNull(minCheck, maxCheck).joinToString(" && ")
             """return ${if (checks.isEmpty()) "true" else checks};"""
         }

--- a/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaEmitterTest.kt
+++ b/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaEmitterTest.kt
@@ -77,8 +77,8 @@ class JavaEmitterTest {
             |public record UUID (String value) implements Wirespec.Refined<String> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(UUID record) {
-            |    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}${'$'}").matcher(record.value).find();
+            |  public boolean validate() {
+            |    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}${'$'}").matcher(value).find();
             |  }
             |  @Override
             |  public String value() { return value; }
@@ -485,8 +485,8 @@ class JavaEmitterTest {
             |public record TodoId (String value) implements Wirespec.Refined<String> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TodoId record) {
-            |    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").matcher(record.value).find();
+            |  public boolean validate() {
+            |    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").matcher(value).find();
             |  }
             |  @Override
             |  public String value() { return value; }
@@ -499,7 +499,7 @@ class JavaEmitterTest {
             |public record TodoNoRegex (String value) implements Wirespec.Refined<String> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TodoNoRegex record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -513,7 +513,7 @@ class JavaEmitterTest {
             |public record TestInt (Long value) implements Wirespec.Refined<Long> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestInt record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -527,7 +527,7 @@ class JavaEmitterTest {
             |public record TestInt0 (Long value) implements Wirespec.Refined<Long> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestInt0 record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -541,8 +541,8 @@ class JavaEmitterTest {
             |public record TestInt1 (Long value) implements Wirespec.Refined<Long> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestInt1 record) {
-            |    return 0 < record.value;
+            |  public boolean validate() {
+            |    return 0 < value;
             |  }
             |  @Override
             |  public Long value() { return value; }
@@ -555,8 +555,8 @@ class JavaEmitterTest {
             |public record TestInt2 (Long value) implements Wirespec.Refined<Long> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestInt2 record) {
-            |    return 1 < record.value && record.value < 3;
+            |  public boolean validate() {
+            |    return 1 < value && value < 3;
             |  }
             |  @Override
             |  public Long value() { return value; }
@@ -569,7 +569,7 @@ class JavaEmitterTest {
             |public record TestNum (Double value) implements Wirespec.Refined<Double> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestNum record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -583,7 +583,7 @@ class JavaEmitterTest {
             |public record TestNum0 (Double value) implements Wirespec.Refined<Double> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestNum0 record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -597,8 +597,8 @@ class JavaEmitterTest {
             |public record TestNum1 (Double value) implements Wirespec.Refined<Double> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestNum1 record) {
-            |    return record.value < 0.5;
+            |  public boolean validate() {
+            |    return value < 0.5;
             |  }
             |  @Override
             |  public Double value() { return value; }
@@ -611,8 +611,8 @@ class JavaEmitterTest {
             |public record TestNum2 (Double value) implements Wirespec.Refined<Double> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestNum2 record) {
-            |    return -0.2 < record.value && record.value < 0.5;
+            |  public boolean validate() {
+            |    return -0.2 < value && value < 0.5;
             |  }
             |  @Override
             |  public Double value() { return value; }
@@ -633,8 +633,8 @@ class JavaEmitterTest {
             |public record TodoId (String value) implements Wirespec.Refined<String> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TodoId record) {
-            |    return java.util.regex.Pattern.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}${'$'}").matcher(record.value).find();
+            |  public boolean validate() {
+            |    return java.util.regex.Pattern.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}${'$'}").matcher(value).find();
             |  }
             |  @Override
             |  public String value() { return value; }

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinRefinedTypeDefinitionEmitter.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinRefinedTypeDefinitionEmitter.kt
@@ -10,9 +10,8 @@ interface KotlinRefinedTypeDefinitionEmitter: RefinedTypeDefinitionEmitter, Kotl
     override fun emit(refined: Refined) = """
         |data class ${refined.identifier.sanitize()}(override val value: ${refined.reference.emit()}): Wirespec.Refined<${refined.reference.emit()}> {
         |${Spacer}override fun toString() = value.toString()
+        |${Spacer}override fun validate() = ${refined.emitValidator()}
         |}
-        |
-        |fun ${refined.identifier.value}.validate() = ${refined.emitValidator()}
         |
     """.trimMargin()
 

--- a/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEmitterTest.kt
+++ b/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEmitterTest.kt
@@ -72,9 +72,8 @@ class KotlinEmitterTest {
             |
             |data class UUID(override val value: String): Wirespec.Refined<String> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = Regex(${"\"\"\""}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}${'$'}${"\"\"\""}).matches(value)
             |}
-            |
-            |fun UUID.validate() = Regex(${"\"\"\""}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}${'$'}${"\"\"\""}).matches(value)
             |
             """.trimMargin(),
         )
@@ -481,9 +480,8 @@ class KotlinEmitterTest {
             |
             |data class TodoId(override val value: String): Wirespec.Refined<String> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = Regex(""${'"'}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""${'"'}).matches(value)
             |}
-            |
-            |fun TodoId.validate() = Regex(""${'"'}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""${'"'}).matches(value)
             |
             |package community.flock.wirespec.generated.model
             |
@@ -492,9 +490,8 @@ class KotlinEmitterTest {
             |
             |data class TodoNoRegex(override val value: String): Wirespec.Refined<String> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TodoNoRegex.validate() = true
             |
             |package community.flock.wirespec.generated.model
             |
@@ -503,9 +500,8 @@ class KotlinEmitterTest {
             |
             |data class TestInt(override val value: Long): Wirespec.Refined<Long> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TestInt.validate() = true
             |
             |package community.flock.wirespec.generated.model
             |
@@ -514,9 +510,8 @@ class KotlinEmitterTest {
             |
             |data class TestInt0(override val value: Long): Wirespec.Refined<Long> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TestInt0.validate() = true
             |
             |package community.flock.wirespec.generated.model
             |
@@ -525,9 +520,8 @@ class KotlinEmitterTest {
             |
             |data class TestInt1(override val value: Long): Wirespec.Refined<Long> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = 0 < value
             |}
-            |
-            |fun TestInt1.validate() = 0 < value
             |
             |package community.flock.wirespec.generated.model
             |
@@ -536,9 +530,8 @@ class KotlinEmitterTest {
             |
             |data class TestInt2(override val value: Long): Wirespec.Refined<Long> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = 1 < value && value < 3
             |}
-            |
-            |fun TestInt2.validate() = 1 < value && value < 3
             |
             |package community.flock.wirespec.generated.model
             |
@@ -547,9 +540,8 @@ class KotlinEmitterTest {
             |
             |data class TestNum(override val value: Double): Wirespec.Refined<Double> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TestNum.validate() = true
             |
             |package community.flock.wirespec.generated.model
             |
@@ -558,9 +550,8 @@ class KotlinEmitterTest {
             |
             |data class TestNum0(override val value: Double): Wirespec.Refined<Double> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TestNum0.validate() = true
             |
             |package community.flock.wirespec.generated.model
             |
@@ -569,9 +560,8 @@ class KotlinEmitterTest {
             |
             |data class TestNum1(override val value: Double): Wirespec.Refined<Double> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = value < 0.5
             |}
-            |
-            |fun TestNum1.validate() = value < 0.5
             |
             |package community.flock.wirespec.generated.model
             |
@@ -580,9 +570,8 @@ class KotlinEmitterTest {
             |
             |data class TestNum2(override val value: Double): Wirespec.Refined<Double> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = -0.2 < value && value < 0.5
             |}
-            |
-            |fun TestNum2.validate() = -0.2 < value && value < 0.5
             |
         """.trimMargin()
 
@@ -618,9 +607,8 @@ class KotlinEmitterTest {
             |
             |data class TodoId(override val value: String): Wirespec.Refined<String> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = Regex(""${'"'}^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}${'$'}""${'"'}).matches(value)
             |}
-            |
-            |fun TodoId.validate() = Regex(""${'"'}^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}${'$'}""${'"'}).matches(value)
             |
             |package community.flock.wirespec.generated.endpoint
             |

--- a/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
+++ b/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
@@ -1,10 +1,11 @@
 package community.flock.wirespec.emitters.wirespec
 
 import community.flock.wirespec.compiler.test.CompileChannelTest
-import community.flock.wirespec.compiler.test.CompileEndpointWithRefinedTypeTest
+import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFullEndpointTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
+import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
@@ -87,7 +88,7 @@ class WirespecEmitterTest {
     @Test
     fun compileRefinedTest() {
         val wirespec = """
-            |type TodoId = String(/^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/g)
+            |type TodoId = String(/^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}${'$'}/g)
             |
             |type TodoNoRegex = String
             |
@@ -110,24 +111,6 @@ class WirespecEmitterTest {
         """.trimMargin()
 
         CompileRefinedTest.compiler { WirespecEmitter() } shouldBeRight wirespec
-    }
-
-    @Test
-    fun compileEndpointWithRefinedTypeTest() {
-        val wirespec = """
-            |type TodoId = String(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}${'$'}/g)
-            |
-            |endpoint GetTodoById GET /todos/{id: TodoId} -> {
-            |  200 -> TodoDto
-            |}
-            |
-            |type TodoDto {
-            |  description: String
-            |}
-            |
-        """.trimMargin()
-
-        CompileEndpointWithRefinedTypeTest.compiler { WirespecEmitter() } shouldBeRight wirespec
     }
 
     @Test
@@ -169,5 +152,65 @@ class WirespecEmitterTest {
         """.trimMargin()
 
         CompileTypeTest.compiler { WirespecEmitter() } shouldBeRight wirespec
+    }
+
+    @Test
+    fun compileNestedTypeTest() {
+        val wirespec = """
+            |type DutchPostalCode = String(/^([0-9]{4}[A-Z]{2})${'$'}/g)
+            |
+            |type Address {
+            |  street: String,
+            |  houseNumber: Integer,
+            |  postalCode: DutchPostalCode
+            |}
+            |
+            |type Person {
+            |  name: String,
+            |  address: Address,
+            |  tags: String[]
+            |}
+            |
+        """.trimMargin()
+
+        CompileNestedTypeTest.compiler { WirespecEmitter() } shouldBeRight wirespec
+    }
+
+    @Test
+    fun compileComplexModelTest() {
+        val wirespec = """
+            |type Email = String(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}${'$'}/g)
+            |
+            |type PhoneNumber = String(/^\+[1-9]\d{1,14}${'$'}/g)
+            |
+            |type Tag = String(/^[a-z][a-z0-9-]{0,19}${'$'}/g)
+            |
+            |type EmployeeAge = Integer(18, 65)
+            |
+            |type ContactInfo {
+            |  email: Email,
+            |  phone: PhoneNumber?
+            |}
+            |
+            |type Employee {
+            |  name: String,
+            |  age: EmployeeAge,
+            |  contactInfo: ContactInfo,
+            |  tags: Tag[]
+            |}
+            |
+            |type Department {
+            |  name: String,
+            |  employees: Employee[]
+            |}
+            |
+            |type Company {
+            |  name: String,
+            |  departments: Department[]
+            |}
+            |
+        """.trimMargin()
+
+        CompileComplexModelTest.compiler { WirespecEmitter() } shouldBeRight wirespec
     }
 }

--- a/src/integration/avro/src/jvmTest/kotlin/community/flock/wirespec/integration/avro/java/emit/AvroJavaEmitterTest.kt
+++ b/src/integration/avro/src/jvmTest/kotlin/community/flock/wirespec/integration/avro/java/emit/AvroJavaEmitterTest.kt
@@ -616,8 +616,8 @@ class AvroJavaEmitterTest {
             |public record TodoId (String value) implements Wirespec.Refined<String> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TodoId record) {
-            |    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").matcher(record.value).find();
+            |  public boolean validate() {
+            |    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").matcher(value).find();
             |  }
             |  @Override
             |  public String value() { return value; }
@@ -630,7 +630,7 @@ class AvroJavaEmitterTest {
             |public record TodoNoRegex (String value) implements Wirespec.Refined<String> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TodoNoRegex record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -644,7 +644,7 @@ class AvroJavaEmitterTest {
             |public record TestInt (Long value) implements Wirespec.Refined<Long> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestInt record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -658,7 +658,7 @@ class AvroJavaEmitterTest {
             |public record TestInt0 (Long value) implements Wirespec.Refined<Long> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestInt0 record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -672,8 +672,8 @@ class AvroJavaEmitterTest {
             |public record TestInt1 (Long value) implements Wirespec.Refined<Long> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestInt1 record) {
-            |    return 0 < record.value;
+            |  public boolean validate() {
+            |    return 0 < value;
             |  }
             |  @Override
             |  public Long value() { return value; }
@@ -686,8 +686,8 @@ class AvroJavaEmitterTest {
             |public record TestInt2 (Long value) implements Wirespec.Refined<Long> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestInt2 record) {
-            |    return 1 < record.value && record.value < 3;
+            |  public boolean validate() {
+            |    return 1 < value && value < 3;
             |  }
             |  @Override
             |  public Long value() { return value; }
@@ -700,7 +700,7 @@ class AvroJavaEmitterTest {
             |public record TestNum (Double value) implements Wirespec.Refined<Double> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestNum record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -714,7 +714,7 @@ class AvroJavaEmitterTest {
             |public record TestNum0 (Double value) implements Wirespec.Refined<Double> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestNum0 record) {
+            |  public boolean validate() {
             |    return true;
             |  }
             |  @Override
@@ -728,8 +728,8 @@ class AvroJavaEmitterTest {
             |public record TestNum1 (Double value) implements Wirespec.Refined<Double> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestNum1 record) {
-            |    return record.value < 0.5;
+            |  public boolean validate() {
+            |    return value < 0.5;
             |  }
             |  @Override
             |  public Double value() { return value; }
@@ -742,8 +742,8 @@ class AvroJavaEmitterTest {
             |public record TestNum2 (Double value) implements Wirespec.Refined<Double> {
             |  @Override
             |  public String toString() { return value.toString(); }
-            |  public static boolean validate(TestNum2 record) {
-            |    return -0.2 < record.value && record.value < 0.5;
+            |  public boolean validate() {
+            |    return -0.2 < value && value < 0.5;
             |  }
             |  @Override
             |  public Double value() { return value; }

--- a/src/integration/avro/src/jvmTest/kotlin/community/flock/wirespec/integration/avro/kotlin/emit/AvroKotlinEmitterTest.kt
+++ b/src/integration/avro/src/jvmTest/kotlin/community/flock/wirespec/integration/avro/kotlin/emit/AvroKotlinEmitterTest.kt
@@ -640,9 +640,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TodoId(override val value: String): Wirespec.Refined<String> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = Regex(""${'"'}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""${'"'}).matches(value)
             |}
-            |
-            |fun TodoId.validate() = Regex(""${'"'}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""${'"'}).matches(value)
             |
             |package packageName.model
             |
@@ -651,9 +650,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TodoNoRegex(override val value: String): Wirespec.Refined<String> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TodoNoRegex.validate() = true
             |
             |package packageName.model
             |
@@ -662,9 +660,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TestInt(override val value: Long): Wirespec.Refined<Long> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TestInt.validate() = true
             |
             |package packageName.model
             |
@@ -673,9 +670,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TestInt0(override val value: Long): Wirespec.Refined<Long> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TestInt0.validate() = true
             |
             |package packageName.model
             |
@@ -684,9 +680,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TestInt1(override val value: Long): Wirespec.Refined<Long> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = 0 < value
             |}
-            |
-            |fun TestInt1.validate() = 0 < value
             |
             |package packageName.model
             |
@@ -695,9 +690,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TestInt2(override val value: Long): Wirespec.Refined<Long> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = 1 < value && value < 3
             |}
-            |
-            |fun TestInt2.validate() = 1 < value && value < 3
             |
             |package packageName.model
             |
@@ -706,9 +700,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TestNum(override val value: Double): Wirespec.Refined<Double> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TestNum.validate() = true
             |
             |package packageName.model
             |
@@ -717,9 +710,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TestNum0(override val value: Double): Wirespec.Refined<Double> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = true
             |}
-            |
-            |fun TestNum0.validate() = true
             |
             |package packageName.model
             |
@@ -728,9 +720,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TestNum1(override val value: Double): Wirespec.Refined<Double> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = value < 0.5
             |}
-            |
-            |fun TestNum1.validate() = value < 0.5
             |
             |package packageName.model
             |
@@ -739,9 +730,8 @@ class AvroKotlinEmitterTest {
             |
             |data class TestNum2(override val value: Double): Wirespec.Refined<Double> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = -0.2 < value && value < 0.5
             |}
-            |
-            |fun TestNum2.validate() = -0.2 < value && value < 0.5
             |
             """.trimMargin()
         result.shouldBeRight(expect)

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/IntRefinedLowerAndUpper.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/IntRefinedLowerAndUpper.java
@@ -5,8 +5,8 @@ import community.flock.wirespec.java.Wirespec;
 public record IntRefinedLowerAndUpper (Long value) implements Wirespec.Refined<Long> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(IntRefinedLowerAndUpper record) {
-    return 3 < record.value && record.value < 4;
+  public boolean validate() {
+    return 3 < value && value < 4;
   }
   @Override
   public Long value() { return value; }

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/IntRefinedLowerBound.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/IntRefinedLowerBound.java
@@ -5,8 +5,8 @@ import community.flock.wirespec.java.Wirespec;
 public record IntRefinedLowerBound (Long value) implements Wirespec.Refined<Long> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(IntRefinedLowerBound record) {
-    return -1 < record.value;
+  public boolean validate() {
+    return -1 < value;
   }
   @Override
   public Long value() { return value; }

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/IntRefinedNoBound.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/IntRefinedNoBound.java
@@ -5,7 +5,7 @@ import community.flock.wirespec.java.Wirespec;
 public record IntRefinedNoBound (Long value) implements Wirespec.Refined<Long> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(IntRefinedNoBound record) {
+  public boolean validate() {
     return true;
   }
   @Override

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/IntRefinedUpperBound.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/IntRefinedUpperBound.java
@@ -5,8 +5,8 @@ import community.flock.wirespec.java.Wirespec;
 public record IntRefinedUpperBound (Long value) implements Wirespec.Refined<Long> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(IntRefinedUpperBound record) {
-    return record.value < 2;
+  public boolean validate() {
+    return value < 2;
   }
   @Override
   public Long value() { return value; }

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/NumberRefinedLowerAndUpper.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/NumberRefinedLowerAndUpper.java
@@ -5,8 +5,8 @@ import community.flock.wirespec.java.Wirespec;
 public record NumberRefinedLowerAndUpper (Double value) implements Wirespec.Refined<Double> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(NumberRefinedLowerAndUpper record) {
-    return 3.0 < record.value && record.value < 4.0;
+  public boolean validate() {
+    return 3.0 < value && value < 4.0;
   }
   @Override
   public Double value() { return value; }

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/NumberRefinedLowerBound.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/NumberRefinedLowerBound.java
@@ -5,8 +5,8 @@ import community.flock.wirespec.java.Wirespec;
 public record NumberRefinedLowerBound (Double value) implements Wirespec.Refined<Double> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(NumberRefinedLowerBound record) {
-    return -1.0 < record.value;
+  public boolean validate() {
+    return -1.0 < value;
   }
   @Override
   public Double value() { return value; }

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/NumberRefinedNoBound.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/NumberRefinedNoBound.java
@@ -5,7 +5,7 @@ import community.flock.wirespec.java.Wirespec;
 public record NumberRefinedNoBound (Double value) implements Wirespec.Refined<Double> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(NumberRefinedNoBound record) {
+  public boolean validate() {
     return true;
   }
   @Override

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/NumberRefinedUpperBound.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/NumberRefinedUpperBound.java
@@ -5,8 +5,8 @@ import community.flock.wirespec.java.Wirespec;
 public record NumberRefinedUpperBound (Double value) implements Wirespec.Refined<Double> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(NumberRefinedUpperBound record) {
-    return record.value < 2.0;
+  public boolean validate() {
+    return value < 2.0;
   }
   @Override
   public Double value() { return value; }

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/StringRefined.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/StringRefined.java
@@ -5,7 +5,7 @@ import community.flock.wirespec.java.Wirespec;
 public record StringRefined (String value) implements Wirespec.Refined<String> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(StringRefined record) {
+  public boolean validate() {
     return true;
   }
   @Override

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/StringRefinedRegex.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/StringRefinedRegex.java
@@ -5,8 +5,8 @@ import community.flock.wirespec.java.Wirespec;
 public record StringRefinedRegex (String value) implements Wirespec.Refined<String> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(StringRefinedRegex record) {
-    return java.util.regex.Pattern.compile("^[0-9a-f]{8}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{12}$").matcher(record.value).find();
+  public boolean validate() {
+    return java.util.regex.Pattern.compile("^[0-9a-f]{8}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{12}$").matcher(value).find();
   }
   @Override
   public String value() { return value; }

--- a/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/TodoId.java
+++ b/src/integration/jackson/src/jvmTest/java/community/flock/wirespec/integration/jackson/java/generated/model/TodoId.java
@@ -5,8 +5,8 @@ import community.flock.wirespec.java.Wirespec;
 public record TodoId (String value) implements Wirespec.Refined<String> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(TodoId record) {
-    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").matcher(record.value).find();
+  public boolean validate() {
+    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").matcher(value).find();
   }
   @Override
   public String value() { return value; }

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/IntRefinedLowerAndUpper.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/IntRefinedLowerAndUpper.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class IntRefinedLowerAndUpper(override val value: Long): Wirespec.Refined<Long> {
   override fun toString() = value.toString()
+  override fun validate() = 3 < value && value < 4
 }
-
-fun IntRefinedLowerAndUpper.validate() = 3 < value && value < 4

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/IntRefinedLowerBound.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/IntRefinedLowerBound.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class IntRefinedLowerBound(override val value: Long): Wirespec.Refined<Long> {
   override fun toString() = value.toString()
+  override fun validate() = -1 < value
 }
-
-fun IntRefinedLowerBound.validate() = -1 < value

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/IntRefinedNoBound.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/IntRefinedNoBound.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class IntRefinedNoBound(override val value: Long): Wirespec.Refined<Long> {
   override fun toString() = value.toString()
+  override fun validate() = true
 }
-
-fun IntRefinedNoBound.validate() = true

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/IntRefinedUpperBound.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/IntRefinedUpperBound.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class IntRefinedUpperBound(override val value: Long): Wirespec.Refined<Long> {
   override fun toString() = value.toString()
+  override fun validate() = value < 2
 }
-
-fun IntRefinedUpperBound.validate() = value < 2

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/NumberRefinedLowerAndUpper.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/NumberRefinedLowerAndUpper.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class NumberRefinedLowerAndUpper(override val value: Double): Wirespec.Refined<Double> {
   override fun toString() = value.toString()
+  override fun validate() = 3.0 < value && value < 4.0
 }
-
-fun NumberRefinedLowerAndUpper.validate() = 3.0 < value && value < 4.0

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/NumberRefinedLowerBound.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/NumberRefinedLowerBound.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class NumberRefinedLowerBound(override val value: Double): Wirespec.Refined<Double> {
   override fun toString() = value.toString()
+  override fun validate() = -1.0 < value
 }
-
-fun NumberRefinedLowerBound.validate() = -1.0 < value

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/NumberRefinedNoBound.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/NumberRefinedNoBound.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class NumberRefinedNoBound(override val value: Double): Wirespec.Refined<Double> {
   override fun toString() = value.toString()
+  override fun validate() = true
 }
-
-fun NumberRefinedNoBound.validate() = true

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/NumberRefinedUpperBound.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/NumberRefinedUpperBound.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class NumberRefinedUpperBound(override val value: Double): Wirespec.Refined<Double> {
   override fun toString() = value.toString()
+  override fun validate() = value < 2.0
 }
-
-fun NumberRefinedUpperBound.validate() = value < 2.0

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/StringRefined.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/StringRefined.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class StringRefined(override val value: String): Wirespec.Refined<String> {
   override fun toString() = value.toString()
+  override fun validate() = true
 }
-
-fun StringRefined.validate() = true

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/StringRefinedRegex.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/StringRefinedRegex.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class StringRefinedRegex(override val value: String): Wirespec.Refined<String> {
   override fun toString() = value.toString()
+  override fun validate() = Regex("""^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$""").matches(value)
 }
-
-fun StringRefinedRegex.validate() = Regex("""^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$""").matches(value)

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/TodoId.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/kotlin/generated/model/TodoId.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class TodoId(override val value: String): Wirespec.Refined<String> {
   override fun toString() = value.toString()
+  override fun validate() = Regex("""^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""").matches(value)
 }
-
-fun TodoId.validate() = Regex("""^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""").matches(value)

--- a/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterTest.java
+++ b/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterTest.java
@@ -444,8 +444,8 @@ public class SpringJavaEmitterTest {
                         public record TodoId (String value) implements Wirespec.Refined<String> {
                           @Override
                           public String toString() { return value.toString(); }
-                          public static boolean validate(TodoId record) {
-                            return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\\\b-[0-9a-fA-F]{4}\\\\b-[0-9a-fA-F]{4}\\\\b-[0-9a-fA-F]{4}\\\\b-[0-9a-fA-F]{12}$").matcher(record.value).find();
+                          public boolean validate() {
+                            return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\\\b-[0-9a-fA-F]{4}\\\\b-[0-9a-fA-F]{4}\\\\b-[0-9a-fA-F]{4}\\\\b-[0-9a-fA-F]{12}$").matcher(value).find();
                           }
                           @Override
                           public String value() { return value; }

--- a/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/generated/model/TodoId.java
+++ b/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/generated/model/TodoId.java
@@ -5,8 +5,8 @@ import community.flock.wirespec.java.Wirespec;
 public record TodoId (String value) implements Wirespec.Refined<String> {
   @Override
   public String toString() { return value.toString(); }
-  public static boolean validate(TodoId record) {
-    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").matcher(record.value).find();
+  public boolean validate() {
+    return java.util.regex.Pattern.compile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$").matcher(value).find();
   }
   @Override
   public String value() { return value; }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitterTest.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitterTest.kt
@@ -40,9 +40,8 @@ class SpringKotlinEmitterTest {
             |
             |data class TodoId(override val value: String): Wirespec.Refined<String> {
             |  override fun toString() = value.toString()
+            |  override fun validate() = Regex(""${'"'}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""${'"'}).matches(value)
             |}
-            |
-            |fun TodoId.validate() = Regex(""${'"'}^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""${'"'}).matches(value)
             |
             |package community.flock.wirespec.spring.test.endpoint
             |

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/generated/model/TodoId.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/generated/model/TodoId.kt
@@ -5,6 +5,5 @@ import kotlin.reflect.typeOf
 
 data class TodoId(override val value: String): Wirespec.Refined<String> {
   override fun toString() = value.toString()
+  override fun validate() = Regex("""^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""").matches(value)
 }
-
-fun TodoId.validate() = Regex("""^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$""").matches(value)

--- a/src/integration/wirespec/src/jvmMain/kotlin/community/flock/wirespec/kotlin/Wirespec.kt
+++ b/src/integration/wirespec/src/jvmMain/kotlin/community/flock/wirespec/kotlin/Wirespec.kt
@@ -1,19 +1,96 @@
 package community.flock.wirespec.kotlin
-
 import kotlin.reflect.KType
-
 object Wirespec {
+    interface Model {
+        fun validate(): List<String>
+    }
     interface Enum {
         val label: String
     }
     interface Endpoint
+    interface Channel
     interface Refined<T : Any> {
         val value: T
+        fun validate(): Boolean
     }
     interface Path
     interface Queries
     interface Headers
     interface Handler
+    interface Call
+    enum class Method {
+        GET,
+        PUT,
+        POST,
+        DELETE,
+        OPTIONS,
+        HEAD,
+        PATCH,
+        TRACE,
+    } interface Request<T : Any> {
+        val path: Path
+        val method: Method
+        val queries: Queries
+        val headers: Headers
+        val body: T
+        interface Headers
+    }
+    interface Response<T : Any> {
+        val status: Int
+        val headers: Headers
+        val body: T
+        interface Headers
+    }
+    interface Serialization :
+        Serializer,
+        Deserializer
+    interface Serializer :
+        BodySerializer,
+        PathSerializer,
+        ParamSerializer
+    interface Deserializer :
+        BodyDeserializer,
+        PathDeserializer,
+        ParamDeserializer
+    interface BodySerialization :
+        BodySerializer,
+        BodyDeserializer
+    interface BodySerializer {
+        fun <T : Any> serializeBody(t: T, type: KType): ByteArray
+    }
+    interface BodyDeserializer {
+        fun <T : Any> deserializeBody(raw: ByteArray, type: KType): T
+    }
+    interface PathSerialization :
+        PathSerializer,
+        PathDeserializer
+    interface PathSerializer {
+        fun <T : Any> serializePath(t: T, type: KType): String
+    }
+    interface PathDeserializer {
+        fun <T : Any> deserializePath(raw: String, type: KType): T
+    }
+    interface ParamSerialization :
+        ParamSerializer,
+        ParamDeserializer
+    interface ParamSerializer {
+        fun <T : Any> serializeParam(value: T, type: KType): List<String>
+    }
+    interface ParamDeserializer {
+        fun <T : Any> deserializeParam(values: List<String>, type: KType): T
+    }
+    data class RawRequest(
+        val method: String,
+        val path: List<String>,
+        val queries: Map<String, List<String>>,
+        val headers: Map<String, List<String>>,
+        val body: ByteArray?,
+    )
+    data class RawResponse(
+        val statusCode: Int,
+        val headers: Map<String, List<String>>,
+        val body: ByteArray?,
+    )
     interface ServerEdge<Req : Request<*>, Res : Response<*>> {
         fun from(request: RawRequest): Req
         fun to(response: Res): RawResponse
@@ -32,59 +109,4 @@ object Wirespec {
         val method: String
         fun server(serialization: Serialization): ServerEdge<Req, Res>
     }
-    enum class Method { GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH, TRACE }
-    interface Request<T : Any> {
-        val path: Path
-        val method: Method
-        val queries: Queries
-        val headers: Headers
-        val body: T
-        interface Headers : Wirespec.Headers
-    }
-    interface Response<T : Any> {
-        val status: Int
-        val headers: Headers
-        val body: T
-        interface Headers : Wirespec.Headers
-    }
-    interface Serialization :
-        Serializer,
-        Deserializer
-    interface Serializer :
-        BodySerializer,
-        PathSerializer,
-        ParamSerializer
-    interface Deserializer :
-        BodyDeserializer,
-        PathDeserializer,
-        ParamDeserializer
-    interface BodySerialization :
-        BodySerializer,
-        BodyDeserializer
-    interface BodySerializer {
-        fun <T : Any> serializeBody(t: T, kType: KType): ByteArray
-    }
-    interface BodyDeserializer {
-        fun <T : Any> deserializeBody(raw: ByteArray, kType: KType): T
-    }
-    interface PathSerialization :
-        PathSerializer,
-        PathDeserializer
-    interface PathSerializer {
-        fun <T : Any> serializePath(t: T, kType: KType): String
-    }
-    interface PathDeserializer {
-        fun <T : Any> deserializePath(raw: String, kType: KType): T
-    }
-    interface ParamSerialization :
-        ParamSerializer,
-        ParamDeserializer
-    interface ParamSerializer {
-        fun <T : Any> serializeParam(value: T, kType: KType): List<String>
-    }
-    interface ParamDeserializer {
-        fun <T : Any> deserializeParam(values: List<String>, kType: KType): T
-    }
-    data class RawRequest(val method: String, val path: List<String>, val queries: Map<String, List<String>>, val headers: Map<String, List<String>>, val body: ByteArray?)
-    data class RawResponse(val statusCode: Int, val headers: Map<String, List<String>>, val body: ByteArray?)
 }

--- a/src/integration/wirespec/src/jvmTest/kotlin/community/flock/wirespec/kotlin/serde/DefaultPathSerializationTest.kt
+++ b/src/integration/wirespec/src/jvmTest/kotlin/community/flock/wirespec/kotlin/serde/DefaultPathSerializationTest.kt
@@ -95,9 +95,15 @@ class DefaultPathSerializationTest {
         }
     }
 
-    data class StringRefined(override val value: String) : Wirespec.Refined<String>
-    data class LongRefined(override val value: Long) : Wirespec.Refined<Long>
-    data class DoubleRefined(override val value: Double) : Wirespec.Refined<Double>
+    data class StringRefined(override val value: String) : Wirespec.Refined<String> {
+        override fun validate() = true
+    }
+    data class LongRefined(override val value: Long) : Wirespec.Refined<Long> {
+        override fun validate() = true
+    }
+    data class DoubleRefined(override val value: Double) : Wirespec.Refined<Double> {
+        override fun validate() = true
+    }
 
     enum class StatusEnum(override val label: String) : Wirespec.Enum {
         ACTIVE("active"),

--- a/src/site/docs/docs/integration/integration-jackson.mdx
+++ b/src/site/docs/docs/integration/integration-jackson.mdx
@@ -70,8 +70,8 @@ public record Name(String value) implements Wirespec.Refined {
         return value;
     }
 
-    public static boolean validate(Name record) {
-        return java.util.regex.Pattern.compile("^[0-9a-zA-Z]{1,50}$").matcher(record.value).find();
+    public boolean validate() {
+        return java.util.regex.Pattern.compile("^[0-9a-zA-Z]{1,50}$").matcher(value).find();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Change `validate` from a static/extension function to an instance member on refined types, aligning with the `Wirespec.Refined<T>` interface contract
- Java: `public static boolean validate(X record)` → `public boolean validate()`
- Kotlin: `fun X.validate()` extension → `override fun validate()` member
- Update `Wirespec.Refined` interface to include `fun validate(): Boolean`

## Test plan
- [x] All JVM tests pass (`./gradlew jvmTest` — BUILD SUCCESSFUL)
- [ ] Verify CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)