### PR TITLE
ci: split sonatype publish from close to wait for storage replication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -569,9 +569,17 @@ jobs:
           distribution: 'temurin'
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
-      - name: Run
-        run: |
-          ./gradlew -Pwirespec.enableNative=true publishToSonatype closeAndReleaseSonatypeStagingRepository -Dorg.gradle.parallel=false
+      - name: Publish to Sonatype staging
+        run: ./gradlew -Pwirespec.enableNative=true publishToSonatype -Dorg.gradle.parallel=false
+      # The Central Portal's OSSRH staging API has a replication lag between
+      # upload acknowledgement and object-storage visibility. Closing too soon
+      # surfaces as `Failed to find file in storage` (HTTP 400). Give the
+      # backend time to catch up, then close+release in a second invocation
+      # that re-discovers the open staging repo via the API.
+      - name: Wait for Sonatype storage to settle
+        run: sleep 300
+      - name: Close and release staging repository
+        run: ./gradlew -Pwirespec.enableNative=true findSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository -Dorg.gradle.parallel=false
 
   release-lib-npm:
 


### PR DESCRIPTION
## Summary

- v0.18.0–v0.18.2 release-maven-central jobs all failed at `closeSonatypeStagingRepository`, never at the upload tasks themselves.
- Likely cause: the Central Portal's OSSRH staging-API shim has a lag between accepting an upload and making the file visible to the close-time validator, surfacing as `Failed to find file in storage` (HTTP 400) or `SocketTimeoutException` during close.
- Splits the gradle invocation into publish → 5-minute sleep → close+release; the second invocation uses `findSonatypeStagingRepository` to re-discover the open staging repo via the API.

## What this does NOT do

This is a tactical workaround, not a migration. If the close still fails after the sleep, the next step is to migrate off `io.github.gradle-nexus.publish-plugin` to `com.gradleup.nmcp` and bypass the OSSRH shim entirely.

## Test plan

- [ ] Trigger a release (or `workflow_dispatch` with a base version) and confirm `release-maven-central` completes both gradle steps without error
- [ ] Verify the resulting version appears under https://repo1.maven.org/maven2/community/flock/wirespec/
- [ ] If it fails again, check whether the close error is the same (storage / find-file) or different (timeout, GPG, etc.) before iterating

🤖 Generated with [Claude Code](https://claude.com/claude-code)