### PR TITLE
feat(spring): @Streaming annotation for binary response streaming

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/Utils.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/Utils.kt
@@ -16,13 +16,15 @@ fun String.addBackticks() = "`$this`"
 
 fun String.orNull() = ifBlank { null }
 
-fun String.concatGenerics() = removeJavaPrefix().removeAngularBrackets().removeCommasAndSpaces()
+fun String.concatGenerics() = removeJavaPrefix().removeAngularBrackets().removeCommasAndSpaces().removePackageDots()
 
 fun String.removeJavaPrefix() = removePrefix("java.util.")
 
 fun String.removeAngularBrackets() = filterNot { it == '<' || it == '>' }
 
 fun String.removeCommasAndSpaces() = filterNot { it == ',' || it == ' ' }
+
+fun String.removePackageDots() = filterNot { it == '.' }
 
 fun String.removeCommentMarkers(): String = if (startsWith("//")) {
     removePrefix("//")

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaEndpointDefinitionEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaEndpointDefinitionEmitter.kt
@@ -53,7 +53,7 @@ interface JavaEndpointDefinitionEmitter : EndpointDefinitionEmitter, HasPackageN
         |${Spacer(2)}}
         |
         |${Spacer(2)}${emitHandleFunction(endpoint)}
-        |${Spacer(2)}class Handlers implements Wirespec.Server<Request, Response<?>>, Wirespec.Client<Request, Response<?>> {
+        |${Spacer(2)}class Handlers implements Wirespec.Server<Request, Response<?>>, Wirespec.Client<Request, Response<?>> {${emitHandlersExtras(endpoint).let { if (it.isBlank()) "" else "\n$it" }}
         |${Spacer(3)}@Override public String getPathTemplate() { return "/${endpoint.path.joinToString("/") { it.emit() }}"; }
         |${Spacer(3)}@Override public String getMethod() { return "${endpoint.method}"; }
         |${Spacer(3)}@Override public Wirespec.ServerEdge<Request, Response<?>> getServer(Wirespec.Serialization serialization) {
@@ -76,6 +76,21 @@ interface JavaEndpointDefinitionEmitter : EndpointDefinitionEmitter, HasPackageN
 
     open fun emitHandleFunction(endpoint: Endpoint) =
         "java.util.concurrent.CompletableFuture<Response<?>> ${emit(endpoint.identifier).firstToLower()}(Request request);"
+
+    open fun emitResponseBodyType(response: Endpoint.Response): String =
+        response.content?.reference?.emit() ?: "Void"
+
+    open fun emitResponseSerializeBody(response: Endpoint.Response): String =
+        if (response.content != null)
+            "java.util.Optional.ofNullable(serialization.serializeBody(r.body, ${response.content!!.reference.emitGetType()}))"
+        else "java.util.Optional.empty()"
+
+    open fun emitResponseDeserializeBody(response: Endpoint.Response): String =
+        if (response.content != null)
+            "response.body().<${emitResponseBodyType(response)}>map(body -> serialization.deserializeBody(body, ${response.content!!.reference.emitGetType()})).orElse(null)"
+        else "null"
+
+    open fun emitHandlersExtras(endpoint: Endpoint): String = ""
 
     private fun Reference?.emitGetType() = "Wirespec.getType(${emitRoot("Void")}.class, ${emitGetTypeRaw()})"
     private fun Reference?.emitGetTypeRaw() = when {
@@ -124,34 +139,33 @@ interface JavaEndpointDefinitionEmitter : EndpointDefinitionEmitter, HasPackageN
         content?.let { """${Spacer(4)}request.body().<${it.emit()}>map(body -> serialization.deserializeBody(body, ${it.reference.emitGetType()})).orElse(null)""" }
     ).joinToString(",\n").let { if (it.isBlank()) "" else "\n$it\n${Spacer(3)}" }
 
-    fun Endpoint.Response.emit() = """
+    fun Endpoint.Response.emit(): String {
+        val bodyType = emitResponseBodyType(this)
+        return """
         |${Spacer}record Response${status.firstToUpper()}(
         |${Spacer(2)}Integer status,
         |${Spacer(2)}Headers headers,
-        |${Spacer(2)}${content.emit()} body
-        |${Spacer}) implements Response${status.first()}XX<${content.emit()}>, Response${content.emit().concatGenerics()} {
-        |${Spacer(2)}public Response${status.firstToUpper()}(${listOfNotNull(headers.joinToString { it.emit() }.orNull(), content?.let { "${it.emit()} body" }).joinToString()}) {
+        |${Spacer(2)}$bodyType body
+        |${Spacer}) implements Response${status.first()}XX<$bodyType>, Response${bodyType.concatGenerics()} {
+        |${Spacer(2)}public Response${status.firstToUpper()}(${listOfNotNull(headers.joinToString { it.emit() }.orNull(), content?.let { "$bodyType body" }).joinToString()}) {
         |${Spacer(3)}this(${status.fixStatus()}, ${
-        headers.joinToString { emit(it.identifier) }.let { "new Headers($it)" }
-    }, ${if (content == null) "null" else "body"});
+            headers.joinToString { emit(it.identifier) }.let { "new Headers($it)" }
+        }, ${if (content == null) "null" else "body"});
         |${Spacer(2)}}
         |${Spacer(1)}${headers.emitObject("Headers", "Wirespec.Response.Headers") { it.emit() }}
         |${Spacer}}
     """.trimMargin()
+    }
 
     private fun Endpoint.Response.emitDeserializedParams() = listOfNotNull(
         headers.joinToString(",\n") {
             """${Spacer(5)}serialization.<${it.reference.emit()}>deserializeParam(response.headers().entrySet().stream().filter(e -> e.getKey().equalsIgnoreCase("${it.identifier.value}")).findFirst().map(java.util.Map.Entry::getValue).orElse(java.util.Collections.emptyList()), ${it.reference.emitGetType()})"""
         }.orNull(),
-        content?.let { """${Spacer(5)}response.body().<${it.emit()}>map(body -> serialization.deserializeBody(body, ${it.reference.emitGetType()})).orElse(null)""" }
+        content?.let { "${Spacer(5)}${emitResponseDeserializeBody(this)}" }
     ).joinToString(",\n").let { if (it.isBlank()) "" else "\n$it\n${Spacer(4)}" }
 
     private fun Endpoint.Response.emitSerialized(): String {
-        val body = if (content != null) {
-            "java.util.Optional.ofNullable(serialization.serializeBody(r.body, ${content!!.reference.emitGetType()}))"
-        } else {
-            "java.util.Optional.empty()"
-        }
+        val body = emitResponseSerializeBody(this)
         val headers =
             if (headers.isNotEmpty()) {
                 "java.util.Map.ofEntries(${headers.joinToString { it.emitSerializedHeader() }})"
@@ -222,7 +236,7 @@ interface JavaEndpointDefinitionEmitter : EndpointDefinitionEmitter, HasPackageN
 
     private fun Endpoint.emitResponseInterfaces() = responses
         .distinctByStatus()
-        .map { it.content.emit() }
+        .map { emitResponseBodyType(it) }
         .distinct()
         .joinToString("\n") { "${Spacer}sealed interface Response${it.concatGenerics()} extends Response<$it> {}" }
 

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEndpointDefinitionEmitter.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEndpointDefinitionEmitter.kt
@@ -54,7 +54,7 @@ interface KotlinEndpointDefinitionEmitter : EndpointDefinitionEmitter, HasPackag
         |${Spacer(2)}${emitHandleFunction(endpoint)}
         |${Spacer(2)}companion object: Wirespec.Server<Request, Response<*>>, Wirespec.Client<Request, Response<*>> {
         |${Spacer(3)}override val pathTemplate = "/${endpoint.path.joinToString("/") { it.emit() }}"
-        |${Spacer(3)}override val method = "${endpoint.method}"
+        |${Spacer(3)}override val method = "${endpoint.method}"${emitHandlerCompanionExtras(endpoint).let { if (it.isBlank()) "" else "\n$it" }}
         |${Spacer(3)}override fun server(serialization: Wirespec.Serialization) = object : Wirespec.ServerEdge<Request, Response<*>> {
         |${Spacer(4)}override fun from(request: Wirespec.RawRequest) = fromRequest(serialization, request)
         |${Spacer(4)}override fun to(response: Response<*>) = toResponse(serialization, response)
@@ -75,12 +75,25 @@ interface KotlinEndpointDefinitionEmitter : EndpointDefinitionEmitter, HasPackag
         .joinToString("\n") { "${Spacer}sealed interface Response${it}XX<T: Any> : Response<T>" }
 
     private fun Endpoint.emitResponseInterfaces() = responses
-        .map { it.content.emit() }
+        .map { emitResponseBodyType(it) }
         .distinct()
         .joinToString("\n") { "${Spacer}sealed interface Response${it.concatGenerics()} : Response<$it>" }
 
     open fun emitHandleFunction(endpoint: Endpoint): String =
         "suspend fun ${emit(endpoint.identifier).firstToLower()}(request: Request): Response<*>"
+
+    open fun emitResponseBodyType(response: Endpoint.Response): String =
+        response.content?.reference?.emit()?.removeQuestionMark() ?: "Unit"
+
+    open fun emitResponseSerializeBody(response: Endpoint.Response): String =
+        if (response.content != null) "serialization.serializeBody(response.body, typeOf<${emitResponseBodyType(response)}>())"
+        else "null"
+
+    open fun emitResponseDeserializeBody(response: Endpoint.Response): String =
+        if (response.content != null) "serialization.deserializeBody(requireNotNull(response.body) { \"body is null\" }, typeOf<${emitResponseBodyType(response)}>())"
+        else "Unit"
+
+    open fun emitHandlerCompanionExtras(endpoint: Endpoint): String = ""
 
     fun Endpoint.Request.emit(endpoint: Endpoint) = """
         |${Spacer}${emitConstructor(endpoint)}
@@ -120,8 +133,9 @@ interface KotlinEndpointDefinitionEmitter : EndpointDefinitionEmitter, HasPackag
 
     fun Endpoint.Response.emit(): String {
         val responseHeaderFields = headers.joinToString(", ") { "val ${it.emit()}" }.let { if (it.isBlank()) "" else ", $it" }
+        val bodyType = emitResponseBodyType(this)
         return """
-            |${Spacer}data class Response$status(override val body: ${content.emit()}$responseHeaderFields) : Response${status[0]}XX<${content.emit()}>, Response${content.emit().concatGenerics()} {
+            |${Spacer}data class Response$status(override val body: $bodyType$responseHeaderFields) : Response${status[0]}XX<$bodyType>, Response${bodyType.concatGenerics()} {
             |${Spacer(2)}override val status = ${status.fixStatus()}
             |${Spacer(2)}override val headers = ResponseHeaders${headers.joinToString { emit(it.identifier) }.brace()}
             |${headers.emitObject("ResponseHeaders", "Wirespec.Response.Headers", 2) { it.emit() }}
@@ -149,7 +163,7 @@ interface KotlinEndpointDefinitionEmitter : EndpointDefinitionEmitter, HasPackag
         |${Spacer(3)}is Response$status -> Wirespec.RawResponse(
         |${Spacer(4)}statusCode = response.status,
         |${Spacer(4)}headers = ${emitHeaders()},
-        |${Spacer(4)}body = ${if (content != null) emitBody(content) else "null"},
+        |${Spacer(4)}body = ${emitResponseSerializeBody(this)},
         |${Spacer(3)})
     """.trimMargin()
 
@@ -165,11 +179,7 @@ interface KotlinEndpointDefinitionEmitter : EndpointDefinitionEmitter, HasPackag
 
     private fun Endpoint.Response.emitDeserialized() = listOfNotNull(
         "${Spacer(3)}$status -> Response$status(",
-        if (content != null) {
-            "${Spacer(4)}body = serialization.deserializeBody(requireNotNull(response.body) { \"body is null\" }, typeOf<${content.emit()}>()),"
-        } else {
-            "${Spacer(4)}body = Unit,"
-        },
+        "${Spacer(4)}body = ${emitResponseDeserializeBody(this)},",
         headers.joinToString(",\n") { it.emitDeserializedParams("response", "headers", 4, caseSensitive = false) }
             .orNull(),
         "${Spacer(3)})"

--- a/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/client/WirespecWebClient.java
+++ b/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/client/WirespecWebClient.java
@@ -2,6 +2,8 @@ package community.flock.wirespec.integration.spring.java.client;
 
 import community.flock.wirespec.java.Wirespec;
 import community.flock.wirespec.java.Wirespec.Serialization;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.util.CollectionUtils;
@@ -9,8 +11,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -22,6 +26,8 @@ public class WirespecWebClient {
     private final Serialization wirespecSerde;
     private final Map<Class<?>, Method> toRequestCache = new ConcurrentHashMap<>();
     private final Map<Class<?>, Method> fromResponseCache = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Boolean> streamingCache = new ConcurrentHashMap<>();
+    private final Map<Map.Entry<Class<?>, Integer>, Constructor<?>> streamingResponseConstructorCache = new ConcurrentHashMap<>();
 
     public WirespecWebClient(WebClient client, Serialization wirespecSerde) {
         this.client = client;
@@ -32,28 +38,15 @@ public class WirespecWebClient {
     public <Req extends Wirespec.Request<?>, Res extends Wirespec.Response<?>> CompletableFuture<Res> send(Req request) {
         try {
             Class<?> declaringClass = request.getClass().getDeclaringClass();
-            Method toRequest = toRequestCache.computeIfAbsent(declaringClass, cls -> {
-                Class<?> handlerClass = Arrays.stream(cls.getDeclaredClasses())
-                        .filter(c -> c.getSimpleName().equals("Handler"))
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("Handler not found in " + cls));
-                return Arrays.stream(handlerClass.getDeclaredMethods())
-                        .filter(m -> m.getName().equals("toRequest") && Modifier.isStatic(m.getModifiers()))
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("toRequest method not found in " + handlerClass));
-            });
-            Method fromResponse = fromResponseCache.computeIfAbsent(declaringClass, cls -> {
-                Class<?> handlerClass = Arrays.stream(cls.getDeclaredClasses())
-                        .filter(c -> c.getSimpleName().equals("Handler"))
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("Handler not found in " + cls));
-                return Arrays.stream(handlerClass.getDeclaredMethods())
-                        .filter(m -> m.getName().equals("fromResponse") && Modifier.isStatic(m.getModifiers()))
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("fromResponse method not found in " + handlerClass));
-            });
+            Method toRequest = toRequestCache.computeIfAbsent(declaringClass, cls -> findHandlerMethod(cls, "toRequest"));
 
             Wirespec.RawRequest rawRequest = (Wirespec.RawRequest) toRequest.invoke(null, wirespecSerde, request);
+
+            if (isStreaming(declaringClass)) {
+                return executeStreaming(rawRequest, declaringClass).thenApply(res -> (Res) res);
+            }
+
+            Method fromResponse = fromResponseCache.computeIfAbsent(declaringClass, cls -> findHandlerMethod(cls, "fromResponse"));
             return executeRequest(rawRequest, client)
                     .thenApply(rawResponse -> {
                         try {
@@ -67,6 +60,102 @@ public class WirespecWebClient {
             CompletableFuture<Res> future = new CompletableFuture<>();
             future.completeExceptionally(e);
             return future;
+        }
+    }
+
+    private static Method findHandlerMethod(Class<?> cls, String name) {
+        Class<?> handlerClass = Arrays.stream(cls.getDeclaredClasses())
+                .filter(c -> c.getSimpleName().equals("Handler"))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Handler not found in " + cls));
+        return Arrays.stream(handlerClass.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name) && Modifier.isStatic(m.getModifiers()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(name + " method not found in " + handlerClass));
+    }
+
+    private boolean isStreaming(Class<?> declaringClass) {
+        return streamingCache.computeIfAbsent(declaringClass, cls -> {
+            try {
+                Class<?> handlerClass = Arrays.stream(cls.getDeclaredClasses())
+                        .filter(c -> c.getSimpleName().equals("Handler"))
+                        .findFirst()
+                        .orElse(null);
+                if (handlerClass == null) return false;
+                Class<?> handlersClass = Arrays.stream(handlerClass.getDeclaredClasses())
+                        .filter(c -> c.getSimpleName().equals("Handlers"))
+                        .findFirst()
+                        .orElse(null);
+                if (handlersClass == null) return false;
+                return handlersClass.getField("STREAMING").getBoolean(null);
+            } catch (Exception e) {
+                return false;
+            }
+        });
+    }
+
+    private CompletableFuture<Wirespec.Response<?>> executeStreaming(Wirespec.RawRequest request, Class<?> declaringClass) {
+        WebClient.RequestBodySpec spec = client.method(HttpMethod.valueOf(request.method()))
+                .uri(uriBuilder -> {
+                    uriBuilder.path(String.join("/", request.path()));
+                    request.queries().forEach((key, value) -> {
+                        if (value != null && !value.isEmpty()) {
+                            uriBuilder.queryParam(key, value);
+                        }
+                    });
+                    return uriBuilder.build();
+                })
+                .headers(headers -> request.headers().forEach((key, value) -> {
+                    if (value != null && !value.isEmpty()) {
+                        headers.addAll(key, value);
+                    }
+                }));
+
+        if (request.body().isPresent()) {
+            spec.contentType(MediaType.APPLICATION_JSON);
+            spec.bodyValue(request.body().get());
+        }
+
+        return spec.<Wirespec.Response<?>>exchangeToMono(response ->
+                        response.bodyToMono(Resource.class)
+                                .<Wirespec.Response<?>>map(resource -> buildStreamingResponse(declaringClass, response.statusCode().value(), resource))
+                                .switchIfEmpty(Mono.<Wirespec.Response<?>>fromCallable(() ->
+                                        buildStreamingResponse(declaringClass, response.statusCode().value(), new ByteArrayResource(new byte[0]))))
+                )
+                .<Wirespec.Response<?>>onErrorResume(throwable -> {
+                    if (throwable instanceof WebClientResponseException e) {
+                        return Mono.just(buildStreamingResponse(
+                                declaringClass,
+                                e.getStatusCode().value(),
+                                new ByteArrayResource(e.getResponseBodyAsByteArray())
+                        ));
+                    } else {
+                        return Mono.error(throwable);
+                    }
+                })
+                .toFuture();
+    }
+
+    private Wirespec.Response<?> buildStreamingResponse(Class<?> declaringClass, int statusCode, Resource resource) {
+        Constructor<?> constructor = streamingResponseConstructorCache.computeIfAbsent(
+                new AbstractMap.SimpleImmutableEntry<>(declaringClass, statusCode),
+                key -> {
+                    Class<?> cls = key.getKey();
+                    int status = key.getValue();
+                    Class<?> responseClass = Arrays.stream(cls.getDeclaredClasses())
+                            .filter(c -> c.getSimpleName().equals("Response" + status))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("No Response" + status + " class in " + cls.getName()));
+                    return Arrays.stream(responseClass.getDeclaredConstructors())
+                            .filter(c -> c.getParameterCount() == 1 && Resource.class.isAssignableFrom(c.getParameterTypes()[0]))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("No 1-arg Resource constructor on " + responseClass.getName()));
+                }
+        );
+        try {
+            return (Wirespec.Response<?>) constructor.newInstance(resource);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/web/WirespecResponseBodyAdvice.java
+++ b/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/web/WirespecResponseBodyAdvice.java
@@ -3,14 +3,17 @@ package community.flock.wirespec.integration.spring.java.web;
 import community.flock.wirespec.integration.spring.shared.RawJsonBody;
 import community.flock.wirespec.java.Wirespec;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
+import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -58,10 +61,20 @@ public class WirespecResponseBodyAdvice implements ResponseBodyAdvice<Object> {
 
             if (body instanceof Wirespec.Response<?> wirespecResponse) {
                 Wirespec.RawResponse rawResponse = (Wirespec.RawResponse) toResponse.invoke(null, wirespecSerialization, wirespecResponse);
-                
+
                 response.setStatusCode(HttpStatusCode.valueOf(rawResponse.statusCode()));
                 for (Map.Entry<String, List<String>> entry : rawResponse.headers().entrySet()) {
                     response.getHeaders().put(entry.getKey(), entry.getValue());
+                }
+                if (wirespecResponse.body() instanceof Resource resource) {
+                    if (!response.getHeaders().containsKey("Content-Type")) {
+                        response.getHeaders().set("Content-Type", MediaType.APPLICATION_OCTET_STREAM_VALUE);
+                    }
+                    try (InputStream in = resource.getInputStream()) {
+                        StreamUtils.copy(in, response.getBody());
+                    }
+                    response.getBody().flush();
+                    return null;
                 }
                 return rawResponse.body().map(RawJsonBody::new).orElse(null);
             }

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterHelper.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterHelper.kt
@@ -4,8 +4,11 @@ import arrow.core.NonEmptyList
 import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.core.emit.Emitted
 import community.flock.wirespec.compiler.core.emit.PackageName
+import community.flock.wirespec.compiler.core.emit.Spacer
 import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.Endpoint
+import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.utils.Logger
 import community.flock.wirespec.emitters.java.JavaEmitter
 
@@ -18,5 +21,40 @@ abstract class SpringJavaEmitterHelper(packageName: PackageName) : JavaEmitter(p
             .takeIf { it.isNotEmpty() }
             ?.let { results + it }
             ?: results
+    }
+
+    override fun emitResponseBodyType(response: Endpoint.Response): String {
+        response.validateStreaming()
+        return if (response.isStreaming()) RESOURCE_TYPE
+        else super.emitResponseBodyType(response)
+    }
+
+    override fun emitResponseSerializeBody(response: Endpoint.Response): String =
+        if (response.isStreaming()) "java.util.Optional.empty()"
+        else super.emitResponseSerializeBody(response)
+
+    override fun emitResponseDeserializeBody(response: Endpoint.Response): String =
+        if (response.isStreaming())
+            "response.body().<$RESOURCE_TYPE>map(body -> (org.springframework.core.io.Resource) new org.springframework.core.io.ByteArrayResource(body)).orElse(null)"
+        else super.emitResponseDeserializeBody(response)
+
+    override fun emitHandlersExtras(endpoint: Endpoint): String =
+        if (endpoint.responses.any { it.isStreaming() }) "${Spacer(3)}public static final boolean STREAMING = true;"
+        else ""
+
+    private fun Endpoint.Response.validateStreaming() {
+        if (!isStreaming()) return
+        val ref = content?.reference
+        require(ref is Reference.Primitive && ref.type is Reference.Primitive.Type.Bytes) {
+            "@Streaming is only allowed on responses whose body is `Bytes`"
+        }
+    }
+
+    companion object {
+        private const val STREAMING_ANNOTATION = "Streaming"
+        private const val RESOURCE_TYPE = "org.springframework.core.io.Resource"
+
+        private fun Endpoint.Response.isStreaming(): Boolean =
+            annotations.any { it.name == STREAMING_ANNOTATION }
     }
 }

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterHelper.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterHelper.kt
@@ -25,22 +25,30 @@ abstract class SpringJavaEmitterHelper(packageName: PackageName) : JavaEmitter(p
 
     override fun emitResponseBodyType(response: Endpoint.Response): String {
         response.validateStreaming()
-        return if (response.isStreaming()) RESOURCE_TYPE
-        else super.emitResponseBodyType(response)
+        return if (response.isStreaming()) {
+            RESOURCE_TYPE
+        } else {
+            super.emitResponseBodyType(response)
+        }
     }
 
-    override fun emitResponseSerializeBody(response: Endpoint.Response): String =
-        if (response.isStreaming()) "java.util.Optional.empty()"
-        else super.emitResponseSerializeBody(response)
+    override fun emitResponseSerializeBody(response: Endpoint.Response): String = if (response.isStreaming()) {
+        "java.util.Optional.empty()"
+    } else {
+        super.emitResponseSerializeBody(response)
+    }
 
-    override fun emitResponseDeserializeBody(response: Endpoint.Response): String =
-        if (response.isStreaming())
-            "response.body().<$RESOURCE_TYPE>map(body -> (org.springframework.core.io.Resource) new org.springframework.core.io.ByteArrayResource(body)).orElse(null)"
-        else super.emitResponseDeserializeBody(response)
+    override fun emitResponseDeserializeBody(response: Endpoint.Response): String = if (response.isStreaming()) {
+        "response.body().<$RESOURCE_TYPE>map(body -> (org.springframework.core.io.Resource) new org.springframework.core.io.ByteArrayResource(body)).orElse(null)"
+    } else {
+        super.emitResponseDeserializeBody(response)
+    }
 
-    override fun emitHandlersExtras(endpoint: Endpoint): String =
-        if (endpoint.responses.any { it.isStreaming() }) "${Spacer(3)}public static final boolean STREAMING = true;"
-        else ""
+    override fun emitHandlersExtras(endpoint: Endpoint): String = if (endpoint.responses.any { it.isStreaming() }) {
+        "${Spacer(3)}public static final boolean STREAMING = true;"
+    } else {
+        ""
+    }
 
     private fun Endpoint.Response.validateStreaming() {
         if (!isStreaming()) return
@@ -54,7 +62,6 @@ abstract class SpringJavaEmitterHelper(packageName: PackageName) : JavaEmitter(p
         private const val STREAMING_ANNOTATION = "Streaming"
         private const val RESOURCE_TYPE = "org.springframework.core.io.Resource"
 
-        private fun Endpoint.Response.isStreaming(): Boolean =
-            annotations.any { it.name == STREAMING_ANNOTATION }
+        private fun Endpoint.Response.isStreaming(): Boolean = annotations.any { it.name == STREAMING_ANNOTATION }
     }
 }

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
@@ -4,12 +4,14 @@ import community.flock.wirespec.integration.spring.shared.filterNotEmpty
 import community.flock.wirespec.kotlin.Wirespec
 import community.flock.wirespec.kotlin.Wirespec.Serialization
 import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.core.io.Resource
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.util.CollectionUtils.toMultiValueMap
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
+import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 
@@ -19,6 +21,8 @@ class WirespecWebClient(
 ) {
     private val toRequestCache = ConcurrentHashMap<Class<*>, Method>()
     private val fromResponseCache = ConcurrentHashMap<Class<*>, Method>()
+    private val streamingCache = ConcurrentHashMap<Class<*>, Boolean>()
+    private val streamingResponseConstructorCache = ConcurrentHashMap<Pair<Class<*>, Int>, Constructor<*>>()
 
     @Suppress("UNCHECKED_CAST")
     suspend fun <Req : Wirespec.Request<*>, Res : Wirespec.Response<*>> send(request: Req): Res {
@@ -26,13 +30,88 @@ class WirespecWebClient(
         val toRequest = toRequestCache.computeIfAbsent(declaringClass) { cls ->
             cls.declaredMethods.first { it.name == "toRequest" }
         }
-        val fromResponse = fromResponseCache.computeIfAbsent(declaringClass) { cls ->
-            cls.declaredMethods.first { it.name == "fromResponse" }
-        }
         val instance = declaringClass.getDeclaredField("INSTANCE").get(null)
         val rawRequest = toRequest.invoke(instance, wirespecSerde, request) as Wirespec.RawRequest
-        val rawResponse = executeRequest(rawRequest, client)
-        return fromResponse.invoke(instance, wirespecSerde, rawResponse) as Res
+        return if (isStreaming(declaringClass)) {
+            executeStreaming(rawRequest, declaringClass) as Res
+        } else {
+            val fromResponse = fromResponseCache.computeIfAbsent(declaringClass) { cls ->
+                cls.declaredMethods.first { it.name == "fromResponse" }
+            }
+            val rawResponse = executeRequest(rawRequest, client)
+            fromResponse.invoke(instance, wirespecSerde, rawResponse) as Res
+        }
+    }
+
+    private fun isStreaming(declaringClass: Class<*>): Boolean = streamingCache.computeIfAbsent(declaringClass) { cls ->
+        runCatching {
+            val handlerClass = cls.declaredClasses.first { it.simpleName == "Handler" }
+            val companionClass = handlerClass.declaredClasses.first { it.simpleName == "Companion" }
+            companionClass.getField("STREAMING").getBoolean(null)
+        }.getOrDefault(false)
+    }
+
+    private suspend fun executeStreaming(
+        request: Wirespec.RawRequest,
+        declaringClass: Class<*>,
+    ): Wirespec.Response<*> = client
+        .method(HttpMethod.valueOf(request.method))
+        .uri { uriBuilder ->
+            uriBuilder
+                .path(request.path.joinToString("/"))
+                .apply { request.queries.filterNotEmpty().forEach { (key, value) -> queryParam(key, value) } }
+                .build()
+        }
+        .headers { headers ->
+            request.headers.filterNotEmpty().forEach { (key, value) -> headers.addAll(key, value) }
+        }
+        .apply {
+            request.body?.let {
+                contentType(MediaType.APPLICATION_JSON)
+                bodyValue(it)
+            }
+        }
+        .exchangeToMono { response ->
+            response.bodyToMono(Resource::class.java)
+                .map { resource -> buildStreamingResponse(declaringClass, response.statusCode().value(), resource) }
+                .switchIfEmpty(
+                    Mono.fromCallable {
+                        buildStreamingResponse(
+                            declaringClass,
+                            response.statusCode().value(),
+                            org.springframework.core.io.ByteArrayResource(ByteArray(0)),
+                        )
+                    },
+                )
+        }
+        .onErrorResume { throwable ->
+            when (throwable) {
+                is WebClientResponseException -> Mono.just(
+                    buildStreamingResponse(
+                        declaringClass,
+                        throwable.statusCode.value(),
+                        org.springframework.core.io.ByteArrayResource(throwable.responseBodyAsByteArray),
+                    ),
+                )
+
+                else -> Mono.error(throwable)
+            }
+        }
+        .awaitSingle()
+
+    private fun buildStreamingResponse(
+        declaringClass: Class<*>,
+        statusCode: Int,
+        resource: Resource,
+    ): Wirespec.Response<*> {
+        val constructor = streamingResponseConstructorCache.computeIfAbsent(declaringClass to statusCode) { (cls, status) ->
+            val responseClass = cls.declaredClasses.firstOrNull { it.simpleName == "Response$status" }
+                ?: error("No Response$status class found in ${cls.name}")
+            responseClass.declaredConstructors.first { ctor ->
+                ctor.parameterCount == 1 && Resource::class.java.isAssignableFrom(ctor.parameterTypes[0])
+            }
+        }
+        return constructor.newInstance(resource) as Wirespec.Response<*>
     }
 
     private suspend fun executeRequest(

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitter.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitter.kt
@@ -10,11 +10,13 @@ import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Model
+import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.utils.Logger
 import community.flock.wirespec.emitters.kotlin.KotlinEmitter
 
 class SpringKotlinEmitter(packageName: PackageName) : KotlinEmitter(packageName, EmitShared(false)) {
     override fun emitHandleFunction(endpoint: Endpoint): String {
+        endpoint.responses.forEach { it.validateStreaming() }
         val path = "/${endpoint.path.joinToString("/") { it.emit() }}"
         val annotation = when (endpoint.method) {
             Endpoint.Method.GET -> "@org.springframework.web.bind.annotation.GetMapping(\"${path}\")"
@@ -32,6 +34,22 @@ class SpringKotlinEmitter(packageName: PackageName) : KotlinEmitter(packageName,
             |
         """.trimMargin()
     }
+
+    override fun emitResponseBodyType(response: Endpoint.Response): String =
+        if (response.isStreaming()) RESOURCE_TYPE
+        else super.emitResponseBodyType(response)
+
+    override fun emitResponseSerializeBody(response: Endpoint.Response): String =
+        if (response.isStreaming()) "null"
+        else super.emitResponseSerializeBody(response)
+
+    override fun emitResponseDeserializeBody(response: Endpoint.Response): String =
+        if (response.isStreaming()) "org.springframework.core.io.ByteArrayResource(requireNotNull(response.body) { \"body is null\" })"
+        else super.emitResponseDeserializeBody(response)
+
+    override fun emitHandlerCompanionExtras(endpoint: Endpoint): String =
+        if (endpoint.responses.any { it.isStreaming() }) "${Spacer(3)}const val STREAMING = true"
+        else ""
 
     override fun emit(ast: AST, logger: Logger): NonEmptyList<Emitted> {
         val results = super.emit(ast, logger)
@@ -98,5 +116,21 @@ class SpringKotlinEmitter(packageName: PackageName) : KotlinEmitter(packageName,
             |}
             |
         """.trimMargin()
+    }
+
+    private fun Endpoint.Response.validateStreaming() {
+        if (!isStreaming()) return
+        val ref = content?.reference
+        require(ref is Reference.Primitive && ref.type is Reference.Primitive.Type.Bytes) {
+            "@Streaming is only allowed on responses whose body is `Bytes`"
+        }
+    }
+
+    companion object {
+        private const val STREAMING_ANNOTATION = "Streaming"
+        private const val RESOURCE_TYPE = "org.springframework.core.io.Resource"
+
+        private fun Endpoint.Response.isStreaming(): Boolean =
+            annotations.any { it.name == STREAMING_ANNOTATION }
     }
 }

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitter.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitter.kt
@@ -35,21 +35,29 @@ class SpringKotlinEmitter(packageName: PackageName) : KotlinEmitter(packageName,
         """.trimMargin()
     }
 
-    override fun emitResponseBodyType(response: Endpoint.Response): String =
-        if (response.isStreaming()) RESOURCE_TYPE
-        else super.emitResponseBodyType(response)
+    override fun emitResponseBodyType(response: Endpoint.Response): String = if (response.isStreaming()) {
+        RESOURCE_TYPE
+    } else {
+        super.emitResponseBodyType(response)
+    }
 
-    override fun emitResponseSerializeBody(response: Endpoint.Response): String =
-        if (response.isStreaming()) "null"
-        else super.emitResponseSerializeBody(response)
+    override fun emitResponseSerializeBody(response: Endpoint.Response): String = if (response.isStreaming()) {
+        "null"
+    } else {
+        super.emitResponseSerializeBody(response)
+    }
 
-    override fun emitResponseDeserializeBody(response: Endpoint.Response): String =
-        if (response.isStreaming()) "org.springframework.core.io.ByteArrayResource(requireNotNull(response.body) { \"body is null\" })"
-        else super.emitResponseDeserializeBody(response)
+    override fun emitResponseDeserializeBody(response: Endpoint.Response): String = if (response.isStreaming()) {
+        "org.springframework.core.io.ByteArrayResource(requireNotNull(response.body) { \"body is null\" })"
+    } else {
+        super.emitResponseDeserializeBody(response)
+    }
 
-    override fun emitHandlerCompanionExtras(endpoint: Endpoint): String =
-        if (endpoint.responses.any { it.isStreaming() }) "${Spacer(3)}const val STREAMING = true"
-        else ""
+    override fun emitHandlerCompanionExtras(endpoint: Endpoint): String = if (endpoint.responses.any { it.isStreaming() }) {
+        "${Spacer(3)}const val STREAMING = true"
+    } else {
+        ""
+    }
 
     override fun emit(ast: AST, logger: Logger): NonEmptyList<Emitted> {
         val results = super.emit(ast, logger)
@@ -130,7 +138,6 @@ class SpringKotlinEmitter(packageName: PackageName) : KotlinEmitter(packageName,
         private const val STREAMING_ANNOTATION = "Streaming"
         private const val RESOURCE_TYPE = "org.springframework.core.io.Resource"
 
-        private fun Endpoint.Response.isStreaming(): Boolean =
-            annotations.any { it.name == STREAMING_ANNOTATION }
+        private fun Endpoint.Response.isStreaming(): Boolean = annotations.any { it.name == STREAMING_ANNOTATION }
     }
 }

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecResponseBodyAdvice.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecResponseBodyAdvice.kt
@@ -3,6 +3,7 @@ package community.flock.wirespec.integration.spring.kotlin.web
 import community.flock.wirespec.integration.spring.shared.RawJsonBody
 import community.flock.wirespec.kotlin.Wirespec
 import org.springframework.core.MethodParameter
+import org.springframework.core.io.Resource
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
 import org.springframework.http.converter.HttpMessageConverter
@@ -41,7 +42,15 @@ class WirespecResponseBodyAdvice(
                 val rawResponse = toResponse.invoke(instance, wirespecSerialization, body) as Wirespec.RawResponse
                 response.setStatusCode(HttpStatusCode.valueOf(rawResponse.statusCode))
                 response.headers.putAll(rawResponse.headers)
-                if (rawResponse.body == null) {
+                val responseBody = body.body
+                if (responseBody is Resource) {
+                    if (!response.headers.containsKey("Content-Type")) {
+                        response.headers.set("Content-Type", MediaType.APPLICATION_OCTET_STREAM_VALUE)
+                    }
+                    responseBody.inputStream.use { it.copyTo(response.body) }
+                    response.body.flush()
+                    null
+                } else if (rawResponse.body == null) {
                     Unit
                 } else {
                     rawResponse.body?.let { RawJsonBody(it) }

--- a/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterTest.java
+++ b/src/integration/spring/src/jvmTest/java/community/flock/wirespec/integration/spring/java/emit/SpringJavaEmitterTest.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SpringJavaEmitterTest {
 
@@ -504,5 +507,60 @@ public class SpringJavaEmitterTest {
         }
 
         assertEquals(expected.stream().sorted().toList(), actual.stream().sorted().toList());
+    }
+
+    @Test
+    public void shouldEmitResourceBodyAndStreamingMarkerForStreamingResponse() {
+        String source = """
+                endpoint DownloadReport GET /api/report -> {
+                    @Streaming
+                    200 -> Bytes
+                }
+                """;
+
+        Root ast = JavaInteropTestHelper.parse(source);
+        SpringJavaEmitter emitter = new SpringJavaEmitter(new PackageName("community.flock.wirespec.spring.test", false));
+        String joined = JavaInteropTestHelper.emit(emitter, ast, LoggerKt.getNoLogger())
+                .stream()
+                .map(Emitted::getResult)
+                .collect(Collectors.joining("\n"));
+
+        assertTrue(joined.contains("org.springframework.core.io.Resource body"),
+                "expected Resource body type, got:\n" + joined);
+        assertTrue(joined.contains("public static final boolean STREAMING = true;"),
+                "expected STREAMING marker, got:\n" + joined);
+        assertTrue(joined.contains("java.util.Optional.empty()"),
+                "expected Optional.empty serialize body, got:\n" + joined);
+        assertTrue(joined.contains("new org.springframework.core.io.ByteArrayResource(body)"),
+                "expected ByteArrayResource fallback, got:\n" + joined);
+    }
+
+    @Test
+    public void shouldNotEmitStreamingMarkerWhenNoResponseIsAnnotated() {
+        String source = "endpoint Plain GET /api/plain -> { 200 -> String }\n";
+
+        Root ast = JavaInteropTestHelper.parse(source);
+        SpringJavaEmitter emitter = new SpringJavaEmitter(new PackageName("community.flock.wirespec.spring.test", false));
+        String joined = JavaInteropTestHelper.emit(emitter, ast, LoggerKt.getNoLogger())
+                .stream()
+                .map(Emitted::getResult)
+                .collect(Collectors.joining("\n"));
+
+        assertFalse(joined.contains("STREAMING"),
+                "expected no STREAMING marker, got:\n" + joined);
+    }
+
+    @Test
+    public void shouldFailWhenStreamingIsAppliedToANonBytesResponse() {
+        String source = """
+                endpoint BadStream GET /api/bad -> {
+                    @Streaming
+                    200 -> String
+                }
+                """;
+
+        Root ast = JavaInteropTestHelper.parse(source);
+        SpringJavaEmitter emitter = new SpringJavaEmitter(new PackageName("community.flock.wirespec.spring.test", false));
+        assertThrows(IllegalArgumentException.class, () -> JavaInteropTestHelper.emit(emitter, ast, LoggerKt.getNoLogger()));
     }
 }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitterTest.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitterTest.kt
@@ -15,7 +15,10 @@ import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.readString
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class SpringKotlinEmitterTest {
 
@@ -524,5 +527,58 @@ class SpringKotlinEmitterTest {
         """.trimMargin()
 
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should emit Resource body, null serialize body and STREAMING marker for streaming response`() {
+        val source = """
+            |endpoint DownloadReport GET /api/report -> {
+            |    @Streaming
+            |    200 -> Bytes
+            |}
+        """.trimMargin()
+
+        val ast = parse(source)
+        val actual = SpringKotlinEmitter(PackageName("community.flock.wirespec.spring.test"))
+            .emit(ast, noLogger)
+            .joinToString("\n") { it.result }
+
+        assertContains(actual, "override val body: org.springframework.core.io.Resource")
+        assertContains(actual, "Response<org.springframework.core.io.Resource>")
+        assertContains(actual, "body = null,")
+        assertContains(actual, "body = org.springframework.core.io.ByteArrayResource(requireNotNull(response.body) { \"body is null\" })")
+        assertContains(actual, "const val STREAMING = true")
+    }
+
+    @Test
+    fun `Should not emit STREAMING marker when no response is annotated`() {
+        val source = """
+            |endpoint Plain GET /api/plain -> {
+            |    200 -> String
+            |}
+        """.trimMargin()
+
+        val ast = parse(source)
+        val actual = SpringKotlinEmitter(PackageName("community.flock.wirespec.spring.test"))
+            .emit(ast, noLogger)
+            .joinToString("\n") { it.result }
+
+        assertTrue("STREAMING" !in actual, "expected no STREAMING marker, got:\n$actual")
+    }
+
+    @Test
+    fun `Should fail when Streaming is applied to a non-Bytes response`() {
+        val source = """
+            |endpoint BadStream GET /api/bad -> {
+            |    @Streaming
+            |    200 -> String
+            |}
+        """.trimMargin()
+
+        val ast = parse(source)
+        val emitter = SpringKotlinEmitter(PackageName("community.flock.wirespec.spring.test"))
+        assertFailsWith<IllegalArgumentException> {
+            emitter.emit(ast, noLogger)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `@Streaming` annotation that opts a `Bytes` response into chunked,
never-fully-buffered response streaming on Spring endpoints — both server
and client (Spring `WirespecWebClient`) sides.

```wirespec
endpoint DownloadReport GET /api/report -> {
    @Streaming
    200 -> Bytes
}
```

## What changes

- **Spring Kotlin/Java emitters** substitute `org.springframework.core.io.Resource`
  for the body type when a response is annotated `@Streaming`, skip the JSON
  serialize step, and emit a `STREAMING` marker on the handler companion.
- **`WirespecResponseBodyAdvice` (Kotlin + Java)** dispatches on a runtime
  `Resource` body and writes `Resource.inputStream` straight to
  `response.body` with `application/octet-stream`.
- **`WirespecWebClient` (Kotlin + Java)** detects the marker reflectively
  and consumes the response via `bodyToMono(Resource.class)` instead of
  buffering bytes.
- **Validation**: `@Streaming` on a non-`Bytes` response fails the emit.
- **Core emitter hooks**: `KotlinEndpointDefinitionEmitter` and
  `JavaEndpointDefinitionEmitter` expose three new `open` hooks
  (`emitResponseBodyType`, `emitResponseSerializeBody`,
  `emitResponseDeserializeBody`) plus a companion-extras hook so per-emitter
  subclasses can override response-body behavior without touching the
  request path.
- **`concatGenerics` sanitizer**: now strips dots so fully-qualified body
  types produce valid identifiers.

## Out of scope (intentional)

- Other client SDKs (Ktor, OkHttp, JS, Python, etc.) keep buffering via
  the existing `RawResponse.body: ByteArray?` contract — unchanged.
- `fromResponse` still works for non-streaming callers (tests, mocks)
  by wrapping the buffered body in `ByteArrayResource`. The Spring
  streaming client bypasses that path entirely.

## Test plan

- [x] `:src:compiler:core:jvmTest`, `:src:compiler:emitters:kotlin:jvmTest`,
      `:src:compiler:emitters:java:jvmTest` — all green
- [x] `:src:integration:spring:jvmTest` — all green (existing 49 tests +
      6 new emitter tests asserting Resource body / STREAMING marker /
      `@Streaming` validation for both Kotlin and Java)
- [x] `:src:converter:openapi:jvmTest`, `:src:integration:jackson:jvmTest`
      — all green (verifies `concatGenerics` change is backward-compatible)
- [ ] Manual end-to-end: streaming client receives first byte before
      full body for a slow `InputStreamResource` server (recommended
      follow-up integration test, not yet added)

https://claude.ai/code/session_013z9Zaawbdh3pnyMg4b2DSG