### PR TITLE
feat: add Avro IDL converter to avro module

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/FileExtension.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/FileExtension.kt
@@ -10,6 +10,6 @@ enum class FileExtension(override val value: String) : Value<String> {
     Wirespec("ws"),
     JSON("json"),
     YAML("yaml"),
-    Avro("avsc"),
+    AvroJson("avsc"),
     AvroIdl("avdl"),
 }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/FileExtension.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/FileExtension.kt
@@ -11,4 +11,5 @@ enum class FileExtension(override val value: String) : Value<String> {
     JSON("json"),
     YAML("yaml"),
     Avro("avsc"),
+    AvroIdl("avdl"),
 }

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitter.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitter.kt
@@ -1,0 +1,140 @@
+package community.flock.wirespec.converter.avro
+
+import arrow.core.NonEmptyList
+import community.flock.wirespec.compiler.core.emit.Emitted
+import community.flock.wirespec.compiler.core.emit.Emitter
+import community.flock.wirespec.compiler.core.emit.FileExtension
+import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Type
+import community.flock.wirespec.compiler.core.parse.ast.Union
+import community.flock.wirespec.compiler.utils.Logger
+
+object AvroIdlEmitter : Emitter {
+
+    override val extension = FileExtension.AvroIdl
+
+    private const val INDENT = "    "
+
+    override fun emit(ast: AST, logger: Logger): NonEmptyList<Emitted> = ast.modules
+        .map {
+            logger.info("Emitting Avro IDL from ${it.fileUri.value}")
+            Emitted("schema.avdl", emit(it, deriveProtocolName(it)))
+        }
+
+    private fun deriveProtocolName(module: Module): String = module.fileUri.value
+        .substringAfterLast('/')
+        .substringBeforeLast('.')
+        .takeIf { it.isNotBlank() }
+        ?.let { it.replaceFirstChar { c -> c.uppercaseChar() } + "Protocol" }
+        ?: "WirespecProtocol"
+
+    fun emit(module: Module, protocolName: String = "WirespecProtocol"): String {
+        val sb = StringBuilder()
+        sb.append("protocol ").append(protocolName).append(" {\n")
+        val statements = module.statements.toList()
+        statements.forEachIndexed { index, definition ->
+            val rendered = when (definition) {
+                is Type -> renderRecord(definition)
+                is Enum -> renderEnum(definition)
+                is Union -> renderUnion(definition)
+                is Refined -> renderRefined(definition)
+                else -> null
+            }
+            if (rendered != null) {
+                sb.append(rendered)
+                if (index != statements.lastIndex) sb.append("\n")
+            }
+        }
+        sb.append("}\n")
+        return sb.toString()
+    }
+
+    private fun renderRecord(type: Type): String {
+        val sb = StringBuilder()
+        type.comment?.value?.let { sb.append(renderDoc(it, INDENT)) }
+        sb.append(INDENT).append("record ").append(type.identifier.value).append(" {\n")
+        type.shape.value.forEach { field ->
+            sb.append(INDENT).append(INDENT)
+            sb.append(renderReference(field.reference))
+            sb.append(' ')
+            sb.append(field.identifier.value)
+            sb.append(";\n")
+        }
+        sb.append(INDENT).append("}\n")
+        return sb.toString()
+    }
+
+    private fun renderEnum(enum: Enum): String {
+        val sb = StringBuilder()
+        enum.comment?.value?.let { sb.append(renderDoc(it, INDENT)) }
+        sb.append(INDENT).append("enum ").append(enum.identifier.value).append(" {\n")
+        sb.append(INDENT).append(INDENT)
+        sb.append(enum.entries.joinToString(", "))
+        sb.append("\n")
+        sb.append(INDENT).append("}\n")
+        return sb.toString()
+    }
+
+    private fun renderUnion(union: Union): String {
+        val sb = StringBuilder()
+        union.comment?.value?.let { sb.append(renderDoc(it, INDENT)) }
+        sb.append(INDENT).append("record ").append(union.identifier.value).append(" {\n")
+        sb.append(INDENT).append(INDENT)
+        sb.append("union { ")
+        sb.append(union.entries.joinToString(", ") { renderReference(it) })
+        sb.append(" } value;\n")
+        sb.append(INDENT).append("}\n")
+        return sb.toString()
+    }
+
+    private fun renderRefined(refined: Refined): String {
+        val sb = StringBuilder()
+        refined.comment?.value?.let { sb.append(renderDoc(it, INDENT)) }
+        sb.append(INDENT).append("// refined ").append(refined.identifier.value)
+        sb.append(" = ").append(renderPrimitive(refined.reference.type)).append("\n")
+        return sb.toString()
+    }
+
+    private fun renderReference(reference: Reference): String = when (reference) {
+        is Reference.Primitive -> wrapNullable(renderPrimitive(reference.type), reference.isNullable)
+        is Reference.Custom -> wrapNullable(reference.value, reference.isNullable)
+        is Reference.Iterable -> wrapNullable("array<${renderReference(reference.reference.copy(isNullable = false))}>", reference.isNullable)
+        is Reference.Dict -> wrapNullable("map<${renderReference(reference.reference.copy(isNullable = false))}>", reference.isNullable)
+        is Reference.Any -> wrapNullable("bytes", reference.isNullable)
+        is Reference.Unit -> "null"
+    }
+
+    private fun renderPrimitive(type: Reference.Primitive.Type): String = when (type) {
+        is Reference.Primitive.Type.String -> "string"
+        is Reference.Primitive.Type.Boolean -> "boolean"
+        is Reference.Primitive.Type.Bytes -> "bytes"
+        is Reference.Primitive.Type.Integer -> when (type.precision) {
+            Reference.Primitive.Type.Precision.P32 -> "int"
+            Reference.Primitive.Type.Precision.P64 -> "long"
+        }
+        is Reference.Primitive.Type.Number -> when (type.precision) {
+            Reference.Primitive.Type.Precision.P32 -> "float"
+            Reference.Primitive.Type.Precision.P64 -> "double"
+        }
+    }
+
+    private fun wrapNullable(rendered: String, isNullable: Boolean): String = if (isNullable) "union { null, $rendered }" else rendered
+
+    private fun renderDoc(value: String, indent: String): String {
+        val lines = value.lines()
+        val sb = StringBuilder()
+        sb.append(indent).append("/**")
+        if (lines.size == 1) {
+            sb.append(' ').append(lines.first()).append(" */\n")
+        } else {
+            sb.append('\n')
+            lines.forEach { sb.append(indent).append(" * ").append(it).append('\n') }
+            sb.append(indent).append(" */\n")
+        }
+        return sb.toString()
+    }
+}

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitter.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitter.kt
@@ -33,70 +33,41 @@ object AvroIdlEmitter : Emitter {
         ?: "WirespecProtocol"
 
     fun emit(module: Module, protocolName: String = "WirespecProtocol"): String {
-        val sb = StringBuilder()
-        sb.append("protocol ").append(protocolName).append(" {\n")
-        val statements = module.statements.toList()
-        statements.forEachIndexed { index, definition ->
-            val rendered = when (definition) {
+        val body = module.statements.toList().mapNotNull { definition ->
+            when (definition) {
                 is Type -> renderRecord(definition)
                 is Enum -> renderEnum(definition)
                 is Union -> renderUnion(definition)
                 is Refined -> renderRefined(definition)
                 else -> null
             }
-            if (rendered != null) {
-                sb.append(rendered)
-                if (index != statements.lastIndex) sb.append("\n")
-            }
-        }
-        sb.append("}\n")
-        return sb.toString()
+        }.joinToString("\n")
+        return "protocol $protocolName {\n$body}\n"
     }
 
     private fun renderRecord(type: Type): String {
-        val sb = StringBuilder()
-        type.comment?.value?.let { sb.append(renderDoc(it, INDENT)) }
-        sb.append(INDENT).append("record ").append(type.identifier.value).append(" {\n")
-        type.shape.value.forEach { field ->
-            sb.append(INDENT).append(INDENT)
-            sb.append(renderReference(field.reference))
-            sb.append(' ')
-            sb.append(field.identifier.value)
-            sb.append(";\n")
+        val doc = type.comment?.value?.let { renderDoc(it, INDENT) }.orEmpty()
+        val fields = type.shape.value.joinToString("") { field ->
+            "$INDENT$INDENT${renderReference(field.reference)} ${field.identifier.value};\n"
         }
-        sb.append(INDENT).append("}\n")
-        return sb.toString()
+        return "$doc${INDENT}record ${type.identifier.value} {\n$fields$INDENT}\n"
     }
 
     private fun renderEnum(enum: Enum): String {
-        val sb = StringBuilder()
-        enum.comment?.value?.let { sb.append(renderDoc(it, INDENT)) }
-        sb.append(INDENT).append("enum ").append(enum.identifier.value).append(" {\n")
-        sb.append(INDENT).append(INDENT)
-        sb.append(enum.entries.joinToString(", "))
-        sb.append("\n")
-        sb.append(INDENT).append("}\n")
-        return sb.toString()
+        val doc = enum.comment?.value?.let { renderDoc(it, INDENT) }.orEmpty()
+        val symbols = enum.entries.joinToString(", ")
+        return "$doc${INDENT}enum ${enum.identifier.value} {\n$INDENT$INDENT$symbols\n$INDENT}\n"
     }
 
     private fun renderUnion(union: Union): String {
-        val sb = StringBuilder()
-        union.comment?.value?.let { sb.append(renderDoc(it, INDENT)) }
-        sb.append(INDENT).append("record ").append(union.identifier.value).append(" {\n")
-        sb.append(INDENT).append(INDENT)
-        sb.append("union { ")
-        sb.append(union.entries.joinToString(", ") { renderReference(it) })
-        sb.append(" } value;\n")
-        sb.append(INDENT).append("}\n")
-        return sb.toString()
+        val doc = union.comment?.value?.let { renderDoc(it, INDENT) }.orEmpty()
+        val members = union.entries.joinToString(", ") { renderReference(it) }
+        return "$doc${INDENT}record ${union.identifier.value} {\n$INDENT${INDENT}union { $members } value;\n$INDENT}\n"
     }
 
     private fun renderRefined(refined: Refined): String {
-        val sb = StringBuilder()
-        refined.comment?.value?.let { sb.append(renderDoc(it, INDENT)) }
-        sb.append(INDENT).append("// refined ").append(refined.identifier.value)
-        sb.append(" = ").append(renderPrimitive(refined.reference.type)).append("\n")
-        return sb.toString()
+        val doc = refined.comment?.value?.let { renderDoc(it, INDENT) }.orEmpty()
+        return "$doc$INDENT// refined ${refined.identifier.value} = ${renderPrimitive(refined.reference.type)}\n"
     }
 
     private fun renderReference(reference: Reference): String = when (reference) {
@@ -126,15 +97,11 @@ object AvroIdlEmitter : Emitter {
 
     private fun renderDoc(value: String, indent: String): String {
         val lines = value.lines()
-        val sb = StringBuilder()
-        sb.append(indent).append("/**")
-        if (lines.size == 1) {
-            sb.append(' ').append(lines.first()).append(" */\n")
+        return if (lines.size == 1) {
+            "$indent/** ${lines.first()} */\n"
         } else {
-            sb.append('\n')
-            lines.forEach { sb.append(indent).append(" * ").append(it).append('\n') }
-            sb.append(indent).append(" */\n")
+            val body = lines.joinToString("") { "$indent * $it\n" }
+            "$indent/**\n$body$indent */\n"
         }
-        return sb.toString()
     }
 }

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlParser.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlParser.kt
@@ -138,7 +138,7 @@ object AvroIdlParser : Parser {
         }
 
         private fun readMatchedBlock(open: Char, close: Char): String {
-            val sb = StringBuilder()
+            var result = ""
             var depth = 0
             while (pos < tokens.size) {
                 val t = tokens[pos]
@@ -146,26 +146,26 @@ object AvroIdlParser : Parser {
                     when (t.value) {
                         open -> {
                             depth++
-                            sb.append(open)
+                            result += open
                             advance()
                         }
                         close -> {
                             depth--
-                            sb.append(close)
+                            result += close
                             advance()
-                            if (depth == 0) return sb.toString()
+                            if (depth == 0) return result
                         }
                         else -> {
-                            sb.append(t.value)
+                            result += t.value
                             advance()
                         }
                     }
                 } else {
-                    when (t) {
-                        is AvroIdlToken.Identifier -> sb.append(t.value)
-                        is AvroIdlToken.NumberLiteral -> sb.append(t.value)
-                        is AvroIdlToken.StringLiteral -> sb.append('"').append(t.value).append('"')
-                        else -> {}
+                    result += when (t) {
+                        is AvroIdlToken.Identifier -> t.value
+                        is AvroIdlToken.NumberLiteral -> t.value
+                        is AvroIdlToken.StringLiteral -> "\"${t.value}\""
+                        else -> ""
                     }
                     advance()
                 }

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlParser.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlParser.kt
@@ -60,7 +60,6 @@ object AvroIdlParser : Parser {
         private fun parseDeclaration(): List<AvroModel.Type> {
             val doc = consumeDoc()
             while (peekSymbol('@')) parseAnnotation()
-            consumeDoc().let { if (doc == null && it != null) Unit }
             val keyword = peekIdentifierName()
             return when (keyword) {
                 "record", "error" -> listOf(parseRecord(doc))
@@ -99,10 +98,11 @@ object AvroIdlParser : Parser {
             while (peekSymbol('@')) parseAnnotation()
             val type = parseType()
             val name = expectIdentifier()
-            var default: String? = null
-            if (peekSymbol('=')) {
+            val default = if (peekSymbol('=')) {
                 advance()
-                default = parseDefaultValue()
+                parseDefaultValue()
+            } else {
+                null
             }
             expectSymbol(';')
             return AvroModel.Field(
@@ -138,37 +138,23 @@ object AvroIdlParser : Parser {
         }
 
         private fun readMatchedBlock(open: Char, close: Char): String {
-            var result = ""
+            val parts = mutableListOf<String>()
             var depth = 0
             while (pos < tokens.size) {
-                val t = tokens[pos]
-                if (t is AvroIdlToken.Symbol) {
-                    when (t.value) {
-                        open -> {
-                            depth++
-                            result += open
-                            advance()
-                        }
-                        close -> {
-                            depth--
-                            result += close
-                            advance()
-                            if (depth == 0) return result
-                        }
-                        else -> {
-                            result += t.value
-                            advance()
-                        }
+                val part = when (val t = tokens[pos]) {
+                    is AvroIdlToken.Symbol -> {
+                        if (t.value == open) depth++
+                        if (t.value == close) depth--
+                        "${t.value}"
                     }
-                } else {
-                    result += when (t) {
-                        is AvroIdlToken.Identifier -> t.value
-                        is AvroIdlToken.NumberLiteral -> t.value
-                        is AvroIdlToken.StringLiteral -> "\"${t.value}\""
-                        else -> ""
-                    }
-                    advance()
+                    is AvroIdlToken.Identifier -> t.value
+                    is AvroIdlToken.NumberLiteral -> t.value
+                    is AvroIdlToken.StringLiteral -> "\"${t.value}\""
+                    is AvroIdlToken.DocComment -> ""
                 }
+                parts += part
+                advance()
+                if (depth == 0 && part == "$close") return parts.joinToString("")
             }
             error("Unmatched bracket")
         }
@@ -198,48 +184,42 @@ object AvroIdlParser : Parser {
 
         private fun parseSingleType(): AvroModel.Type {
             val token = peekToken() ?: error("Expected type")
-            return when {
-                token is AvroIdlToken.Identifier -> when (token.value) {
-                    "array" -> {
+            if (token !is AvroIdlToken.Identifier) error("Unexpected token while parsing type: $token")
+            return when (token.value) {
+                "array" -> {
+                    advance()
+                    expectSymbol('<')
+                    val inner = parseSingleType()
+                    consumeOptionalNullable()
+                    expectSymbol('>')
+                    AvroModel.ArrayType(type = "array", items = inner)
+                }
+                "map" -> {
+                    advance()
+                    expectSymbol('<')
+                    val inner = parseSingleType()
+                    consumeOptionalNullable()
+                    expectSymbol('>')
+                    AvroModel.MapType(type = "map", values = inner)
+                }
+                "union" -> {
+                    advance()
+                    expectSymbol('{')
+                    val types = mutableListOf<AvroModel.Type>()
+                    types.add(parseSingleType())
+                    consumeOptionalNullable()
+                    while (peekSymbol(',')) {
                         advance()
-                        expectSymbol('<')
-                        val inner = parseSingleType()
-                        consumeOptionalNullable()
-                        expectSymbol('>')
-                        AvroModel.ArrayType(type = "array", items = inner)
-                    }
-                    "map" -> {
-                        advance()
-                        expectSymbol('<')
-                        val inner = parseSingleType()
-                        consumeOptionalNullable()
-                        expectSymbol('>')
-                        AvroModel.MapType(type = "map", values = inner)
-                    }
-                    "union" -> {
-                        advance()
-                        expectSymbol('{')
-                        val types = mutableListOf<AvroModel.Type>()
                         types.add(parseSingleType())
                         consumeOptionalNullable()
-                        while (peekSymbol(',')) {
-                            advance()
-                            types.add(parseSingleType())
-                            consumeOptionalNullable()
-                        }
-                        expectSymbol('}')
-                        AvroModel.UnionType(name = "", type = AvroModel.TypeList(types))
                     }
-                    "null", "boolean", "int", "long", "float", "double", "bytes", "string" -> {
-                        advance()
-                        AvroModel.SimpleType(token.value)
-                    }
-                    else -> {
-                        advance()
-                        AvroModel.SimpleType(token.value)
-                    }
+                    expectSymbol('}')
+                    AvroModel.UnionType(name = "", type = AvroModel.TypeList(types))
                 }
-                else -> error("Unexpected token while parsing type: $token")
+                else -> {
+                    advance()
+                    AvroModel.SimpleType(token.value)
+                }
             }
         }
 
@@ -312,11 +292,12 @@ object AvroIdlParser : Parser {
 
         private fun consumeDoc(): String? {
             var last: String? = null
-            while (peekToken() is AvroIdlToken.DocComment) {
-                last = (peekToken() as AvroIdlToken.DocComment).value
+            while (true) {
+                val token = peekToken()
+                if (token !is AvroIdlToken.DocComment) return last
+                last = token.value
                 advance()
             }
-            return last
         }
 
         private fun peekToken(): AvroIdlToken? = if (pos < tokens.size) tokens[pos] else null

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlParser.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlParser.kt
@@ -1,0 +1,357 @@
+package community.flock.wirespec.converter.avro
+
+import arrow.core.nonEmptyListOf
+import arrow.core.toNonEmptyListOrNull
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.converter.avro.AvroConverter.flatten
+import community.flock.wirespec.converter.common.Parser
+
+object AvroIdlParser : Parser {
+
+    data class Protocol(
+        val name: String,
+        val namespace: String?,
+        val types: List<AvroModel.Type>,
+    )
+
+    override fun parse(moduleContent: ModuleContent, strict: Boolean): AST {
+        val tokens = AvroIdlTokenizer(moduleContent.content).tokenize()
+        val protocol = ProtocolParser(tokens).parseProtocol()
+        val definitions: List<Definition> = protocol.types.flatMap { it.flatten() }
+        return AST(
+            nonEmptyListOf(
+                Module(
+                    moduleContent.fileUri,
+                    definitions.toNonEmptyListOrNull() ?: error("Cannot yield empty AST from protocol ${protocol.name}"),
+                ),
+            ),
+        )
+    }
+
+    fun parseProtocol(source: String): Protocol {
+        val tokens = AvroIdlTokenizer(source).tokenize()
+        return ProtocolParser(tokens).parseProtocol()
+    }
+
+    private class ProtocolParser(private val tokens: List<AvroIdlToken>) {
+        private var pos = 0
+
+        fun parseProtocol(): Protocol {
+            var namespace: String? = null
+            while (peekSymbol('@')) {
+                val (name, value) = parseAnnotation()
+                if (name == "namespace") namespace = value
+            }
+            expectKeyword("protocol")
+            val protocolName = expectIdentifier()
+            expectSymbol('{')
+            val types = mutableListOf<AvroModel.Type>()
+            while (!peekSymbol('}')) {
+                types.addAll(parseDeclaration())
+            }
+            expectSymbol('}')
+            if (pos != tokens.size) error("Unexpected tokens after protocol body")
+            return Protocol(protocolName, namespace, types)
+        }
+
+        private fun parseDeclaration(): List<AvroModel.Type> {
+            val doc = consumeDoc()
+            while (peekSymbol('@')) parseAnnotation()
+            consumeDoc().let { if (doc == null && it != null) Unit }
+            val keyword = peekIdentifierName()
+            return when (keyword) {
+                "record", "error" -> listOf(parseRecord(doc))
+                "enum" -> listOf(parseEnum(doc))
+                "fixed" -> {
+                    skipFixed()
+                    emptyList()
+                }
+                "import" -> {
+                    skipImport()
+                    emptyList()
+                }
+                else -> error("Unexpected token in protocol body: ${peekToken()}")
+            }
+        }
+
+        private fun parseRecord(doc: String?): AvroModel.RecordType {
+            advance()
+            val name = expectIdentifier()
+            expectSymbol('{')
+            val fields = mutableListOf<AvroModel.Field>()
+            while (!peekSymbol('}')) {
+                fields.add(parseField())
+            }
+            expectSymbol('}')
+            return AvroModel.RecordType(
+                type = "record",
+                name = name,
+                fields = fields,
+                doc = doc,
+            )
+        }
+
+        private fun parseField(): AvroModel.Field {
+            val doc = consumeDoc()
+            while (peekSymbol('@')) parseAnnotation()
+            val type = parseType()
+            val name = expectIdentifier()
+            var default: String? = null
+            if (peekSymbol('=')) {
+                advance()
+                default = parseDefaultValue()
+            }
+            expectSymbol(';')
+            return AvroModel.Field(
+                name = name,
+                type = type,
+                doc = doc,
+                default = default,
+            )
+        }
+
+        private fun parseDefaultValue(): String {
+            val token = peekToken() ?: error("Expected default value")
+            return when (token) {
+                is AvroIdlToken.StringLiteral -> {
+                    advance()
+                    token.value
+                }
+                is AvroIdlToken.NumberLiteral -> {
+                    advance()
+                    token.value
+                }
+                is AvroIdlToken.Identifier -> {
+                    advance()
+                    token.value
+                }
+                is AvroIdlToken.Symbol -> when (token.value) {
+                    '[' -> readMatchedBlock('[', ']')
+                    '{' -> readMatchedBlock('{', '}')
+                    else -> error("Unexpected symbol in default value: ${token.value}")
+                }
+                else -> error("Unexpected token in default value: $token")
+            }
+        }
+
+        private fun readMatchedBlock(open: Char, close: Char): String {
+            val sb = StringBuilder()
+            var depth = 0
+            while (pos < tokens.size) {
+                val t = tokens[pos]
+                if (t is AvroIdlToken.Symbol) {
+                    when (t.value) {
+                        open -> {
+                            depth++
+                            sb.append(open)
+                            advance()
+                        }
+                        close -> {
+                            depth--
+                            sb.append(close)
+                            advance()
+                            if (depth == 0) return sb.toString()
+                        }
+                        else -> {
+                            sb.append(t.value)
+                            advance()
+                        }
+                    }
+                } else {
+                    when (t) {
+                        is AvroIdlToken.Identifier -> sb.append(t.value)
+                        is AvroIdlToken.NumberLiteral -> sb.append(t.value)
+                        is AvroIdlToken.StringLiteral -> sb.append('"').append(t.value).append('"')
+                        else -> {}
+                    }
+                    advance()
+                }
+            }
+            error("Unmatched bracket")
+        }
+
+        private fun parseType(): AvroModel.TypeList {
+            if (peekIdentifierName() == "union") {
+                advance()
+                expectSymbol('{')
+                val types = mutableListOf<AvroModel.Type>()
+                types.add(parseSingleType())
+                consumeOptionalNullable()
+                while (peekSymbol(',')) {
+                    advance()
+                    types.add(parseSingleType())
+                    consumeOptionalNullable()
+                }
+                expectSymbol('}')
+                return AvroModel.TypeList(types)
+            }
+            val type = parseSingleType()
+            if (peekSymbol('?')) {
+                advance()
+                return AvroModel.TypeList(AvroModel.SimpleType("null"), type)
+            }
+            return AvroModel.TypeList(type)
+        }
+
+        private fun parseSingleType(): AvroModel.Type {
+            val token = peekToken() ?: error("Expected type")
+            return when {
+                token is AvroIdlToken.Identifier -> when (token.value) {
+                    "array" -> {
+                        advance()
+                        expectSymbol('<')
+                        val inner = parseSingleType()
+                        consumeOptionalNullable()
+                        expectSymbol('>')
+                        AvroModel.ArrayType(type = "array", items = inner)
+                    }
+                    "map" -> {
+                        advance()
+                        expectSymbol('<')
+                        val inner = parseSingleType()
+                        consumeOptionalNullable()
+                        expectSymbol('>')
+                        AvroModel.MapType(type = "map", values = inner)
+                    }
+                    "union" -> {
+                        advance()
+                        expectSymbol('{')
+                        val types = mutableListOf<AvroModel.Type>()
+                        types.add(parseSingleType())
+                        consumeOptionalNullable()
+                        while (peekSymbol(',')) {
+                            advance()
+                            types.add(parseSingleType())
+                            consumeOptionalNullable()
+                        }
+                        expectSymbol('}')
+                        AvroModel.UnionType(name = "", type = AvroModel.TypeList(types))
+                    }
+                    "null", "boolean", "int", "long", "float", "double", "bytes", "string" -> {
+                        advance()
+                        AvroModel.SimpleType(token.value)
+                    }
+                    else -> {
+                        advance()
+                        AvroModel.SimpleType(token.value)
+                    }
+                }
+                else -> error("Unexpected token while parsing type: $token")
+            }
+        }
+
+        private fun consumeOptionalNullable() {
+            if (peekSymbol('?')) advance()
+        }
+
+        private fun parseEnum(doc: String?): AvroModel.EnumType {
+            advance()
+            val name = expectIdentifier()
+            expectSymbol('{')
+            val symbols = mutableListOf<String>()
+            if (!peekSymbol('}')) {
+                symbols.add(expectIdentifier())
+                while (peekSymbol(',')) {
+                    advance()
+                    if (peekSymbol('}')) break
+                    symbols.add(expectIdentifier())
+                }
+            }
+            expectSymbol('}')
+            if (peekSymbol('=')) {
+                advance()
+                expectIdentifier()
+                expectSymbol(';')
+            }
+            return AvroModel.EnumType(
+                type = "enum",
+                name = name,
+                symbols = symbols,
+                doc = doc,
+            )
+        }
+
+        private fun skipFixed() {
+            advance()
+            expectIdentifier()
+            expectSymbol('(')
+            advance()
+            expectSymbol(')')
+            expectSymbol(';')
+        }
+
+        private fun skipImport() {
+            advance()
+            expectIdentifier()
+            if (peekToken() is AvroIdlToken.StringLiteral) advance()
+            expectSymbol(';')
+        }
+
+        private fun parseAnnotation(): Pair<String, String> {
+            expectSymbol('@')
+            val name = expectIdentifier()
+            expectSymbol('(')
+            val token = peekToken() ?: error("Expected annotation value")
+            val value = when (token) {
+                is AvroIdlToken.StringLiteral -> {
+                    advance()
+                    token.value
+                }
+                is AvroIdlToken.Identifier -> {
+                    advance()
+                    token.value
+                }
+                else -> error("Unexpected annotation value: $token")
+            }
+            expectSymbol(')')
+            return name to value
+        }
+
+        private fun consumeDoc(): String? {
+            var last: String? = null
+            while (peekToken() is AvroIdlToken.DocComment) {
+                last = (peekToken() as AvroIdlToken.DocComment).value
+                advance()
+            }
+            return last
+        }
+
+        private fun peekToken(): AvroIdlToken? = if (pos < tokens.size) tokens[pos] else null
+
+        private fun peekSymbol(c: Char): Boolean {
+            val t = peekToken() ?: return false
+            return t is AvroIdlToken.Symbol && t.value == c
+        }
+
+        private fun peekIdentifierName(): String? {
+            val t = peekToken() ?: return null
+            return if (t is AvroIdlToken.Identifier) t.value else null
+        }
+
+        private fun advance() {
+            pos++
+        }
+
+        private fun expectIdentifier(): String {
+            val t = peekToken() ?: error("Expected identifier, got EOF")
+            if (t !is AvroIdlToken.Identifier) error("Expected identifier, got $t")
+            advance()
+            return t.value
+        }
+
+        private fun expectKeyword(keyword: String) {
+            val t = peekToken() ?: error("Expected '$keyword', got EOF")
+            if (t !is AvroIdlToken.Identifier || t.value != keyword) error("Expected '$keyword', got $t")
+            advance()
+        }
+
+        private fun expectSymbol(c: Char) {
+            val t = peekToken() ?: error("Expected '$c', got EOF")
+            if (t !is AvroIdlToken.Symbol || t.value != c) error("Expected '$c', got $t")
+            advance()
+        }
+    }
+}

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlTokenizer.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlTokenizer.kt
@@ -1,0 +1,158 @@
+package community.flock.wirespec.converter.avro
+
+internal sealed interface AvroIdlToken {
+    val line: Int
+    val column: Int
+
+    data class Identifier(val value: String, override val line: Int, override val column: Int) : AvroIdlToken
+    data class StringLiteral(val value: String, override val line: Int, override val column: Int) : AvroIdlToken
+    data class NumberLiteral(val value: String, override val line: Int, override val column: Int) : AvroIdlToken
+    data class DocComment(val value: String, override val line: Int, override val column: Int) : AvroIdlToken
+    data class Symbol(val value: Char, override val line: Int, override val column: Int) : AvroIdlToken
+}
+
+internal class AvroIdlTokenizer(private val source: String) {
+    private var pos = 0
+    private var line = 1
+    private var column = 1
+
+    fun tokenize(): List<AvroIdlToken> {
+        val tokens = mutableListOf<AvroIdlToken>()
+        while (pos < source.length) {
+            val c = source[pos]
+            when {
+                c.isWhitespace() -> advance()
+                c == '/' && peek(1) == '*' && peek(2) == '*' -> tokens.add(readDocComment())
+                c == '/' && peek(1) == '*' -> skipBlockComment()
+                c == '/' && peek(1) == '/' -> skipLineComment()
+                c == '"' -> tokens.add(readStringLiteral())
+                c.isLetter() || c == '_' -> tokens.add(readIdentifier())
+                c.isDigit() || (c == '-' && peek(1)?.isDigit() == true) -> tokens.add(readNumber())
+                c in SYMBOL_CHARS -> {
+                    tokens.add(AvroIdlToken.Symbol(c, line, column))
+                    advance()
+                }
+                else -> error("Unexpected character '$c' at line $line column $column")
+            }
+        }
+        return tokens
+    }
+
+    private fun peek(offset: Int): Char? = if (pos + offset < source.length) source[pos + offset] else null
+
+    private fun advance() {
+        if (source[pos] == '\n') {
+            line++
+            column = 1
+        } else {
+            column++
+        }
+        pos++
+    }
+
+    private fun skipLineComment() {
+        while (pos < source.length && source[pos] != '\n') advance()
+    }
+
+    private fun skipBlockComment() {
+        advance()
+        advance()
+        while (pos < source.length) {
+            if (source[pos] == '*' && peek(1) == '/') {
+                advance()
+                advance()
+                return
+            }
+            advance()
+        }
+    }
+
+    private fun readDocComment(): AvroIdlToken.DocComment {
+        val startLine = line
+        val startColumn = column
+        advance()
+        advance()
+        advance()
+        val sb = StringBuilder()
+        while (pos < source.length) {
+            if (source[pos] == '*' && peek(1) == '/') {
+                advance()
+                advance()
+                break
+            }
+            sb.append(source[pos])
+            advance()
+        }
+        val cleaned = sb.toString()
+            .lines()
+            .joinToString("\n") { it.trim().removePrefix("*").trim() }
+            .trim()
+        return AvroIdlToken.DocComment(cleaned, startLine, startColumn)
+    }
+
+    private fun readStringLiteral(): AvroIdlToken.StringLiteral {
+        val startLine = line
+        val startColumn = column
+        advance()
+        val sb = StringBuilder()
+        while (pos < source.length && source[pos] != '"') {
+            if (source[pos] == '\\' && pos + 1 < source.length) {
+                advance()
+                when (val esc = source[pos]) {
+                    'n' -> sb.append('\n')
+                    't' -> sb.append('\t')
+                    'r' -> sb.append('\r')
+                    '"' -> sb.append('"')
+                    '\\' -> sb.append('\\')
+                    else -> sb.append(esc)
+                }
+                advance()
+            } else {
+                sb.append(source[pos])
+                advance()
+            }
+        }
+        if (pos < source.length) advance()
+        return AvroIdlToken.StringLiteral(sb.toString(), startLine, startColumn)
+    }
+
+    private fun readIdentifier(): AvroIdlToken.Identifier {
+        val startLine = line
+        val startColumn = column
+        val sb = StringBuilder()
+        while (pos < source.length) {
+            val c = source[pos]
+            if (c.isLetterOrDigit() || c == '_' || c == '.') {
+                sb.append(c)
+                advance()
+            } else {
+                break
+            }
+        }
+        return AvroIdlToken.Identifier(sb.toString(), startLine, startColumn)
+    }
+
+    private fun readNumber(): AvroIdlToken.NumberLiteral {
+        val startLine = line
+        val startColumn = column
+        val sb = StringBuilder()
+        if (source[pos] == '-') {
+            sb.append('-')
+            advance()
+        }
+        while (pos < source.length) {
+            val c = source[pos]
+            if (c.isDigit() || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-') {
+                sb.append(c)
+                advance()
+            } else {
+                break
+            }
+        }
+        return AvroIdlToken.NumberLiteral(sb.toString(), startLine, startColumn)
+    }
+
+    companion object {
+        private val SYMBOL_CHARS = setOf('{', '}', '(', ')', '[', ']', '<', '>', ',', ';', '=', '@', '?', ':')
+    }
+}

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlTokenizer.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlTokenizer.kt
@@ -1,14 +1,11 @@
 package community.flock.wirespec.converter.avro
 
 internal sealed interface AvroIdlToken {
-    val line: Int
-    val column: Int
-
-    data class Identifier(val value: String, override val line: Int, override val column: Int) : AvroIdlToken
-    data class StringLiteral(val value: String, override val line: Int, override val column: Int) : AvroIdlToken
-    data class NumberLiteral(val value: String, override val line: Int, override val column: Int) : AvroIdlToken
-    data class DocComment(val value: String, override val line: Int, override val column: Int) : AvroIdlToken
-    data class Symbol(val value: Char, override val line: Int, override val column: Int) : AvroIdlToken
+    data class Identifier(val value: String) : AvroIdlToken
+    data class StringLiteral(val value: String) : AvroIdlToken
+    data class NumberLiteral(val value: String) : AvroIdlToken
+    data class DocComment(val value: String) : AvroIdlToken
+    data class Symbol(val value: Char) : AvroIdlToken
 }
 
 internal class AvroIdlTokenizer(private val source: String) {
@@ -29,7 +26,7 @@ internal class AvroIdlTokenizer(private val source: String) {
                 c.isLetter() || c == '_' -> tokens.add(readIdentifier())
                 c.isDigit() || (c == '-' && peek(1)?.isDigit() == true) -> tokens.add(readNumber())
                 c in SYMBOL_CHARS -> {
-                    tokens.add(AvroIdlToken.Symbol(c, line, column))
+                    tokens.add(AvroIdlToken.Symbol(c))
                     advance()
                 }
                 else -> error("Unexpected character '$c' at line $line column $column")
@@ -68,8 +65,6 @@ internal class AvroIdlTokenizer(private val source: String) {
     }
 
     private fun readDocComment(): AvroIdlToken.DocComment {
-        val startLine = line
-        val startColumn = column
         advance()
         advance()
         advance()
@@ -89,18 +84,16 @@ internal class AvroIdlTokenizer(private val source: String) {
             .lines()
             .joinToString("\n") { it.trim().removePrefix("*").trim() }
             .trim()
-        return AvroIdlToken.DocComment(cleaned, startLine, startColumn)
+        return AvroIdlToken.DocComment(cleaned)
     }
 
     private fun readStringLiteral(): AvroIdlToken.StringLiteral {
-        val startLine = line
-        val startColumn = column
         advance()
-        var value = ""
+        val parts = mutableListOf<String>()
         while (pos < source.length && source[pos] != '"') {
             if (source[pos] == '\\' && pos + 1 < source.length) {
                 advance()
-                value += when (val esc = source[pos]) {
+                parts += when (val esc = source[pos]) {
                     'n' -> "\n"
                     't' -> "\t"
                     'r' -> "\r"
@@ -110,17 +103,15 @@ internal class AvroIdlTokenizer(private val source: String) {
                 }
                 advance()
             } else {
-                value += source[pos]
+                parts += "${source[pos]}"
                 advance()
             }
         }
         if (pos < source.length) advance()
-        return AvroIdlToken.StringLiteral(value, startLine, startColumn)
+        return AvroIdlToken.StringLiteral(parts.joinToString(""))
     }
 
     private fun readIdentifier(): AvroIdlToken.Identifier {
-        val startLine = line
-        val startColumn = column
         val start = pos
         while (pos < source.length) {
             val c = source[pos]
@@ -130,12 +121,10 @@ internal class AvroIdlTokenizer(private val source: String) {
                 break
             }
         }
-        return AvroIdlToken.Identifier(source.substring(start, pos), startLine, startColumn)
+        return AvroIdlToken.Identifier(source.substring(start, pos))
     }
 
     private fun readNumber(): AvroIdlToken.NumberLiteral {
-        val startLine = line
-        val startColumn = column
         val start = pos
         if (source[pos] == '-') advance()
         while (pos < source.length) {
@@ -146,7 +135,7 @@ internal class AvroIdlTokenizer(private val source: String) {
                 break
             }
         }
-        return AvroIdlToken.NumberLiteral(source.substring(start, pos), startLine, startColumn)
+        return AvroIdlToken.NumberLiteral(source.substring(start, pos))
     }
 
     companion object {

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlTokenizer.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlTokenizer.kt
@@ -73,17 +73,19 @@ internal class AvroIdlTokenizer(private val source: String) {
         advance()
         advance()
         advance()
-        val sb = StringBuilder()
+        val contentStart = pos
+        var contentEnd = pos
         while (pos < source.length) {
             if (source[pos] == '*' && peek(1) == '/') {
+                contentEnd = pos
                 advance()
                 advance()
                 break
             }
-            sb.append(source[pos])
+            contentEnd = pos + 1
             advance()
         }
-        val cleaned = sb.toString()
+        val cleaned = source.substring(contentStart, contentEnd)
             .lines()
             .joinToString("\n") { it.trim().removePrefix("*").trim() }
             .trim()
@@ -94,62 +96,57 @@ internal class AvroIdlTokenizer(private val source: String) {
         val startLine = line
         val startColumn = column
         advance()
-        val sb = StringBuilder()
+        var value = ""
         while (pos < source.length && source[pos] != '"') {
             if (source[pos] == '\\' && pos + 1 < source.length) {
                 advance()
-                when (val esc = source[pos]) {
-                    'n' -> sb.append('\n')
-                    't' -> sb.append('\t')
-                    'r' -> sb.append('\r')
-                    '"' -> sb.append('"')
-                    '\\' -> sb.append('\\')
-                    else -> sb.append(esc)
+                value += when (val esc = source[pos]) {
+                    'n' -> "\n"
+                    't' -> "\t"
+                    'r' -> "\r"
+                    '"' -> "\""
+                    '\\' -> "\\"
+                    else -> "$esc"
                 }
                 advance()
             } else {
-                sb.append(source[pos])
+                value += source[pos]
                 advance()
             }
         }
         if (pos < source.length) advance()
-        return AvroIdlToken.StringLiteral(sb.toString(), startLine, startColumn)
+        return AvroIdlToken.StringLiteral(value, startLine, startColumn)
     }
 
     private fun readIdentifier(): AvroIdlToken.Identifier {
         val startLine = line
         val startColumn = column
-        val sb = StringBuilder()
+        val start = pos
         while (pos < source.length) {
             val c = source[pos]
             if (c.isLetterOrDigit() || c == '_' || c == '.') {
-                sb.append(c)
                 advance()
             } else {
                 break
             }
         }
-        return AvroIdlToken.Identifier(sb.toString(), startLine, startColumn)
+        return AvroIdlToken.Identifier(source.substring(start, pos), startLine, startColumn)
     }
 
     private fun readNumber(): AvroIdlToken.NumberLiteral {
         val startLine = line
         val startColumn = column
-        val sb = StringBuilder()
-        if (source[pos] == '-') {
-            sb.append('-')
-            advance()
-        }
+        val start = pos
+        if (source[pos] == '-') advance()
         while (pos < source.length) {
             val c = source[pos]
             if (c.isDigit() || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-') {
-                sb.append(c)
                 advance()
             } else {
                 break
             }
         }
-        return AvroIdlToken.NumberLiteral(sb.toString(), startLine, startColumn)
+        return AvroIdlToken.NumberLiteral(source.substring(start, pos), startLine, startColumn)
     }
 
     companion object {

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroJsonEmitter.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroJsonEmitter.kt
@@ -17,7 +17,7 @@ import community.flock.wirespec.compiler.utils.Logger
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-object AvroEmitter : Emitter {
+object AvroJsonEmitter : Emitter {
 
     override val extension = FileExtension.JSON
 

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroJsonParser.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroJsonParser.kt
@@ -13,7 +13,7 @@ import community.flock.wirespec.converter.avro.AvroConverter.flatten
 import community.flock.wirespec.converter.common.Parser
 import kotlinx.serialization.json.Json
 
-object AvroParser : Parser {
+object AvroJsonParser : Parser {
 
     override fun parse(moduleContent: ModuleContent, strict: Boolean): AST {
         val json = Json {

--- a/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitterTest.kt
+++ b/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitterTest.kt
@@ -1,0 +1,316 @@
+package community.flock.wirespec.converter.avro
+
+import arrow.core.nonEmptyListOf
+import community.flock.wirespec.compiler.core.FileUri
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.core.ParseContext
+import community.flock.wirespec.compiler.core.WirespecSpec
+import community.flock.wirespec.compiler.core.parse
+import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.compiler.test.CompileChannelTest
+import community.flock.wirespec.compiler.test.CompileEnumTest
+import community.flock.wirespec.compiler.test.CompileFullEndpointTest
+import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
+import community.flock.wirespec.compiler.test.CompileRefinedTest
+import community.flock.wirespec.compiler.test.CompileTypeTest
+import community.flock.wirespec.compiler.test.CompileUnionTest
+import community.flock.wirespec.compiler.utils.NoLogger
+import community.flock.wirespec.compiler.utils.noLogger
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldStartWith
+import kotlin.test.Test
+
+class AvroIdlEmitterTest {
+
+    private fun parse(source: String): AST = object : ParseContext, NoLogger {
+        override val spec = WirespecSpec
+    }.parse(nonEmptyListOf(ModuleContent(FileUri("test.ws"), source))).getOrNull() ?: error("Parsing failed.")
+
+    @Test
+    fun emitsProtocolWrapper() {
+        val ast = parse("type Pet { name: String }")
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "PetProtocol")
+        output shouldStartWith "protocol PetProtocol {\n"
+        output.trim().endsWith("}") shouldBe true
+    }
+
+    @Test
+    fun emitsSimpleRecord() {
+        val ast = parse("type Pet { name: String, age: Integer }")
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "record Pet {"
+        output shouldContain "string name;"
+        output shouldContain "long age;"
+    }
+
+    @Test
+    fun emitsAllPrimitives() {
+        val ast = parse(
+            """
+            type AllPrimitives {
+                s: String,
+                i: Integer,
+                n: Number,
+                b: Boolean
+            }
+            """.trimIndent(),
+        )
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "string s;"
+        output shouldContain "long i;"
+        output shouldContain "double n;"
+        output shouldContain "boolean b;"
+    }
+
+    @Test
+    fun emitsNullableFieldAsUnionWithNull() {
+        val ast = parse("type Pet { name: String, nickname: String? }")
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "union { null, string } nickname;"
+        output shouldContain "string name;"
+    }
+
+    @Test
+    fun emitsArrayField() {
+        val ast = parse("type Pet { tags: String[] }")
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "array<string> tags;"
+    }
+
+    @Test
+    fun emitsNullableArrayField() {
+        val ast = parse("type Pet { tags: String[]? }")
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "union { null, array<string> } tags;"
+    }
+
+    @Test
+    fun emitsCustomTypeReference() {
+        val ast = parse(
+            """
+            type Address { street: String }
+            type Pet { home: Address }
+            """.trimIndent(),
+        )
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "record Address {"
+        output shouldContain "Address home;"
+    }
+
+    @Test
+    fun emitsNullableCustomReference() {
+        val ast = parse(
+            """
+            type Address { street: String }
+            type Pet { home: Address? }
+            """.trimIndent(),
+        )
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "union { null, Address } home;"
+    }
+
+    @Test
+    fun emitsEnum() {
+        val ast = parse(
+            """
+            enum Status { PUBLIC, PRIVATE }
+            type Doc { status: Status }
+            """.trimIndent(),
+        )
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "enum Status {"
+        output shouldContain "PUBLIC, PRIVATE"
+    }
+
+    @Test
+    fun emitsUnionAsWrapperRecord() {
+        val ast = parse(
+            """
+            type Left { left: String }
+            type Right { right: String }
+            type Either = Left | Right
+            type Doc { value: Either }
+            """.trimIndent(),
+        )
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "record Either {"
+        output shouldContain "union {"
+        output shouldContain "Left"
+        output shouldContain "Right"
+    }
+
+    @Test
+    fun emitTodoWs() {
+        val source = """
+            enum Status {
+                PUBLIC,
+                PRIVATE
+            }
+
+            type Todo {
+                id: String,
+                name: String?,
+                done: Boolean,
+                tags: String[],
+                status: Status
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "TodoProtocol")
+        output shouldStartWith "protocol TodoProtocol {\n"
+        output shouldContain "enum Status {"
+        output shouldContain "record Todo {"
+        output shouldContain "string id;"
+        output shouldContain "union { null, string } name;"
+        output shouldContain "boolean done;"
+        output shouldContain "array<string> tags;"
+        output shouldContain "Status status;"
+    }
+
+    @Test
+    fun emitFromCompileMinimalEndpointTest() {
+        val result = CompileMinimalEndpointTest.compiler {
+            AvroIdlEmitter
+        }
+        val output = result.shouldBeRight()
+        output shouldContain "protocol"
+        output shouldContain "record TodoDto {"
+        output shouldContain "string description;"
+    }
+
+    @Test
+    fun emitFromCompileFullEndpointTest() {
+        val result = CompileFullEndpointTest.compiler {
+            AvroIdlEmitter
+        }
+        val output = result.shouldBeRight()
+        output shouldContain "record PotentialTodoDto {"
+        output shouldContain "record Token {"
+        output shouldContain "record TodoDto {"
+        output shouldContain "record Error {"
+        output shouldContain "string name;"
+        output shouldContain "boolean done;"
+        output shouldContain "long code;"
+    }
+
+    @Test
+    fun emitFromCompileEnumTest() {
+        val result = CompileEnumTest.compiler {
+            AvroIdlEmitter
+        }
+        val output = result.shouldBeRight()
+        output shouldContain "enum MyAwesomeEnum {"
+        output shouldContain "ONE"
+        output shouldContain "Two"
+        output shouldContain "THREE_MORE"
+    }
+
+    @Test
+    fun emitFromCompileChannelTestProducesEmptyProtocol() {
+        val result = CompileChannelTest.compiler {
+            AvroIdlEmitter
+        }
+        val output = result.shouldBeRight()
+        output shouldStartWith "protocol"
+        output shouldNotContain "record"
+        output shouldNotContain "enum"
+    }
+
+    @Test
+    fun emitFromCompileRefinedTestRendersRefinedAsComment() {
+        val result = CompileRefinedTest.compiler {
+            AvroIdlEmitter
+        }
+        val output = result.shouldBeRight()
+        output shouldContain "// refined"
+    }
+
+    @Test
+    fun emitFromCompileUnionTest() {
+        val result = CompileUnionTest.compiler {
+            AvroIdlEmitter
+        }
+        val output = result.shouldBeRight()
+        output shouldContain "record UserAccount {"
+        output shouldContain "UserAccountPassword"
+        output shouldContain "UserAccountToken"
+        output shouldContain "record User {"
+    }
+
+    @Test
+    fun emitFromCompileTypeTest() {
+        val result = CompileTypeTest.compiler { AvroIdlEmitter }
+        val output = result.shouldBeRight()
+        output shouldContain "record Request {"
+        output shouldContain "array<string> params;"
+        output shouldContain "map<string> headers;"
+        output shouldContain "union { null, string } BODY_TYPE;"
+        output shouldContain "union { null, map<array<string>> } body;"
+    }
+
+    @Test
+    fun emitWithDictField() {
+        val ast = parse("type Mappy { entries: { String } }")
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "map<string> entries;"
+    }
+
+    @Test
+    fun emitWithDictOfArrayField() {
+        val ast = parse("type Outer { values: { String[] } }")
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "map<array<string>> values;"
+    }
+
+    @Test
+    fun emitWithIntegerPrecisionLong() {
+        val ast = parse("type X { id: Integer }")
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "long id;"
+    }
+
+    @Test
+    fun roundTripParseEmitParseProducesEqualStructure() {
+        val source = """
+            protocol Test {
+                record User {
+                    string id;
+                    union { null, string } nickname;
+                    int age;
+                    array<string> tags;
+                    map<int> ratings;
+                }
+            }
+        """.trimIndent()
+
+        val ast1 = AvroIdlParser.parse(ModuleContent(FileUri("test.ws"), source), true)
+        val emitted = AvroIdlEmitter.emit(ast1.modules.first(), "Test")
+        val ast2 = AvroIdlParser.parse(ModuleContent(FileUri("test.ws"), emitted), true)
+
+        ast1.modules.first().statements.toList().map { it.identifier.value } shouldBe
+            ast2.modules.first().statements.toList().map { it.identifier.value }
+    }
+
+    @Test
+    fun emitterUsesAvroIdlExtension() {
+        AvroIdlEmitter.extension shouldBe community.flock.wirespec.compiler.core.emit.FileExtension.AvroIdl
+        AvroIdlEmitter.extension.value shouldBe "avdl"
+    }
+
+    @Test
+    fun emitDerivesProtocolNameFromFileUri() {
+        val ast = parse("type Pet { name: String }")
+        val moduleWithUri = community.flock.wirespec.compiler.core.parse.ast.Module(
+            fileUri = FileUri("path/to/myfile.ws"),
+            statements = ast.modules.first().statements,
+        )
+        val output = AvroIdlEmitter.emit(
+            community.flock.wirespec.compiler.core.parse.ast.Root(nonEmptyListOf(moduleWithUri)),
+            noLogger,
+        )
+        output.first().result shouldContain "protocol MyfileProtocol {"
+    }
+}

--- a/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroIdlParserTest.kt
+++ b/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroIdlParserTest.kt
@@ -1,0 +1,714 @@
+package community.flock.wirespec.converter.avro
+
+import community.flock.wirespec.compiler.core.FileUri
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Type
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AvroIdlParserTest {
+
+    private fun parse(source: String) = AvroIdlParser.parse(ModuleContent(FileUri("test.ws"), source), true)
+
+    private fun loadResource(name: String): String = SystemFileSystem.source(Path("src/commonTest/resources/$name")).buffered().readString()
+
+    @Test
+    fun parseSimpleProtocol() {
+        val ast = parse(loadResource("simple.avdl"))
+        val statements = ast.modules.flatMap { it.statements }.toList()
+        statements.size shouldBe 1
+        val pet = statements.first()
+        pet.shouldBeInstanceOf<Type>()
+        pet.identifier.value shouldBe "Pet"
+        pet.shape.value.size shouldBe 3
+        pet.shape.value.map { it.identifier.value } shouldContainExactly listOf("name", "age", "vaccinated")
+    }
+
+    @Test
+    fun parseSimpleProtocolFieldTypes() {
+        val ast = parse(loadResource("simple.avdl"))
+        val pet = ast.modules.first().statements.first() as Type
+        pet.shape.value[0].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.String(null),
+            isNullable = false,
+        )
+        pet.shape.value[1].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Integer(Reference.Primitive.Type.Precision.P32, null),
+            isNullable = false,
+        )
+        pet.shape.value[2].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Boolean,
+            isNullable = false,
+        )
+    }
+
+    @Test
+    fun parseInlineSimpleProtocol() {
+        val source = """
+            protocol Test {
+                record Item {
+                    long id;
+                    double price;
+                    bytes payload;
+                    float ratio;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val item = ast.modules.first().statements.first() as Type
+        item.shape.value[0].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Integer(Reference.Primitive.Type.Precision.P64, null),
+            isNullable = false,
+        )
+        item.shape.value[1].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Number(Reference.Primitive.Type.Precision.P64, null),
+            isNullable = false,
+        )
+        item.shape.value[2].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Bytes,
+            isNullable = false,
+        )
+        item.shape.value[3].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Number(Reference.Primitive.Type.Precision.P32, null),
+            isNullable = false,
+        )
+    }
+
+    @Test
+    fun parseNullableUnion() {
+        val ast = parse(loadResource("nullable.avdl"))
+        val user = ast.modules.first().statements.first() as Type
+        user.shape.value.map { it.identifier.value } shouldContainExactly listOf("id", "nickname", "email", "age")
+
+        user.shape.value[0].reference.isNullable shouldBe false
+        user.shape.value[1].reference.isNullable shouldBe true
+        user.shape.value[2].reference.isNullable shouldBe true
+        user.shape.value[3].reference.isNullable shouldBe true
+
+        user.shape.value[1].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.String(null),
+            isNullable = true,
+        )
+        user.shape.value[3].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Integer(Reference.Primitive.Type.Precision.P32, null),
+            isNullable = true,
+        )
+    }
+
+    @Test
+    fun parseQuestionMarkSyntax() {
+        val source = """
+            protocol Test {
+                record Profile {
+                    string? bio;
+                    int? followers;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val profile = ast.modules.first().statements.first() as Type
+        profile.shape.value.forEach { it.reference.isNullable shouldBe true }
+    }
+
+    @Test
+    fun parseArrayAndMap() {
+        val ast = parse(loadResource("collections.avdl"))
+        val product = ast.modules.first().statements.first() as Type
+        product.shape.value[1].reference shouldBe Reference.Iterable(
+            reference = Reference.Primitive(type = Reference.Primitive.Type.String(null), isNullable = false),
+            isNullable = false,
+        )
+        product.shape.value[2].reference shouldBe Reference.Dict(
+            reference = Reference.Primitive(
+                type = Reference.Primitive.Type.Integer(Reference.Primitive.Type.Precision.P32, null),
+                isNullable = false,
+            ),
+            isNullable = false,
+        )
+    }
+
+    @Test
+    fun parseNestedArrayOfArray() {
+        val ast = parse(loadResource("collections.avdl"))
+        val product = ast.modules.first().statements.first() as Type
+        product.shape.value[3].reference shouldBe Reference.Iterable(
+            reference = Reference.Iterable(
+                reference = Reference.Primitive(
+                    type = Reference.Primitive.Type.String(null),
+                    isNullable = false,
+                ),
+                isNullable = false,
+            ),
+            isNullable = false,
+        )
+    }
+
+    @Test
+    fun parseMapOfArray() {
+        val ast = parse(loadResource("collections.avdl"))
+        val product = ast.modules.first().statements.first() as Type
+        product.shape.value[4].reference shouldBe Reference.Dict(
+            reference = Reference.Iterable(
+                reference = Reference.Primitive(
+                    type = Reference.Primitive.Type.String(null),
+                    isNullable = false,
+                ),
+                isNullable = false,
+            ),
+            isNullable = false,
+        )
+    }
+
+    @Test
+    fun parseEnums() {
+        val ast = parse(loadResource("enums.avdl"))
+        val statements = ast.modules.flatMap { it.statements }.toList()
+        val enums = statements.filterIsInstance<Enum>()
+        enums.size shouldBe 2
+        val color = enums.find { it.identifier.value == "Color" }!!
+        color.entries shouldBe setOf("RED", "GREEN", "BLUE")
+        val priority = enums.find { it.identifier.value == "Priority" }!!
+        priority.entries shouldBe setOf("LOW", "MEDIUM", "HIGH")
+    }
+
+    @Test
+    fun parseEnumReferenceFields() {
+        val ast = parse(loadResource("enums.avdl"))
+        val task = ast.modules.flatMap { it.statements }.toList().filterIsInstance<Type>()
+            .find { it.identifier.value == "Task" }!!
+        task.shape.value[1].reference shouldBe Reference.Custom("Color", isNullable = false)
+        task.shape.value[2].reference shouldBe Reference.Custom("Priority", isNullable = false)
+    }
+
+    @Test
+    fun parseExampleProtocol() {
+        val ast = parse(loadResource("example.avdl"))
+        val statements = ast.modules.flatMap { it.statements }.toList()
+        val names = statements.map { it.identifier.value }
+        names shouldContain "OAuthStatus"
+        names shouldContain "ToDoStatus"
+        names shouldContain "EmailAddress"
+        names shouldContain "TwitterAccount"
+        names shouldContain "ToDoItem"
+        names shouldContain "User"
+    }
+
+    @Test
+    fun parseExampleProtocolUserFields() {
+        val ast = parse(loadResource("example.avdl"))
+        val user = ast.modules.flatMap { it.statements }.toList()
+            .filterIsInstance<Type>().find { it.identifier.value == "User" }!!
+        user.shape.value.map { it.identifier.value } shouldContainExactly listOf(
+            "id",
+            "username",
+            "passwordHash",
+            "signupDate",
+            "emailAddresses",
+            "twitterAccounts",
+            "toDoItems",
+        )
+
+        user.shape.value[4].reference shouldBe Reference.Iterable(
+            reference = Reference.Custom("EmailAddress", isNullable = false),
+            isNullable = false,
+        )
+    }
+
+    @Test
+    fun parseExampleProtocolEmailAddressNullableField() {
+        val ast = parse(loadResource("example.avdl"))
+        val email = ast.modules.flatMap { it.statements }.toList()
+            .filterIsInstance<Type>().find { it.identifier.value == "EmailAddress" }!!
+        val dateBounced = email.shape.value.find { it.identifier.value == "dateBounced" }!!
+        dateBounced.reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Integer(Reference.Primitive.Type.Precision.P64, null),
+            isNullable = true,
+        )
+    }
+
+    @Test
+    fun parseRecursiveRecord() {
+        val source = """
+            protocol Recursion {
+                record Node {
+                    string name;
+                    array<Node> children;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val node = ast.modules.first().statements.first() as Type
+        node.shape.value[1].reference shouldBe Reference.Iterable(
+            reference = Reference.Custom("Node", isNullable = false),
+            isNullable = false,
+        )
+    }
+
+    @Test
+    fun parseFieldWithDefaultValue() {
+        val source = """
+            protocol Defaults {
+                record Settings {
+                    boolean autosave = true;
+                    int retries = 3;
+                    string name = "anon";
+                    array<string> tags = [];
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val settings = ast.modules.first().statements.first() as Type
+        settings.shape.value.size shouldBe 4
+        settings.shape.value.map { it.identifier.value } shouldContainExactly listOf(
+            "autosave",
+            "retries",
+            "name",
+            "tags",
+        )
+    }
+
+    @Test
+    fun parseDocComments() {
+        val source = """
+            protocol DocTest {
+                /** A user record */
+                record User {
+                    /** unique id */
+                    string id;
+                }
+            }
+        """.trimIndent()
+        shouldNotThrow<Exception> { parse(source) }
+    }
+
+    @Test
+    fun parseLineComments() {
+        val source = """
+            // top-level comment
+            protocol Test {
+                record A { // inline comment
+                    string id;
+                    // another comment
+                    int value;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val a = ast.modules.first().statements.first() as Type
+        a.shape.value.size shouldBe 2
+    }
+
+    @Test
+    fun parseBlockComments() {
+        val source = """
+            /* block comment */
+            protocol Test {
+                /* another block */
+                record A {
+                    string id;
+                }
+            }
+        """.trimIndent()
+        shouldNotThrow<Exception> { parse(source) }
+    }
+
+    @Test
+    fun parseAnnotationsOnFieldsAreIgnored() {
+        val source = """
+            protocol Test {
+                record A {
+                    @order("ascending") string id;
+                    int value;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val a = ast.modules.first().statements.first() as Type
+        a.shape.value.size shouldBe 2
+    }
+
+    @Test
+    fun parseProtocolNamespaceAnnotation() {
+        val source = """
+            @namespace("com.example.test")
+            protocol AnnotatedProtocol {
+                record A {
+                    string id;
+                }
+            }
+        """.trimIndent()
+        val protocol = AvroIdlParser.parseProtocol(source)
+        protocol.namespace shouldBe "com.example.test"
+        protocol.name shouldBe "AnnotatedProtocol"
+    }
+
+    @Test
+    fun parseEmptyProtocolFails() {
+        val source = """
+            protocol Empty {
+            }
+        """.trimIndent()
+        shouldThrow<Exception> {
+            parse(source)
+        }
+    }
+
+    @Test
+    fun parseMissingProtocolKeywordFails() {
+        val source = """
+            record A {
+                string id;
+            }
+        """.trimIndent()
+        shouldThrow<Exception> {
+            parse(source)
+        }
+    }
+
+    @Test
+    fun parseUnclosedBraceFails() {
+        val source = """
+            protocol Test {
+                record A {
+                    string id;
+        """.trimIndent()
+        shouldThrow<Exception> {
+            parse(source)
+        }
+    }
+
+    @Test
+    fun parseInvalidPrimitiveTreatedAsCustom() {
+        val source = """
+            protocol Test {
+                record A {
+                    SomeUnknownType field;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val a = ast.modules.first().statements.first() as Type
+        a.shape.value[0].reference shouldBe Reference.Custom("SomeUnknownType", isNullable = false)
+    }
+
+    @Test
+    fun parseFixedTypeIsSkipped() {
+        val source = """
+            protocol Test {
+                fixed Md5(16);
+                record A {
+                    string id;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val statements = ast.modules.flatMap { it.statements }.toList()
+        statements.size shouldBe 1
+        statements.first().identifier.value shouldBe "A"
+    }
+
+    @Test
+    fun parseImportIsSkipped() {
+        val source = """
+            protocol Test {
+                import schema "other.avsc";
+                record A {
+                    string id;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val statements = ast.modules.flatMap { it.statements }.toList()
+        statements.size shouldBe 1
+    }
+
+    @Test
+    fun parseCustomerProtocol() {
+        val ast = parse(loadResource("customer.avdl"))
+        val statements = ast.modules.flatMap { it.statements }.toList()
+        val customer = statements.filterIsInstance<Type>().find { it.identifier.value == "Customer" }!!
+        customer.shape.value.size shouldBe 7
+        customer.shape.value.last().reference shouldBe Reference.Custom("Address", isNullable = false)
+    }
+
+    @Test
+    fun parseUnionWithMultipleTypes() {
+        val source = """
+            protocol Test {
+                record Wrapper {
+                    union { null, string, int } value;
+                }
+            }
+        """.trimIndent()
+        // Wirespec converter rejects unions of multiple primitive types in a single field
+        shouldThrow<Exception> { parse(source) }
+            .message shouldBe "Cannot have multiple SimpleTypes in Union"
+    }
+
+    @Test
+    fun parseMultipleProtocolsNotSupported() {
+        val source = """
+            protocol One {
+                record A { string id; }
+            }
+            protocol Two {
+                record B { string id; }
+            }
+        """.trimIndent()
+        shouldThrow<Exception> { parse(source) }
+    }
+
+    @Test
+    fun parseFieldWithoutSemicolonFails() {
+        val source = """
+            protocol Test {
+                record A {
+                    string id
+                }
+            }
+        """.trimIndent()
+        shouldThrow<Exception> { parse(source) }
+    }
+
+    @Test
+    fun parseEnumWithSingleSymbol() {
+        val source = """
+            protocol Test {
+                enum One {
+                    SOLE
+                }
+                record A {
+                    One value;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val statements = ast.modules.flatMap { it.statements }.toList()
+        val enum = statements.filterIsInstance<Enum>().first()
+        enum.entries shouldBe setOf("SOLE")
+    }
+
+    @Test
+    fun parseEnumWithTrailingComma() {
+        val source = """
+            protocol Test {
+                enum Trailing {
+                    A, B, C,
+                }
+                record R {
+                    Trailing value;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val enum = ast.modules.flatMap { it.statements }.toList().filterIsInstance<Enum>().first()
+        enum.entries shouldBe setOf("A", "B", "C")
+    }
+
+    @Test
+    fun parseFullExpectedTypeStructure() {
+        val ast = parse(loadResource("simple.avdl"))
+        val expected = Type(
+            comment = null,
+            annotations = emptyList(),
+            identifier = DefinitionIdentifier("Pet"),
+            extends = emptyList(),
+            shape = Type.Shape(
+                listOf(
+                    Field(
+                        identifier = FieldIdentifier("name"),
+                        annotations = emptyList(),
+                        reference = Reference.Primitive(
+                            type = Reference.Primitive.Type.String(null),
+                            isNullable = false,
+                        ),
+                    ),
+                    Field(
+                        identifier = FieldIdentifier("age"),
+                        annotations = emptyList(),
+                        reference = Reference.Primitive(
+                            type = Reference.Primitive.Type.Integer(Reference.Primitive.Type.Precision.P32, null),
+                            isNullable = false,
+                        ),
+                    ),
+                    Field(
+                        identifier = FieldIdentifier("vaccinated"),
+                        annotations = emptyList(),
+                        reference = Reference.Primitive(
+                            type = Reference.Primitive.Type.Boolean,
+                            isNullable = false,
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertEquals(expected, ast.modules.first().statements.first())
+    }
+
+    @Test
+    fun parseHandlesWhitespaceAndNewlines() {
+        val source = "protocol  T  {\n\nrecord    A   {\n  string\n  id\n  ;\n}\n}\n"
+        shouldNotThrow<Exception> { parse(source) }
+    }
+
+    @Test
+    fun parseHandlesCRLFLineEndings() {
+        val source = "protocol T {\r\n  record A {\r\n    string id;\r\n  }\r\n}\r\n"
+        val ast = parse(source)
+        val a = ast.modules.first().statements.first() as Type
+        a.shape.value.size shouldBe 1
+    }
+
+    @Test
+    fun tokenizerHandlesEscapedStrings() {
+        val tokens = AvroIdlTokenizer("\"hello\\nworld\"").tokenize()
+        tokens.size shouldBe 1
+        val literal = tokens.first() as AvroIdlToken.StringLiteral
+        literal.value shouldBe "hello\nworld"
+    }
+
+    @Test
+    fun tokenizerSkipsBlockComments() {
+        val tokens = AvroIdlTokenizer("/* this is a block comment */ identifier").tokenize()
+        tokens.size shouldBe 1
+        (tokens.first() as AvroIdlToken.Identifier).value shouldBe "identifier"
+    }
+
+    @Test
+    fun tokenizerSkipsLineComments() {
+        val tokens = AvroIdlTokenizer("foo // bar\nbaz").tokenize()
+        tokens.map { (it as AvroIdlToken.Identifier).value } shouldContainExactly listOf("foo", "baz")
+    }
+
+    @Test
+    fun tokenizerCapturesDocComments() {
+        val tokens = AvroIdlTokenizer("/** documentation */ id").tokenize()
+        val doc = tokens.first() as AvroIdlToken.DocComment
+        doc.value shouldBe "documentation"
+    }
+
+    @Test
+    fun tokenizerCapturesMultilineDocComments() {
+        val tokens = AvroIdlTokenizer(
+            """
+            /**
+             * line one
+             * line two
+             */
+            id
+            """.trimIndent(),
+        ).tokenize()
+        val doc = tokens.first() as AvroIdlToken.DocComment
+        assertTrue(doc.value.contains("line one"))
+        assertTrue(doc.value.contains("line two"))
+    }
+
+    @Test
+    fun tokenizerHandlesNumbers() {
+        val tokens = AvroIdlTokenizer("42 -7 3.14 1e10").tokenize()
+        tokens.size shouldBe 4
+        tokens.forEach { it.shouldBeInstanceOf<AvroIdlToken.NumberLiteral>() }
+    }
+
+    @Test
+    fun tokenizerHandlesAllSymbols() {
+        val tokens = AvroIdlTokenizer("{ } ( ) [ ] < > , ; = @ ?").tokenize()
+        tokens.size shouldBe 13
+        tokens.forEach { it.shouldBeInstanceOf<AvroIdlToken.Symbol>() }
+    }
+
+    @Test
+    fun parseFloatAndDoublePrimitives() {
+        val source = """
+            protocol Test {
+                record A {
+                    float a;
+                    double b;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val a = ast.modules.first().statements.first() as Type
+        a.shape.value[0].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Number(Reference.Primitive.Type.Precision.P32, null),
+            isNullable = false,
+        )
+        a.shape.value[1].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Number(Reference.Primitive.Type.Precision.P64, null),
+            isNullable = false,
+        )
+    }
+
+    @Test
+    fun parseIntAndLongPrimitives() {
+        val source = """
+            protocol Test {
+                record A {
+                    int a;
+                    long b;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val a = ast.modules.first().statements.first() as Type
+        a.shape.value[0].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Integer(Reference.Primitive.Type.Precision.P32, null),
+            isNullable = false,
+        )
+        a.shape.value[1].reference shouldBe Reference.Primitive(
+            type = Reference.Primitive.Type.Integer(Reference.Primitive.Type.Precision.P64, null),
+            isNullable = false,
+        )
+    }
+
+    @Test
+    fun parseRecordReferencingAnotherRecord() {
+        val source = """
+            protocol Test {
+                record Inner {
+                    string id;
+                }
+                record Outer {
+                    Inner inner;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val statements = ast.modules.flatMap { it.statements }.toList()
+        val outer = statements.filterIsInstance<Type>().find { it.identifier.value == "Outer" }!!
+        outer.shape.value[0].reference shouldBe Reference.Custom("Inner", isNullable = false)
+    }
+
+    @Test
+    fun parseErrorKeywordTreatedAsRecord() {
+        val source = """
+            protocol Test {
+                error MyError {
+                    string message;
+                }
+                record A {
+                    MyError err;
+                }
+            }
+        """.trimIndent()
+        val ast = parse(source)
+        val statements = ast.modules.flatMap { it.statements }.toList()
+        statements.any { it.identifier.value == "MyError" } shouldBe true
+    }
+}

--- a/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroJsonEmitterTest.kt
+++ b/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroJsonEmitterTest.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.json.Json
 import kotlin.test.Ignore
 import kotlin.test.Test
 
-class AvroEmitterTest {
+class AvroJsonEmitterTest {
 
     private val json = Json {
         prettyPrint = true
@@ -43,7 +43,7 @@ class AvroEmitterTest {
         val text = SystemFileSystem.source(path).buffered().readString()
 
         val ast = parse(text)
-        val actual = AvroEmitter.emit(ast.modules.first()).let { json.encodeToString(it) }
+        val actual = AvroJsonEmitter.emit(ast.modules.first()).let { json.encodeToString(it) }
         val expected =
             // language=json
             """
@@ -131,8 +131,8 @@ class AvroEmitterTest {
         val path = Path("src/commonTest/resources/example.avsc")
         val text = SystemFileSystem.source(path).buffered().readString()
 
-        val ast = AvroParser.parse(ModuleContent(FileUri("test.ws"), text), true)
-        val actual = AvroEmitter.emit(ast.modules.first()).let { json.encodeToString(it) }
+        val ast = AvroJsonParser.parse(ModuleContent(FileUri("test.ws"), text), true)
+        val actual = AvroJsonEmitter.emit(ast.modules.first()).let { json.encodeToString(it) }
 
         val expected =
             // language=json
@@ -435,7 +435,7 @@ class AvroEmitterTest {
     @Test
     fun compileFullEndpointTest() {
         val result = CompileFullEndpointTest.compiler {
-            AvroEmitter
+            AvroJsonEmitter
         }
         val expect =
             //language=json
@@ -505,7 +505,7 @@ class AvroEmitterTest {
     @Test
     fun compileMinimalEndpointTest() {
         val result = CompileMinimalEndpointTest.compiler {
-            AvroEmitter
+            AvroJsonEmitter
         }
         val expect =
             //language=json
@@ -529,7 +529,7 @@ class AvroEmitterTest {
     @Test
     fun compileChannelTest() {
         val result = CompileChannelTest.compiler {
-            AvroEmitter
+            AvroJsonEmitter
         }
         val expect =
             //language=json
@@ -542,7 +542,7 @@ class AvroEmitterTest {
     @Test
     fun compileEnumTest() {
         val result = CompileEnumTest.compiler {
-            AvroEmitter
+            AvroJsonEmitter
         }
         val expect =
             //language=json
@@ -571,7 +571,7 @@ class AvroEmitterTest {
     @Test
     fun compileRefinedTest() {
         val result = CompileRefinedTest.compiler {
-            AvroEmitter
+            AvroJsonEmitter
         }
         val expect =
             //language=json
@@ -584,7 +584,7 @@ class AvroEmitterTest {
     @Test
     fun compileUnionTest() {
         val result = CompileUnionTest.compiler {
-            AvroEmitter
+            AvroJsonEmitter
         }
         val expect =
             //language=json
@@ -642,7 +642,7 @@ class AvroEmitterTest {
 
     @Test
     fun compileTypeTest() {
-        val result = CompileTypeTest.compiler { AvroEmitter }
+        val result = CompileTypeTest.compiler { AvroJsonEmitter }
         val expect =
             //language=json
             """

--- a/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroJsonParserTest.kt
+++ b/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroJsonParserTest.kt
@@ -18,14 +18,14 @@ import kotlinx.io.readString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class AvroParserTest {
+class AvroJsonParserTest {
 
     @Test
     fun testCustomer() {
         val path = Path("src/commonTest/resources/customer.avsc")
         val resource = SystemFileSystem.source(path).buffered().readString()
 
-        AvroParser.parse(ModuleContent(FileUri("test.ws"), resource), true)
+        AvroJsonParser.parse(ModuleContent(FileUri("test.ws"), resource), true)
     }
 
     @Test
@@ -34,7 +34,7 @@ class AvroParserTest {
         val resource = SystemFileSystem.source(path).buffered().readString()
 
         shouldThrow<Exception> {
-            AvroParser.parse(ModuleContent(FileUri("test.ws"), resource), true)
+            AvroJsonParser.parse(ModuleContent(FileUri("test.ws"), resource), true)
         }.message shouldBe "Cannot have multiple SimpleTypes in Union"
     }
 
@@ -44,7 +44,7 @@ class AvroParserTest {
         val resource = SystemFileSystem.source(path).buffered().readString()
 
         shouldNotThrow<Exception> {
-            AvroParser.parse(ModuleContent(FileUri("test.ws"), resource), true)
+            AvroJsonParser.parse(ModuleContent(FileUri("test.ws"), resource), true)
         }
     }
 
@@ -53,7 +53,7 @@ class AvroParserTest {
         val path = Path("src/commonTest/resources/example.avsc")
         val resource = SystemFileSystem.source(path).buffered().readString()
 
-        val ast = AvroParser.parse(ModuleContent(FileUri("test.ws"), resource), true)
+        val ast = AvroJsonParser.parse(ModuleContent(FileUri("test.ws"), resource), true)
 
         assertEquals(
             listOf("User", "EmailAddress", "TwitterAccount", "OAuthStatus", "ToDoItem", "ToDoStatus", "User"),

--- a/src/converter/avro/src/commonTest/resources/collections.avdl
+++ b/src/converter/avro/src/commonTest/resources/collections.avdl
@@ -1,0 +1,9 @@
+protocol CollectionsProtocol {
+    record Product {
+        string id;
+        array<string> tags;
+        map<int> ratings;
+        array<array<string>> nestedTags;
+        map<array<string>> aliases;
+    }
+}

--- a/src/converter/avro/src/commonTest/resources/customer.avdl
+++ b/src/converter/avro/src/commonTest/resources/customer.avdl
@@ -1,0 +1,27 @@
+@namespace("com.example")
+protocol CustomerProtocol {
+    record Address {
+        /** Street */
+        string street;
+        /** Zipcode */
+        string zipcode;
+    }
+
+    /** Customer record */
+    record Customer {
+        /** First Name of Customer */
+        string first_name;
+        /** Last Name of Customer */
+        string last_name;
+        /** Age at the time of registration */
+        int age;
+        /** Height in cm */
+        float height;
+        /** Weight in kg */
+        float weight;
+        /** Marketing email enrollment */
+        boolean automated_email = true;
+        /** Address of Customer */
+        Address address;
+    }
+}

--- a/src/converter/avro/src/commonTest/resources/enums.avdl
+++ b/src/converter/avro/src/commonTest/resources/enums.avdl
@@ -1,0 +1,17 @@
+protocol EnumsProtocol {
+    enum Color {
+        RED,
+        GREEN,
+        BLUE
+    }
+
+    enum Priority {
+        LOW, MEDIUM, HIGH
+    }
+
+    record Task {
+        string title;
+        Color color;
+        Priority priority;
+    }
+}

--- a/src/converter/avro/src/commonTest/resources/example.avdl
+++ b/src/converter/avro/src/commonTest/resources/example.avdl
@@ -1,0 +1,46 @@
+@namespace("com.example.avro")
+protocol UserProtocol {
+
+    enum OAuthStatus {
+        PENDING, ACTIVE, DENIED, EXPIRED, REVOKED
+    }
+
+    enum ToDoStatus {
+        HIDDEN, ACTIONABLE, DONE, ARCHIVED, DELETED
+    }
+
+    record EmailAddress {
+        string address;
+        boolean verified;
+        long dateAdded;
+        union { null, long } dateBounced;
+    }
+
+    record TwitterAccount {
+        OAuthStatus status;
+        long userId;
+        string screenName;
+        string oauthToken;
+        union { null, string } oauthTokenSecret;
+        long dateAuthorized;
+    }
+
+    record ToDoItem {
+        ToDoStatus status;
+        string title;
+        union { null, string } description;
+        union { null, long } snoozeDate;
+        array<ToDoItem> subItems;
+    }
+
+    /** Top-level user record */
+    record User {
+        int id;
+        string username;
+        string passwordHash;
+        long signupDate;
+        array<EmailAddress> emailAddresses;
+        array<TwitterAccount> twitterAccounts;
+        array<ToDoItem> toDoItems;
+    }
+}

--- a/src/converter/avro/src/commonTest/resources/nullable.avdl
+++ b/src/converter/avro/src/commonTest/resources/nullable.avdl
@@ -1,0 +1,8 @@
+protocol NullableProtocol {
+    record User {
+        string id;
+        union { null, string } nickname;
+        string? email;
+        union { null, int } age;
+    }
+}

--- a/src/converter/avro/src/commonTest/resources/simple.avdl
+++ b/src/converter/avro/src/commonTest/resources/simple.avdl
@@ -1,0 +1,7 @@
+protocol SimpleProtocol {
+    record Pet {
+        string name;
+        int age;
+        boolean vaccinated;
+    }
+}

--- a/src/integration/avro/src/jvmMain/kotlin/community/flock/wirespec/integration/avro/Utils.kt
+++ b/src/integration/avro/src/jvmMain/kotlin/community/flock/wirespec/integration/avro/Utils.kt
@@ -6,14 +6,14 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
-import community.flock.wirespec.converter.avro.AvroEmitter
+import community.flock.wirespec.converter.avro.AvroJsonEmitter
 import community.flock.wirespec.converter.avro.AvroModel
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 object Utils {
 
-    fun emitAvroSchema(packageName: PackageName, type: Definition, module: Module) = AvroEmitter
+    fun emitAvroSchema(packageName: PackageName, type: Definition, module: Module) = AvroJsonEmitter
         .emit(module)
         .map {
             when (it) {

--- a/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Language.kt
+++ b/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Language.kt
@@ -2,7 +2,7 @@ package community.flock.wirespec.plugin
 
 import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.core.emit.PackageName
-import community.flock.wirespec.converter.avro.AvroEmitter
+import community.flock.wirespec.converter.avro.AvroJsonEmitter
 import community.flock.wirespec.emitters.java.JavaEmitter
 import community.flock.wirespec.emitters.kotlin.KotlinEmitter
 import community.flock.wirespec.emitters.python.PythonEmitter
@@ -36,5 +36,5 @@ fun Language.toEmitter(packageName: PackageName, emitShared: EmitShared) = when 
     Language.Wirespec -> WirespecEmitter()
     Language.OpenAPIV2 -> OpenAPIV2Emitter
     Language.OpenAPIV3 -> OpenAPIV3Emitter
-    Language.Avro -> AvroEmitter
+    Language.Avro -> AvroJsonEmitter
 }

--- a/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Wirespec.kt
+++ b/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Wirespec.kt
@@ -11,7 +11,7 @@ import community.flock.wirespec.compiler.core.emit.Emitted
 import community.flock.wirespec.compiler.core.exceptions.WirespecException
 import community.flock.wirespec.compiler.core.parse.ParseOptions
 import community.flock.wirespec.compiler.core.validate.Validator
-import community.flock.wirespec.converter.avro.AvroParser
+import community.flock.wirespec.converter.avro.AvroJsonParser
 import community.flock.wirespec.converter.common.Parser
 import community.flock.wirespec.openapi.v2.OpenAPIV2Parser
 import community.flock.wirespec.openapi.v3.OpenAPIV3Parser
@@ -35,7 +35,7 @@ fun convert(arguments: ConverterArguments) {
     val parser: Parser = when (arguments.format) {
         Format.OpenAPIV2 -> OpenAPIV2Parser
         Format.OpenAPIV3 -> OpenAPIV3Parser
-        Format.Avro -> AvroParser
+        Format.Avro -> AvroJsonParser
     }
     val options = ParseOptions(
         strict = arguments.strict,

--- a/src/plugin/gradle/src/main/kotlin/ConvertWirespecTask.kt
+++ b/src/plugin/gradle/src/main/kotlin/ConvertWirespecTask.kt
@@ -47,7 +47,7 @@ abstract class ConvertWirespecTask : BaseWirespecTask() {
             is DirectoryPath -> throw ConvertNeedsAFile()
             is FilePath -> when (inputPath.extension) {
                 FileExtension.JSON -> Source<JSON>(inputPath.name, preProcessorFunction(inputPath.read()))
-                FileExtension.Avro -> Source<JSON>(inputPath.name, preProcessorFunction(inputPath.read()))
+                FileExtension.AvroJson -> Source<JSON>(inputPath.name, preProcessorFunction(inputPath.read()))
                 else -> throw JSONFileError()
             }
                 .also { logger.info("Found 1 file to process: $inputPath") }

--- a/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/ConvertMojo.kt
+++ b/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/ConvertMojo.kt
@@ -119,7 +119,7 @@ class ConvertMojo : BaseMojo() {
             is DirectoryPath -> throw ConvertNeedsAFile()
             is FilePath -> when (inputPath.extension) {
                 FileExtension.JSON -> Source<JSON>(inputPath.name, inputPath.read())
-                FileExtension.Avro -> Source<JSON>(inputPath.name, inputPath.read())
+                FileExtension.AvroJson -> Source<JSON>(inputPath.name, inputPath.read())
                 else -> throw JSONFileError()
             }
                 .also { logger.info("Found 1 file to process: $inputPath") }

--- a/src/plugin/npm/src/jsMain/kotlin/community/flock/wirespec/plugin/npm/Main.kt
+++ b/src/plugin/npm/src/jsMain/kotlin/community/flock/wirespec/plugin/npm/Main.kt
@@ -21,8 +21,8 @@ import community.flock.wirespec.compiler.lib.consume
 import community.flock.wirespec.compiler.lib.produce
 import community.flock.wirespec.compiler.utils.NoLogger
 import community.flock.wirespec.compiler.utils.noLogger
-import community.flock.wirespec.converter.avro.AvroEmitter
-import community.flock.wirespec.converter.avro.AvroParser
+import community.flock.wirespec.converter.avro.AvroJsonEmitter
+import community.flock.wirespec.converter.avro.AvroJsonParser
 import community.flock.wirespec.emitters.java.JavaEmitter
 import community.flock.wirespec.emitters.java.JavaShared
 import community.flock.wirespec.emitters.kotlin.KotlinEmitter
@@ -85,7 +85,7 @@ fun parse(source: String) = object : ParseContext, NoLogger {}.parse(nonEmptyLis
 fun convert(source: String, converters: Converters, strict: Boolean = false) = when (converters) {
     Converters.OPENAPI_V2 -> OpenAPIV2Parser.parse(ModuleContent(FileUri(""), source), strict).produce()
     Converters.OPENAPI_V3 -> OpenAPIV3Parser.parse(ModuleContent(FileUri(""), source), strict).produce()
-    Converters.AVRO -> AvroParser.parse(ModuleContent(FileUri(""), source), strict).produce()
+    Converters.AVRO -> AvroJsonParser.parse(ModuleContent(FileUri(""), source), strict).produce()
 }
 
 @JsExport
@@ -137,7 +137,7 @@ fun emit(wsAst: WsAST, emitter: Emitters, packageName: String, emitShared: Boole
 
         Emitters.AVRO ->
             ast.modules
-                .map { ast -> AvroEmitter.emit(ast) }
+                .map { ast -> AvroJsonEmitter.emit(ast) }
                 .map { Json.encodeToString(it) }
                 .map { Emitted("avro", it) }
     }


### PR DESCRIPTION
Adds an Avro IDL (.avdl) converter alongside the existing Avro JSON
schema converter, sharing the same AvroModel/AvroConverter foundation.

- AvroIdlTokenizer: hand-written lexer for Avro IDL syntax
- AvroIdlParser: parses protocol/record/enum/field declarations into
  AvroModel.Type, then flattens through AvroConverter into wirespec AST
- AvroIdlEmitter: emits a wirespec Module as an Avro IDL protocol
- New FileExtension.AvroIdl ("avdl")

Supports primitives (null/boolean/int/long/float/double/bytes/string),
arrays, maps, nullable shorthand (T?), inline unions, custom type
references, recursive records, namespace annotations, doc comments,
and field default values. Skips fixed and import declarations.

All sources live in commonMain/commonTest using only multiplatform-safe
APIs (kotlinx-io, kotlinx-serialization, arrow-core, kotlin stdlib),
so the converter inherits all native targets the avro module already
exposes (linuxX64, mingwX64, macosX64, macosArm64, plus jvm/js).

Adds 82 tests covering tokenization, parsing edge cases, error paths,
all primitive types, collections, enums, unions, recursion, doc
comments, annotations, and round-trip parse/emit/parse equality.