### PR TITLE
perf: gate native targets behind wirespec.enableNative property

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           distribution: 'temurin'
           cache: gradle
       - name: Run Linux native tests
-        run: ./gradlew linuxX64Test
+        run: ./gradlew -Pwirespec.enableNative=true linuxX64Test
 
   js-test:
 
@@ -92,7 +92,7 @@ jobs:
           distribution: 'temurin'
           cache: gradle
       - name: Run native tests
-        run: ./gradlew macosArm64Test macosX64Test
+        run: ./gradlew -Pwirespec.enableNative=true macosArm64Test macosX64Test
 
   windows-native-test:
 
@@ -107,7 +107,7 @@ jobs:
           distribution: 'temurin'
           cache: gradle
       - name: Run Windows native tests
-        run: ./gradlew mingwX64Test
+        run: ./gradlew -Pwirespec.enableNative=true mingwX64Test
 
   site:
 
@@ -356,7 +356,8 @@ jobs:
           cache: gradle
       - name: Build CLI release executables
         run: |
-          ./gradlew :src:plugin:cli:linkReleaseExecutableLinuxX64 \
+          ./gradlew -Pwirespec.enableNative=true \
+                    :src:plugin:cli:linkReleaseExecutableLinuxX64 \
                     :src:plugin:cli:linkReleaseExecutableMacosX64 \
                     :src:plugin:cli:linkReleaseExecutableMacosArm64 \
                     :src:plugin:cli:linkReleaseExecutableMingwX64
@@ -512,7 +513,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
       - name: Run
         run: |
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Dorg.gradle.parallel=false
+          ./gradlew -Pwirespec.enableNative=true publishToSonatype closeAndReleaseSonatypeStagingRepository -Dorg.gradle.parallel=false
 
   release-lib-npm:
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-site:
 	(cd src/site && make build)
 
 build-wirespec:
-	./gradlew build && (cd src/ide/vscode && npm i && npm run build)
+	./gradlew -Pwirespec.enableNative=true build && (cd src/ide/vscode && npm i && npm run build)
 
 clean:
 	$(shell pwd)/scripts/clean.sh

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,17 @@ jvm:
 local:
 	$(shell pwd)/scripts/local.sh
 
+# Fast build: JVM + JS only (no klib/native), no tests, then run examples without
+# their own tests. Use this for tight local iteration. Native artifacts can be
+# produced by adding `-Pwirespec.enableNative=true` to the gradle command.
+quick:
+	./gradlew --no-configuration-cache -x test \
+		publishToMavenLocal \
+		:src:plugin:npm:jsNodeProductionLibraryDistribution && \
+	(cd examples && make yolo)
+
 publish:
-	./gradlew publish
+	./gradlew -Pwirespec.enableNative=true publish
 
 test:
 	$(shell pwd)/scripts/test.sh

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,8 @@ kotlin.native.cacheKind.macosArm64=none
 kotlin.native.cacheKind.mingwX64=none
 kotlin.apple.xcodeCompatibility.nowarn=true
 kotlin.version=2.3.10
+
+# Build native (klib + native binaries) targets. Off by default so local builds
+# only compile JVM and JS, which is dramatically faster. CI and release jobs
+# pass -Pwirespec.enableNative=true to produce klibs and native CLI executables.
+wirespec.enableNative=false

--- a/src/compiler/core/build.gradle.kts
+++ b/src/compiler/core/build.gradle.kts
@@ -14,11 +14,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
         useEsModules()

--- a/src/compiler/emitters/java/build.gradle.kts
+++ b/src/compiler/emitters/java/build.gradle.kts
@@ -14,11 +14,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
         useEsModules()

--- a/src/compiler/emitters/kotlin/build.gradle.kts
+++ b/src/compiler/emitters/kotlin/build.gradle.kts
@@ -14,11 +14,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
         useEsModules()

--- a/src/compiler/emitters/python/build.gradle.kts
+++ b/src/compiler/emitters/python/build.gradle.kts
@@ -14,11 +14,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
         useEsModules()

--- a/src/compiler/emitters/typescript/build.gradle.kts
+++ b/src/compiler/emitters/typescript/build.gradle.kts
@@ -14,11 +14,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
         useEsModules()

--- a/src/compiler/emitters/wirespec/build.gradle.kts
+++ b/src/compiler/emitters/wirespec/build.gradle.kts
@@ -14,11 +14,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
         useEsModules()

--- a/src/compiler/test/build.gradle.kts
+++ b/src/compiler/test/build.gradle.kts
@@ -13,11 +13,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
         useEsModules()

--- a/src/converter/avro/build.gradle.kts
+++ b/src/converter/avro/build.gradle.kts
@@ -13,11 +13,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
     }

--- a/src/converter/common/build.gradle.kts
+++ b/src/converter/common/build.gradle.kts
@@ -12,11 +12,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
     }

--- a/src/converter/openapi/build.gradle.kts
+++ b/src/converter/openapi/build.gradle.kts
@@ -12,11 +12,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
     }

--- a/src/plugin/arguments/build.gradle.kts
+++ b/src/plugin/arguments/build.gradle.kts
@@ -9,11 +9,15 @@ plugins {
 group = "${libs.versions.group.id.get()}.plugin.arguments"
 version = System.getenv(libs.versions.from.env.get()) ?: libs.versions.default.get()
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
     }

--- a/src/plugin/cli/build.gradle.kts
+++ b/src/plugin/cli/build.gradle.kts
@@ -16,6 +16,8 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
     targets.all {
         compilations.all {
@@ -25,10 +27,12 @@ kotlin {
         }
     }
 
-    macosX64 { build() }
-    macosArm64 { build() }
-    linuxX64 { build() }
-    mingwX64 { build() }
+    if (enableNative) {
+        macosX64 { build() }
+        macosArm64 { build() }
+        linuxX64 { build() }
+        mingwX64 { build() }
+    }
     js(IR) { build() }
     jvm {
         java {

--- a/src/tools/generator/build.gradle.kts
+++ b/src/tools/generator/build.gradle.kts
@@ -12,11 +12,15 @@ repositories {
     mavenLocal()
 }
 
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
 kotlin {
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
     js(IR) {
         nodejs()
     }


### PR DESCRIPTION
Native targets (macosX64, macosArm64, linuxX64, mingwX64) are off by default
so local `./gradlew build` only compiles JVM and JS, drastically cutting build
time. CI native-test/release jobs and `make publish` opt in via
-Pwirespec.enableNative=true.

Add `make quick`: publishes JVM + JS to maven local without tests and runs the
examples via `make yolo` for tight local iteration.