### PR TITLE
Add binary (Bytes) response support to Spring integration

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/Utils.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/Utils.kt
@@ -16,11 +16,13 @@ fun String.addBackticks() = "`$this`"
 
 fun String.orNull() = ifBlank { null }
 
-fun String.concatGenerics() = removeJavaPrefix().removeAngularBrackets().removeCommasAndSpaces()
+fun String.concatGenerics() = removeJavaPrefix().removeAngularBrackets().removeArrayBrackets().removeCommasAndSpaces()
 
 fun String.removeJavaPrefix() = removePrefix("java.util.")
 
 fun String.removeAngularBrackets() = filterNot { it == '<' || it == '>' }
+
+fun String.removeArrayBrackets() = replace("[]", "")
 
 fun String.removeCommasAndSpaces() = filterNot { it == ',' || it == ' ' }
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/EndpointParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/EndpointParser.kt
@@ -50,7 +50,7 @@ object EndpointParser {
             Endpoint.Request(
                 content = it?.let {
                     Endpoint.Content(
-                        type = "application/json",
+                        type = it.inferContentType(),
                         reference = it,
                     )
                 },
@@ -176,7 +176,7 @@ object EndpointParser {
                 null
             } else {
                 Endpoint.Content(
-                    type = "application/json",
+                    type = reference.inferContentType(),
                     reference = reference,
                 )
             }
@@ -189,6 +189,11 @@ object EndpointParser {
             content = content,
             annotations = annotations,
         )
+    }
+
+    private fun Reference.inferContentType(): String = when {
+        this is Reference.Primitive && type == Reference.Primitive.Type.Bytes -> "application/octet-stream"
+        else -> "application/json"
     }
 
     private fun TokenProvider.parseHeaders() = either {

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseEndpointTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseEndpointTest.kt
@@ -233,6 +233,54 @@ class ParseEndpointTest {
     }
 
     @Test
+    fun testBytesResponseContentType() {
+        val source =
+            // language=ws
+            """
+            |endpoint DownloadFile GET /download -> {
+            |    200 -> Bytes
+            |}
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(1)
+            .first()
+            .shouldBeInstanceOf<Endpoint>()
+            .responses.shouldNotBeEmpty()
+            .shouldHaveSize(1)
+            .first()
+            .content.shouldNotBeNull().run {
+                type shouldBe "application/octet-stream"
+                reference.shouldBeInstanceOf<Reference.Primitive>().type shouldBe Reference.Primitive.Type.Bytes
+            }
+    }
+
+    @Test
+    fun testBytesRequestContentType() {
+        val source =
+            // language=ws
+            """
+            |endpoint UploadFile POST Bytes /upload -> {
+            |    200 -> Unit
+            |}
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(1)
+            .first()
+            .shouldBeInstanceOf<Endpoint>()
+            .requests.shouldNotBeEmpty()
+            .shouldHaveSize(1)
+            .first()
+            .content.shouldNotBeNull().run {
+                type shouldBe "application/octet-stream"
+                reference.shouldBeInstanceOf<Reference.Primitive>().type shouldBe Reference.Primitive.Type.Bytes
+            }
+    }
+
+    @Test
     fun testDictionaryResponse() {
         val source =
             // language=ws

--- a/src/integration/jackson/src/jvmMain/java/community/flock/wirespec/integration/jackson/java/WirespecSerialization.java
+++ b/src/integration/jackson/src/jvmMain/java/community/flock/wirespec/integration/jackson/java/WirespecSerialization.java
@@ -26,7 +26,9 @@ public class WirespecSerialization implements Serialization, DefaultParamSeriali
 
     @Override
     public <T> byte[] serializeBody(T body, Type type) {
-        if (body instanceof String) {
+        if (body instanceof byte[] bytes) {
+            return bytes;
+        } else if (body instanceof String) {
             return ((String) body).getBytes(StandardCharsets.UTF_8);
         } else {
             try {
@@ -44,9 +46,11 @@ public class WirespecSerialization implements Serialization, DefaultParamSeriali
             return null;
         }
 
-        if (valueType.equals(String.class)) {
-                return (T) new String(raw, StandardCharsets.UTF_8);
-            } else {
+        if (valueType.equals(byte[].class)) {
+            return (T) raw;
+        } else if (valueType.equals(String.class)) {
+            return (T) new String(raw, StandardCharsets.UTF_8);
+        } else {
             try {
                 JavaType type = wirespecObjectMapper.getTypeFactory().constructType(valueType);
                 return wirespecObjectMapper.readValue(raw, type);

--- a/src/integration/jackson/src/jvmMain/kotlin/community/flock/wirespec/integration/jackson/kotlin/WirespecSerialization.kt
+++ b/src/integration/jackson/src/jvmMain/kotlin/community/flock/wirespec/integration/jackson/kotlin/WirespecSerialization.kt
@@ -21,6 +21,7 @@ class WirespecSerialization(
     private val wirespecObjectMapper = objectMapper.copy().registerModule(WirespecModuleKotlin())
 
     override fun <T : Any> serializeBody(t: T, kType: KType): ByteArray = when (t) {
+        is ByteArray -> t
         is String -> t.toByteArray()
         else -> wirespecObjectMapper.writeValueAsBytes(t)
     }
@@ -28,6 +29,7 @@ class WirespecSerialization(
     @Suppress("UNCHECKED_CAST")
     @OptIn(ExperimentalStdlibApi::class)
     override fun <T : Any> deserializeBody(raw: ByteArray, kType: KType): T = when {
+        kType.classifier == ByteArray::class -> raw as T
         kType.classifier == String::class -> raw as T
         else ->
             wirespecObjectMapper

--- a/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitter.java
+++ b/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitter.java
@@ -55,8 +55,8 @@ public class SpringJavaEmitter extends SpringJavaEmitterHelper {
             case PUT -> "@org.springframework.web.bind.annotation.PutMapping(\"" + path + "\")";
             case DELETE -> "@org.springframework.web.bind.annotation.DeleteMapping(\"" + path + "\")";
             case OPTIONS -> "@org.springframework.web.bind.annotation.RequestMapping(value=\"" + path + "\", method = org.springframework.web.bind.annotation.RequestMethod.OPTIONS)";
-            case HEAD -> "@org.springframework.web.bind.annotation.RequestMapping(value=\"" + path + "\", method = org.springframework.web.bind.annotation.RequestMethod.HEAD)";
             case PATCH -> "@org.springframework.web.bind.annotation.RequestMapping(value=\"" + path + "\", method = org.springframework.web.bind.annotation.RequestMethod.PATCH)";
+            case HEAD -> "@org.springframework.web.bind.annotation.RequestMapping(value=\"" + path + "\", method = org.springframework.web.bind.annotation.RequestMethod.HEAD)";
             case TRACE -> "@org.springframework.web.bind.annotation.RequestMapping(value=\"" + path + "\", method = org.springframework.web.bind.annotation.RequestMethod.TRACE)";
         };
 

--- a/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/web/WirespecResponseBodyAdvice.java
+++ b/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/web/WirespecResponseBodyAdvice.java
@@ -58,10 +58,22 @@ public class WirespecResponseBodyAdvice implements ResponseBodyAdvice<Object> {
 
             if (body instanceof Wirespec.Response<?> wirespecResponse) {
                 Wirespec.RawResponse rawResponse = (Wirespec.RawResponse) toResponse.invoke(null, wirespecSerialization, wirespecResponse);
-                
+
                 response.setStatusCode(HttpStatusCode.valueOf(rawResponse.statusCode()));
                 for (Map.Entry<String, List<String>> entry : rawResponse.headers().entrySet()) {
                     response.getHeaders().put(entry.getKey(), entry.getValue());
+                }
+                if (wirespecResponse.body() instanceof byte[]) {
+                    response.getHeaders().set("Content-Type", MediaType.APPLICATION_OCTET_STREAM_VALUE);
+                    rawResponse.body().ifPresent(bytes -> {
+                        try {
+                            response.getBody().write(bytes);
+                            response.getBody().flush();
+                        } catch (Exception e) {
+                            throw new RuntimeException("Failed to write binary response body", e);
+                        }
+                    });
+                    return null;
                 }
                 return rawResponse.body().map(RawJsonBody::new).orElse(null);
             }

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitter.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitter.kt
@@ -16,6 +16,7 @@ import community.flock.wirespec.emitters.kotlin.KotlinEmitter
 class SpringKotlinEmitter(packageName: PackageName) : KotlinEmitter(packageName, EmitShared(false)) {
     override fun emitHandleFunction(endpoint: Endpoint): String {
         val path = "/${endpoint.path.joinToString("/") { it.emit() }}"
+
         val annotation = when (endpoint.method) {
             Endpoint.Method.GET -> "@org.springframework.web.bind.annotation.GetMapping(\"${path}\")"
             Endpoint.Method.POST -> "@org.springframework.web.bind.annotation.PostMapping(\"${path}\")"

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecResponseBodyAdvice.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecResponseBodyAdvice.kt
@@ -43,6 +43,11 @@ class WirespecResponseBodyAdvice(
                 response.headers.putAll(rawResponse.headers)
                 if (rawResponse.body == null) {
                     Unit
+                } else if (body.body is ByteArray) {
+                    response.headers.set("Content-Type", MediaType.APPLICATION_OCTET_STREAM_VALUE)
+                    response.body.write(rawResponse.body!!)
+                    response.body.flush()
+                    null
                 } else {
                     rawResponse.body?.let { RawJsonBody(it) }
                 }

--- a/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/application/Controller.java
+++ b/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/application/Controller.java
@@ -17,7 +17,8 @@ public class Controller implements
         DeletePet.Handler,
         FindPetsByTags.Handler,
         UploadFile.Handler,
-        RequestParrot.Handler {
+        RequestParrot.Handler,
+        DownloadReport.Handler {
 
     private final Service service;
 
@@ -87,6 +88,13 @@ public class Controller implements
                         request.queries().QueryParam(),
                         request.queries().RanDoMQueRY(),
                         request.body())
+        );
+    }
+
+    @Override
+    public CompletableFuture<DownloadReport.Response<?>> downloadReport(DownloadReport.Request request) {
+        return CompletableFuture.completedFuture(
+                new DownloadReport.Response200(new byte[]{0x50, 0x4B, 0x03, 0x04})
         );
     }
 }

--- a/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterTest.java
+++ b/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterTest.java
@@ -451,6 +451,99 @@ public class SpringJavaEmitterTest {
                           public String value() { return value; }
                         }
                         """, """
+                        package community.flock.wirespec.spring.test.endpoint;
+
+                        import community.flock.wirespec.java.Wirespec;
+
+
+
+                        public interface DownloadReport extends Wirespec.Endpoint {
+                          static class Path implements Wirespec.Path {}
+
+                          static class Queries implements Wirespec.Queries {}
+
+                          static class RequestHeaders implements Wirespec.Request.Headers {}
+
+                          record Request (
+                            Path path,
+                            Wirespec.Method method,
+                            Queries queries,
+                            RequestHeaders headers,
+                            Void body
+                          ) implements Wirespec.Request<Void> {
+                            public Request() {
+                              this(new Path(), Wirespec.Method.GET, new Queries(), new RequestHeaders(), null);
+                            }
+                          }
+
+                          sealed interface Response<T> extends Wirespec.Response<T> {}
+                          sealed interface Response2XX<T> extends Response<T> {}
+                          sealed interface Responsebyte extends Response<byte[]> {}
+
+                          record Response200(
+                            Integer status,
+                            Headers headers,
+                            byte[] body
+                          ) implements Response2XX<byte[]>, Responsebyte {
+                            public Response200(byte[] body) {
+                              this(200, new Headers(), body);
+                            }
+                            static class Headers implements Wirespec.Response.Headers {}
+                          }
+
+                          interface Handler extends Wirespec.Handler {
+
+                            static Wirespec.RawRequest toRequest(Wirespec.Serializer serialization, Request request) {
+                              return new Wirespec.RawRequest(
+                                request.method().name(),
+                                java.util.List.of("api", "report"),
+                                java.util.Collections.emptyMap(),
+                                java.util.Collections.emptyMap(),
+                                java.util.Optional.empty()
+                              );
+                            }
+
+                            static Request fromRequest(Wirespec.Deserializer serialization, Wirespec.RawRequest request) {
+                              return new Request();
+                            }
+
+                            static Wirespec.RawResponse toResponse(Wirespec.Serializer serialization, Response<?> response) {
+                              if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.status(), java.util.Collections.emptyMap(), java.util.Optional.ofNullable(serialization.serializeBody(r.body, Wirespec.getType(byte[].class, null)))); }
+                              else { throw new IllegalStateException("Cannot match response with status: " + response.status());}
+                            }
+
+                            static Response<?> fromResponse(Wirespec.Deserializer serialization, Wirespec.RawResponse response) {
+                              if (response.statusCode() == 200) {
+                                return new Response200(
+                                  response.body().<byte[]>map(body -> serialization.deserializeBody(body, Wirespec.getType(byte[].class, null))).orElse(null)
+                                );
+                              } else {
+                                throw new IllegalStateException("Cannot match response with status: " + response.statusCode());
+                              }
+                            }
+
+                            @org.springframework.web.bind.annotation.GetMapping("/api/report")
+                            java.util.concurrent.CompletableFuture<Response<?>> downloadReport(Request request);
+
+                            class Handlers implements Wirespec.Server<Request, Response<?>>, Wirespec.Client<Request, Response<?>> {
+                              @Override public String getPathTemplate() { return "/api/report"; }
+                              @Override public String getMethod() { return "GET"; }
+                              @Override public Wirespec.ServerEdge<Request, Response<?>> getServer(Wirespec.Serialization serialization) {
+                                return new Wirespec.ServerEdge<>() {
+                                  @Override public Request from(Wirespec.RawRequest request) { return fromRequest(serialization, request); }
+                                  @Override public Wirespec.RawResponse to(Response<?> response) { return toResponse(serialization, response); }
+                                };
+                              }
+                              @Override public Wirespec.ClientEdge<Request, Response<?>> getClient(Wirespec.Serialization serialization) {
+                                return new Wirespec.ClientEdge<>() {
+                                  @Override public Wirespec.RawRequest to(Request request) { return toRequest(serialization, request); }
+                                  @Override public Response<?> from(Wirespec.RawResponse response) { return fromResponse(serialization, response); }
+                                };
+                              }
+                            }
+                          }
+                        }
+                        """, """
                         package community.flock.wirespec.spring.test;
 
                         import community.flock.wirespec.spring.test.model.TodoId;
@@ -461,6 +554,7 @@ public class SpringJavaEmitterTest {
                         import community.flock.wirespec.spring.test.endpoint.RequestParrot;
                         import community.flock.wirespec.spring.test.endpoint.GetTodos;
                         import community.flock.wirespec.spring.test.endpoint.PatchTodos;
+                        import community.flock.wirespec.spring.test.endpoint.DownloadReport;
 
                         import org.springframework.aot.hint.MemberCategory;
                         import org.springframework.aot.hint.RuntimeHints;
@@ -484,6 +578,7 @@ public class SpringJavaEmitterTest {
                               registerWithInnerClasses(hints, RequestParrot.class, allMembers);
                               registerWithInnerClasses(hints, GetTodos.class, allMembers);
                               registerWithInnerClasses(hints, PatchTodos.class, allMembers);
+                              registerWithInnerClasses(hints, DownloadReport.class, allMembers);
                             }
 
                             private static void registerWithInnerClasses(RuntimeHints hints, Class<?> clazz, MemberCategory[] categories) {

--- a/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/generated/WirespecNativeHints.java
+++ b/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/generated/WirespecNativeHints.java
@@ -8,6 +8,7 @@ import community.flock.wirespec.integration.spring.java.generated.model.Error;
 import community.flock.wirespec.integration.spring.java.generated.endpoint.RequestParrot;
 import community.flock.wirespec.integration.spring.java.generated.endpoint.GetTodos;
 import community.flock.wirespec.integration.spring.java.generated.endpoint.PatchTodos;
+import community.flock.wirespec.integration.spring.java.generated.endpoint.DownloadReport;
 
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
@@ -31,6 +32,7 @@ public class WirespecNativeHints {
       registerWithInnerClasses(hints, RequestParrot.class, allMembers);
       registerWithInnerClasses(hints, GetTodos.class, allMembers);
       registerWithInnerClasses(hints, PatchTodos.class, allMembers);
+      registerWithInnerClasses(hints, DownloadReport.class, allMembers);
     }
 
     private static void registerWithInnerClasses(RuntimeHints hints, Class<?> clazz, MemberCategory[] categories) {

--- a/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/generated/endpoint/DownloadReport.java
+++ b/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/generated/endpoint/DownloadReport.java
@@ -1,0 +1,92 @@
+package community.flock.wirespec.integration.spring.java.generated.endpoint;
+
+import community.flock.wirespec.java.Wirespec;
+
+
+
+public interface DownloadReport extends Wirespec.Endpoint {
+  static class Path implements Wirespec.Path {}
+
+  static class Queries implements Wirespec.Queries {}
+
+  static class RequestHeaders implements Wirespec.Request.Headers {}
+
+  record Request (
+    Path path,
+    Wirespec.Method method,
+    Queries queries,
+    RequestHeaders headers,
+    Void body
+  ) implements Wirespec.Request<Void> {
+    public Request() {
+      this(new Path(), Wirespec.Method.GET, new Queries(), new RequestHeaders(), null);
+    }
+  }
+
+  sealed interface Response<T> extends Wirespec.Response<T> {}
+  sealed interface Response2XX<T> extends Response<T> {}
+  sealed interface Responsebyte extends Response<byte[]> {}
+
+  record Response200(
+    Integer status,
+    Headers headers,
+    byte[] body
+  ) implements Response2XX<byte[]>, Responsebyte {
+    public Response200(byte[] body) {
+      this(200, new Headers(), body);
+    }
+    static class Headers implements Wirespec.Response.Headers {}
+  }
+
+  interface Handler extends Wirespec.Handler {
+
+    static Wirespec.RawRequest toRequest(Wirespec.Serializer serialization, Request request) {
+      return new Wirespec.RawRequest(
+        request.method().name(),
+        java.util.List.of("api", "report"),
+        java.util.Collections.emptyMap(),
+        java.util.Collections.emptyMap(),
+        java.util.Optional.empty()
+      );
+    }
+
+    static Request fromRequest(Wirespec.Deserializer serialization, Wirespec.RawRequest request) {
+      return new Request();
+    }
+
+    static Wirespec.RawResponse toResponse(Wirespec.Serializer serialization, Response<?> response) {
+      if (response instanceof Response200 r) { return new Wirespec.RawResponse(r.status(), java.util.Collections.emptyMap(), java.util.Optional.ofNullable(serialization.serializeBody(r.body, Wirespec.getType(byte[].class, null)))); }
+      else { throw new IllegalStateException("Cannot match response with status: " + response.status());}
+    }
+
+    static Response<?> fromResponse(Wirespec.Deserializer serialization, Wirespec.RawResponse response) {
+      if (response.statusCode() == 200) {
+        return new Response200(
+          response.body().<byte[]>map(body -> serialization.deserializeBody(body, Wirespec.getType(byte[].class, null))).orElse(null)
+        );
+      } else {
+        throw new IllegalStateException("Cannot match response with status: " + response.statusCode());
+      }
+    }
+
+    @org.springframework.web.bind.annotation.GetMapping("/api/report")
+    java.util.concurrent.CompletableFuture<Response<?>> downloadReport(Request request);
+
+    class Handlers implements Wirespec.Server<Request, Response<?>>, Wirespec.Client<Request, Response<?>> {
+      @Override public String getPathTemplate() { return "/api/report"; }
+      @Override public String getMethod() { return "GET"; }
+      @Override public Wirespec.ServerEdge<Request, Response<?>> getServer(Wirespec.Serialization serialization) {
+        return new Wirespec.ServerEdge<>() {
+          @Override public Request from(Wirespec.RawRequest request) { return fromRequest(serialization, request); }
+          @Override public Wirespec.RawResponse to(Response<?> response) { return toResponse(serialization, response); }
+        };
+      }
+      @Override public Wirespec.ClientEdge<Request, Response<?>> getClient(Wirespec.Serialization serialization) {
+        return new Wirespec.ClientEdge<>() {
+          @Override public Wirespec.RawRequest to(Request request) { return toRequest(serialization, request); }
+          @Override public Response<?> from(Wirespec.RawResponse response) { return fromResponse(serialization, response); }
+        };
+      }
+    }
+  }
+}

--- a/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/it/controller/RestControllerIntegrationTest.java
+++ b/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/it/controller/RestControllerIntegrationTest.java
@@ -118,6 +118,18 @@ public class RestControllerIntegrationTest {
         assertArrayEquals(service.getFiles().get(0), file.getBytes());
     }
 
+    @Test
+    public void binaryResponseDownload() throws Exception {
+        byte[] expected = new byte[]{0x50, 0x4B, 0x03, 0x04};
+        byte[] actual = asyncDispatch(mockMvc
+            .perform(get("/api/report")))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsByteArray();
+        assertArrayEquals(expected, actual);
+    }
+
     private ResultActions asyncDispatch(ResultActions resultActions) throws Exception {
         if (resultActions.andReturn().getRequest().isAsyncStarted()) {
             return mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(resultActions.andReturn()));

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/application/Controller.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/application/Controller.kt
@@ -2,6 +2,7 @@ package community.flock.wirespec.integration.spring.kotlin.application
 
 import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.AddPet
 import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.DeletePet
+import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.DownloadReport
 import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.FindPetsByTags
 import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.GetPetById
 import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.RequestParrot
@@ -19,7 +20,8 @@ class Controller(
     DeletePet.Handler,
     FindPetsByTags.Handler,
     UploadFile.Handler,
-    RequestParrot.Handler {
+    RequestParrot.Handler,
+    DownloadReport.Handler {
 
     override suspend fun addPet(request: AddPet.Request): AddPet.Response<*> {
         service.create(request.body)
@@ -63,4 +65,7 @@ class Controller(
         QueryParamParrot = request.queries.QueryParam,
         RanDoMQueRYParrot = request.queries.RanDoMQueRY,
     )
+
+    override suspend fun downloadReport(request: DownloadReport.Request): DownloadReport.Response<*> =
+        DownloadReport.Response200(byteArrayOf(0x50, 0x4B, 0x03, 0x04))
 }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/application/Controller.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/application/Controller.kt
@@ -66,6 +66,5 @@ class Controller(
         RanDoMQueRYParrot = request.queries.RanDoMQueRY,
     )
 
-    override suspend fun downloadReport(request: DownloadReport.Request): DownloadReport.Response<*> =
-        DownloadReport.Response200(byteArrayOf(0x50, 0x4B, 0x03, 0x04))
+    override suspend fun downloadReport(request: DownloadReport.Request): DownloadReport.Response<*> = DownloadReport.Response200(byteArrayOf(0x50, 0x4B, 0x03, 0x04))
 }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitterTest.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitterTest.kt
@@ -478,6 +478,88 @@ class SpringKotlinEmitterTest {
             |  }
             |}
             |
+            |package community.flock.wirespec.spring.test.endpoint
+            |
+            |import community.flock.wirespec.kotlin.Wirespec
+            |import kotlin.reflect.typeOf
+            |
+            |
+            |
+            |object DownloadReport : Wirespec.Endpoint {
+            |  data object Path : Wirespec.Path
+            |
+            |  data object Queries : Wirespec.Queries
+            |
+            |  data object Headers : Wirespec.Request.Headers
+            |
+            |  object Request : Wirespec.Request<Unit> {
+            |    override val path = Path
+            |    override val method = Wirespec.Method.GET
+            |    override val queries = Queries
+            |    override val headers = Headers
+            |    override val body = Unit
+            |  }
+            |
+            |  fun toRequest(serialization: Wirespec.Serializer, request: Request): Wirespec.RawRequest =
+            |    Wirespec.RawRequest(
+            |      path = listOf("api", "report"),
+            |      method = request.method.name,
+            |      queries = emptyMap(),
+            |      headers = emptyMap(),
+            |      body = null,
+            |    )
+            |
+            |  fun fromRequest(serialization: Wirespec.Deserializer, request: Wirespec.RawRequest): Request =
+            |    Request
+            |
+            |  sealed interface Response<T: Any> : Wirespec.Response<T>
+            |
+            |  sealed interface Response2XX<T: Any> : Response<T>
+            |
+            |  sealed interface ResponseByteArray : Response<ByteArray>
+            |
+            |  data class Response200(override val body: ByteArray) : Response2XX<ByteArray>, ResponseByteArray {
+            |    override val status = 200
+            |    override val headers = ResponseHeaders
+            |    data object ResponseHeaders : Wirespec.Response.Headers
+            |  }
+            |
+            |  fun toResponse(serialization: Wirespec.Serializer, response: Response<*>): Wirespec.RawResponse =
+            |    when(response) {
+            |      is Response200 -> Wirespec.RawResponse(
+            |        statusCode = response.status,
+            |        headers = emptyMap(),
+            |        body = serialization.serializeBody(response.body, typeOf<ByteArray>()),
+            |      )
+            |    }
+            |
+            |  fun fromResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Response<*> =
+            |    when (response.statusCode) {
+            |      200 -> Response200(
+            |        body = serialization.deserializeBody(requireNotNull(response.body) { "body is null" }, typeOf<ByteArray>()),
+            |      )
+            |      else -> error("Cannot match response with status: ${'$'}{response.statusCode}")
+            |    }
+            |
+            |  interface Handler: Wirespec.Handler {
+            |    @org.springframework.web.bind.annotation.GetMapping("/api/report")
+            |    suspend fun downloadReport(request: Request): Response<*>
+            |
+            |    companion object: Wirespec.Server<Request, Response<*>>, Wirespec.Client<Request, Response<*>> {
+            |      override val pathTemplate = "/api/report"
+            |      override val method = "GET"
+            |      override fun server(serialization: Wirespec.Serialization) = object : Wirespec.ServerEdge<Request, Response<*>> {
+            |        override fun from(request: Wirespec.RawRequest) = fromRequest(serialization, request)
+            |        override fun to(response: Response<*>) = toResponse(serialization, response)
+            |      }
+            |      override fun client(serialization: Wirespec.Serialization) = object : Wirespec.ClientEdge<Request, Response<*>> {
+            |        override fun to(request: Request) = toRequest(serialization, request)
+            |        override fun from(response: Wirespec.RawResponse) = fromResponse(serialization, response)
+            |      }
+            |    }
+            |  }
+            |}
+            |
             |package community.flock.wirespec.spring.test
             |
             |import community.flock.wirespec.spring.test.model.TodoId
@@ -488,6 +570,7 @@ class SpringKotlinEmitterTest {
             |import community.flock.wirespec.spring.test.endpoint.RequestParrot
             |import community.flock.wirespec.spring.test.endpoint.GetTodos
             |import community.flock.wirespec.spring.test.endpoint.PatchTodos
+            |import community.flock.wirespec.spring.test.endpoint.DownloadReport
             |
             |import org.springframework.aot.hint.MemberCategory
             |import org.springframework.aot.hint.RuntimeHints
@@ -510,6 +593,7 @@ class SpringKotlinEmitterTest {
             |      registerWithInnerClasses(hints, RequestParrot::class.java, allMembers)
             |      registerWithInnerClasses(hints, GetTodos::class.java, allMembers)
             |      registerWithInnerClasses(hints, PatchTodos::class.java, allMembers)
+            |      registerWithInnerClasses(hints, DownloadReport::class.java, allMembers)
             |    }
             |
             |    private fun registerWithInnerClasses(hints: RuntimeHints, clazz: Class<*>, categories: Array<MemberCategory>) {

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/generated/WirespecNativeHints.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/generated/WirespecNativeHints.kt
@@ -8,6 +8,7 @@ import community.flock.wirespec.integration.spring.kotlin.generated.model.Error
 import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.RequestParrot
 import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.GetTodos
 import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.PatchTodos
+import community.flock.wirespec.integration.spring.kotlin.generated.endpoint.DownloadReport
 
 import org.springframework.aot.hint.MemberCategory
 import org.springframework.aot.hint.RuntimeHints
@@ -30,6 +31,7 @@ open class WirespecNativeHints {
       registerWithInnerClasses(hints, RequestParrot::class.java, allMembers)
       registerWithInnerClasses(hints, GetTodos::class.java, allMembers)
       registerWithInnerClasses(hints, PatchTodos::class.java, allMembers)
+      registerWithInnerClasses(hints, DownloadReport::class.java, allMembers)
     }
 
     private fun registerWithInnerClasses(hints: RuntimeHints, clazz: Class<*>, categories: Array<MemberCategory>) {

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/generated/endpoint/DownloadReport.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/generated/endpoint/DownloadReport.kt
@@ -1,0 +1,81 @@
+package community.flock.wirespec.integration.spring.kotlin.generated.endpoint
+
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+
+
+
+object DownloadReport : Wirespec.Endpoint {
+  data object Path : Wirespec.Path
+
+  data object Queries : Wirespec.Queries
+
+  data object Headers : Wirespec.Request.Headers
+
+  object Request : Wirespec.Request<Unit> {
+    override val path = Path
+    override val method = Wirespec.Method.GET
+    override val queries = Queries
+    override val headers = Headers
+    override val body = Unit
+  }
+
+  fun toRequest(serialization: Wirespec.Serializer, request: Request): Wirespec.RawRequest =
+    Wirespec.RawRequest(
+      path = listOf("api", "report"),
+      method = request.method.name,
+      queries = emptyMap(),
+      headers = emptyMap(),
+      body = null,
+    )
+
+  fun fromRequest(serialization: Wirespec.Deserializer, request: Wirespec.RawRequest): Request =
+    Request
+
+  sealed interface Response<T: Any> : Wirespec.Response<T>
+
+  sealed interface Response2XX<T: Any> : Response<T>
+
+  sealed interface ResponseByteArray : Response<ByteArray>
+
+  data class Response200(override val body: ByteArray) : Response2XX<ByteArray>, ResponseByteArray {
+    override val status = 200
+    override val headers = ResponseHeaders
+    data object ResponseHeaders : Wirespec.Response.Headers
+  }
+
+  fun toResponse(serialization: Wirespec.Serializer, response: Response<*>): Wirespec.RawResponse =
+    when(response) {
+      is Response200 -> Wirespec.RawResponse(
+        statusCode = response.status,
+        headers = emptyMap(),
+        body = serialization.serializeBody(response.body, typeOf<ByteArray>()),
+      )
+    }
+
+  fun fromResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Response<*> =
+    when (response.statusCode) {
+      200 -> Response200(
+        body = serialization.deserializeBody(requireNotNull(response.body) { "body is null" }, typeOf<ByteArray>()),
+      )
+      else -> error("Cannot match response with status: ${response.statusCode}")
+    }
+
+  interface Handler: Wirespec.Handler {
+    @org.springframework.web.bind.annotation.GetMapping("/api/report")
+    suspend fun downloadReport(request: Request): Response<*>
+
+    companion object: Wirespec.Server<Request, Response<*>>, Wirespec.Client<Request, Response<*>> {
+      override val pathTemplate = "/api/report"
+      override val method = "GET"
+      override fun server(serialization: Wirespec.Serialization) = object : Wirespec.ServerEdge<Request, Response<*>> {
+        override fun from(request: Wirespec.RawRequest) = fromRequest(serialization, request)
+        override fun to(response: Response<*>) = toResponse(serialization, response)
+      }
+      override fun client(serialization: Wirespec.Serialization) = object : Wirespec.ClientEdge<Request, Response<*>> {
+        override fun to(request: Request) = toRequest(serialization, request)
+        override fun from(response: Wirespec.RawResponse) = fromResponse(serialization, response)
+      }
+    }
+  }
+}

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/it/controller/RestControllerIntegrationTest.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/it/controller/RestControllerIntegrationTest.kt
@@ -113,6 +113,7 @@ class RestControllerIntegrationTest {
 
         assertContentEquals(service.files.first(), file.bytes)
     }
+
     @Test
     fun `binary response download`() {
         val expected = byteArrayOf(0x50, 0x4B, 0x03, 0x04)

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/it/controller/RestControllerIntegrationTest.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/it/controller/RestControllerIntegrationTest.kt
@@ -113,5 +113,17 @@ class RestControllerIntegrationTest {
 
         assertContentEquals(service.files.first(), file.bytes)
     }
+    @Test
+    fun `binary response download`() {
+        val expected = byteArrayOf(0x50, 0x4B, 0x03, 0x04)
+        mockMvc
+            .perform(get("/api/report"))
+            .asyncDispatch()
+            .andExpect(status().isOk())
+            .andExpect { result ->
+                assertContentEquals(expected, result.response.contentAsByteArray)
+            }
+    }
+
     fun ResultActions.asyncDispatch(): ResultActions = mockMvc.perform(asyncDispatch(this.andReturn()))
 }

--- a/src/integration/spring/src/jvmTest/resources/todo.ws
+++ b/src/integration/spring/src/jvmTest/resources/todo.ws
@@ -37,3 +37,7 @@ endpoint PatchTodos PATCH TodoDtoPatch /api/todos/{id:String} -> {
     200 -> TodoDto
     500 -> Error
 }
+
+endpoint DownloadReport GET /api/report -> {
+    200 -> Bytes
+}


### PR DESCRIPTION
## Summary

- **Parser**: Infer `application/octet-stream` content type when the body type is `Bytes` (instead of hardcoded `application/json`)
- **Jackson serialization**: Add `ByteArray`/`byte[]` passthrough in both Kotlin and Java `WirespecSerialization` so binary data skips JSON encoding
- **Spring ResponseBodyAdvice**: Handle binary responses by writing directly to the output stream with `Content-Type: application/octet-stream`, instead of wrapping in `RawJsonBody`
- **Bug fix**: Fix `concatGenerics()` in `Utils.kt` to handle Java array bracket notation (`byte[]` → `byte` instead of invalid `byte[]` in interface names)

This enables defining endpoints like:
```wirespec
endpoint DownloadReport GET /api/report -> {
    200 -> Bytes
}
```

## Test plan

- [x] Parser tests: verify `Bytes` body infers `application/octet-stream` content type for both request and response
- [x] Spring Kotlin emitter test: verify generated code includes correct handler interface
- [x] Spring Java emitter test: verify generated code includes correct handler interface  
- [x] Kotlin Spring integration test: verify binary response returns correct bytes via MockMvc
- [x] Java Spring integration test: verify binary response returns correct bytes via MockMvc
- [x] Existing CRUD, query parameter, and multipart tests still pass

https://claude.ai/code/session_01JNutdTfvBVFQXNDPx9Xb7H