### PR TITLE
docs: add type composition example to getting started

### DIFF
--- a/src/site/docs/docs/getting-started/getting-started.mdx
+++ b/src/site/docs/docs/getting-started/getting-started.mdx
@@ -77,7 +77,17 @@ The following `todo.ws` file defines such a contract for the basic CRUD operatio
 ```wirespec title="todo.ws"
 type TodoDto {
     id: Integer?,
-    name: String
+    name: String,
+    assignee: UserDto?
+}
+
+type UserDto {
+    name: String,
+    role: Role
+}
+
+enum Role {
+    Admin, Editor, Viewer
 }
 
 endpoint GetTodos GET /api/todos -> {


### PR DESCRIPTION
## Summary
- Expands the getting started `todo.ws` example with a `UserDto` type and `Role` enum to demonstrate type composition
- The previous example only used primitive fields, which led users to believe custom type references weren't supported (see #612)
- The types.mdx page already documents this feature, but the getting started page (most newcomers' first stop) did not show it

Closes #612

## Test plan
- [ ] Verify the docs site builds: `cd src/site/docs && npm run build`
- [ ] Check the getting started page renders the expanded example correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)