### PR TITLE
ci: disable configuration cache for release-vscode publishToMavenLocal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -494,8 +494,8 @@ jobs:
           node-version: 20
       - name: Build lib
         run: |
-          ./gradlew publishToMavenLocal \
-                    src:plugin:npm:jsNodeProductionLibraryDistribution
+          ./gradlew --no-configuration-cache publishToMavenLocal \
+                    :src:plugin:npm:jsNodeProductionLibraryDistribution
       - name: Build vscode extension
         working-directory: ./src/ide/vscode
         run: |


### PR DESCRIPTION
## Summary
- The `release-vscode` job's *Build lib* step runs `./gradlew publishToMavenLocal …` with the configuration cache enabled. Under Gradle 9.3.1, `GenerateMavenPom` for `src:integration:avro` and `src:integration:spring` cannot be serialized (references `Configuration` / `DependencyHandler` / `Project` at execution time), producing 32 cache problems and failing the build before the vscode extension is built or published (see [run 26023573401 / job 76493309595](https://github.com/flock-community/wirespec/actions/runs/26023573401/job/76493309595)).
- Pass `--no-configuration-cache`, matching the workaround already used by the `example-build` job.
- Drive-by: add the leading `:` to `:src:plugin:npm:jsNodeProductionLibraryDistribution` for consistency.

## Test plan
- [ ] Re-run the release workflow (or dispatch a manual RC) and confirm `release-vscode` reaches and completes `npm run vscode:publish`.
- [ ] Follow-up: fix the underlying POM-generation tasks in `src/integration/avro` and `src/integration/spring` so the configuration cache can be re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)