### PR TITLE
Add Transportation interface for request/response handling

### DIFF
--- a/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
+++ b/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
@@ -49,6 +49,7 @@ public interface Wirespec {
     interface ParamDeserializer { <T> T deserializeParam(List<String> values, Type type); }
     record RawRequest(String method, List<String> path, Map<String, List<String>> queries, Map<String, List<String>> headers, Optional<byte[]> body) {}
     record RawResponse(int statusCode, Map<String, List<String>> headers, Optional<byte[]> body) {}
+    interface Transportation { java.util.concurrent.CompletableFuture<RawResponse> transport(RawRequest request); }
     static Type getType(final Class<?> actualTypeArguments, final Class<?> rawType) {
         if(rawType != null) {
             return new ParameterizedType() {

--- a/src/integration/wirespec/src/jvmMain/kotlin/community/flock/wirespec/kotlin/Wirespec.kt
+++ b/src/integration/wirespec/src/jvmMain/kotlin/community/flock/wirespec/kotlin/Wirespec.kt
@@ -91,6 +91,9 @@ object Wirespec {
         val headers: Map<String, List<String>>,
         val body: ByteArray?,
     )
+    interface Transportation {
+        suspend fun transport(request: RawRequest): RawResponse
+    }
     interface ServerEdge<Req : Request<*>, Res : Response<*>> {
         fun from(request: RawRequest): Req
         fun to(response: Res): RawResponse


### PR DESCRIPTION
## Description

Introduces a new `Transportation` interface to both Kotlin and Java implementations that abstracts the transport layer for sending `RawRequest` objects and receiving `RawResponse` objects.

**Kotlin**: Defines `Transportation` as a suspend interface with an async `transport(request: RawRequest): RawResponse` method.

**Java**: Defines `Transportation` as a functional interface with `transport(RawRequest request): CompletableFuture<RawResponse>` for async handling.

This interface provides a standardized contract for implementing custom HTTP transport mechanisms, enabling pluggable transport implementations while maintaining the existing `ServerEdge` abstraction for request/response transformation.

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
- [x] I have followed the contribution guidelines
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [x] I have written code in a functional style (using Arrow where appropriate)

## Breaking Changes

None. This is a new interface addition that does not affect existing code.

https://claude.ai/code/session_0191i99WugWnGgS9H3jPMgjV