### PR TITLE
fix(plugin/maven): drop duplicate mavenJava publication to unblock release

### DIFF
--- a/src/plugin/maven/build.gradle.kts
+++ b/src/plugin/maven/build.gradle.kts
@@ -31,11 +31,17 @@ java {
     withSourcesJar()
 }
 
+// The `module.publication` convention (vanniktech) auto-registers a `maven`
+// publication from `components["java"]`; we only override its artifactId here
+// instead of registering a duplicate publication. Registering a second
+// publication (e.g. `mavenJava`) would produce two signing tasks writing to
+// the same `.asc` path under `build/libs/` and fail Gradle 9's dependency
+// validation when the publish task picks up an `.asc` from a sibling sign
+// task. `configureEach` is used because vanniktech registers `maven` lazily.
 publishing {
-    publications {
-        register("mavenJava", MavenPublication::class) {
+    publications.withType<MavenPublication>().configureEach {
+        if (name == "maven") {
             artifactId = "wirespec-maven-plugin"
-            from(components["java"])
         }
     }
 }


### PR DESCRIPTION
## Summary

- The vanniktech-maven-publish migration (#634) auto-registers a `maven` publication for the Kotlin JVM maven-plugin module on top of the pre-existing explicit `mavenJava`, leaving two `MavenPublication`s producing the same `maven-X.X.X.jar` artifact path.
- With `signAllPublications()` enabled in CI, both `signMavenPublication` and `signMavenJavaPublication` write `.asc` files to the same `build/libs/` paths, and Gradle 9.3.1's task-dependency validation rejects the conflict, breaking [the release-maven-central job](https://github.com/flock-community/wirespec/actions/runs/26032999993/job/76529012884).
- Drop the explicit `mavenJava` publication; rename the auto-registered `maven` publication's artifactId via `configureEach` (lazy because vanniktech registers `maven` after build-script evaluation).

## Test plan

- [x] `./gradlew :src:plugin:maven:tasks --group=publishing` lists only the `maven` publication's tasks (no `mavenJava` tasks remain).
- [x] `./gradlew :src:plugin:maven:publishToMavenLocal` produces `community/flock/wirespec/plugin/maven/wirespec-maven-plugin/<version>/wirespec-maven-plugin-<version>.jar` containing `META-INF/maven/plugin.xml` (confirms the Maven plugin descriptor is still bundled).
- [ ] Trigger the `release-maven-central` workflow (e.g. via a release tag) and confirm `:src:plugin:maven:signMavenPublication` and `:src:plugin:maven:publishMavenPublicationToMavenCentralRepository` succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)