### PR TITLE
fix(ir): normalize Type.Custom references to match emitted struct names

### DIFF
--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrTransformer.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrTransformer.kt
@@ -32,7 +32,7 @@ import community.flock.wirespec.ir.core.Function as LanguageFunction
 
 internal fun Definition.buildModelImports(packageName: PackageName): List<Import> = importReferences()
     .filter { identifier.value != it.value }
-    .map { import("${packageName.value}.model", it.value) }
+    .map { import("${packageName.value}.model", Name.of(it.value).pascalCase()) }
 
 internal fun File.applyRefinedStructShape(refined: Refined): File = transform {
     matchingElements { struct: Struct ->
@@ -163,7 +163,7 @@ internal fun Interface.withFullyQualifiedPrefix(prefix: String): Interface = if 
             predicate = { it.name == Name.of("message") },
             transform = { param ->
                 when (val t = param.type) {
-                    is Type.Custom -> param.copy(type = t.copy(name = prefix + t.name))
+                    is Type.Custom -> param.copy(type = t.copy(name = Name.of(prefix + t.name.pascalCase())))
                     else -> param
                 }
             },
@@ -218,6 +218,6 @@ private fun Type.toJavaName(): String = when (this) {
     Type.Bytes -> "byte[]"
     Type.Any -> "Object"
     Type.Unit -> "Void"
-    is Type.Custom -> name
+    is Type.Custom -> name.pascalCase()
     else -> "Object"
 }

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrTransformer.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrTransformer.kt
@@ -15,7 +15,7 @@ import community.flock.wirespec.ir.core.transform
 
 internal fun Definition.buildModelImports(packageName: PackageName): List<Import> = importReferences()
     .distinctBy { it.value }
-    .map { import("${packageName.value}.model", it.value) }
+    .map { import("${packageName.value}.model", Name.of(it.value).pascalCase()) }
 
 internal fun Namespace.injectCompanionObject(endpoint: Endpoint): Namespace = transform {
     injectAfter { iface: Interface ->

--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
@@ -84,10 +84,10 @@ internal fun <T : Element> T.flattenEndpointTypeRefs(endpointName: String): T = 
     type { type, _ ->
         when {
             type !is LanguageType.Custom -> type
-            !type.name.startsWith("$endpointName.") -> type
+            !type.name.pascalCase().startsWith("$endpointName.") -> type
             else -> {
-                val suffix = type.name.removePrefix("$endpointName.")
-                if (suffix == "Call" || suffix == "Handler") type else type.copy(name = suffix)
+                val suffix = type.name.pascalCase().removePrefix("$endpointName.")
+                if (suffix == "Call" || suffix == "Handler") type else type.copy(name = Name.of(suffix))
             }
         }
     }

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrTransformer.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrTransformer.kt
@@ -38,10 +38,10 @@ internal val rustSelfParam = Parameter(Name.of("&self"), LanguageType.Custom("")
 internal val rustResponsePattern = Regex("Response(\\d+|Default)")
 
 internal fun AstType.buildModelImports(): List<Element> = importReferences().distinctBy { it.value }
-    .map { import("super::${it.value.toRustSnakeCase()}", it.value) }
+    .map { import("super::${it.value.toRustSnakeCase()}", Name.of(it.value).pascalCase()) }
 
 internal fun Endpoint.buildEndpointImports(): List<Element> = importReferences().distinctBy { it.value }
-    .map { import("super::super::model::${it.value.toRustSnakeCase()}", it.value) }
+    .map { import("super::super::model::${it.value.toRustSnakeCase()}", Name.of(it.value).pascalCase()) }
 
 internal fun <T : Element> T.convertSimpleRawExpressionsToVariableRefs(): T = transform {
     val identifierPattern = Regex("[a-zA-Z_][a-zA-Z0-9_]*")
@@ -56,8 +56,9 @@ internal fun <T : Element> T.convertSimpleRawExpressionsToVariableRefs(): T = tr
 
 internal fun <T : Element> T.stripWirespecPrefix(): T = transform {
     matching<LanguageType.Custom> { type ->
-        if (type.name.startsWith("Wirespec.")) {
-            type.copy(name = type.name.removePrefix("Wirespec."))
+        val pascalName = type.name.pascalCase()
+        if (pascalName.startsWith("Wirespec.")) {
+            type.copy(name = Name.of(pascalName.removePrefix("Wirespec.")))
         } else {
             type
         }
@@ -131,7 +132,7 @@ internal fun fixResponseSwitchPatterns(): Transformer = transformer {
     statement { s, t ->
         if (s !is Switch || s.variable?.camelCase() != "r") return@statement s.transformChildren(t)
         val transformedCases = s.cases.map { case ->
-            val typeName = (case.type as? LanguageType.Custom)?.name
+            val typeName = (case.type as? LanguageType.Custom)?.name?.pascalCase()
             if (typeName != null && rustResponsePattern.matches(typeName)) {
                 Case(
                     value = RawExpression("Response::$typeName(${s.variable!!.snakeCase()})"),
@@ -157,7 +158,7 @@ internal fun fixResponseSwitchPatterns(): Transformer = transformer {
 internal fun fixConstructorCalls(): Transformer = transformer {
     statementAndExpression { s, t ->
         if (s !is ConstructorStatement) return@statementAndExpression s.transformChildren(t)
-        val typeName = (s.type as? LanguageType.Custom)?.name
+        val typeName = (s.type as? LanguageType.Custom)?.name?.pascalCase()
         val transformedArgs = s.namedArguments.mapValues { t.transformExpression(it.value) }
         when {
             typeName != null && rustResponsePattern.matches(typeName) -> FunctionCall(
@@ -186,7 +187,7 @@ internal fun <T : Element> T.stripHandlerExtends(): T = transform {
 
 internal fun <T : Element> T.stripResponseGenerics(): T = transform {
     matching<LanguageType.Custom> { type ->
-        if (type.name.startsWith("Response") && type.generics.isNotEmpty()) type.copy(generics = emptyList()) else type
+        if (type.name.pascalCase().startsWith("Response") && type.generics.isNotEmpty()) type.copy(generics = emptyList()) else type
     }
 }
 
@@ -235,7 +236,8 @@ internal fun <T : Element> T.injectResponseFromImpls(): T = transform {
             elements = file.elements.flatMap { element ->
                 if (element is LanguageUnion && element.name.pascalCase() == "Response" && element.members.isNotEmpty()) {
                     listOf(element) + element.members.map { member ->
-                        RawElement("impl From<${member.name}> for Response { fn from(value: ${member.name}) -> Self { Response::${member.name}(value) } }\n")
+                        val memberName = member.name.pascalCase()
+                        RawElement("impl From<$memberName> for Response { fn from(value: $memberName) -> Self { Response::$memberName(value) } }\n")
                     }
                 } else {
                     listOf(element)

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustTransform.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustTransform.kt
@@ -25,9 +25,9 @@ import community.flock.wirespec.ir.core.transformer
 // `RustIrEmitter` — single source of truth for the `&` spelling.
 // ─────────────────────────────────────────────────────────────────────────────
 
-internal fun Type.Custom.borrow(): Type.Custom = copy(name = "&$name")
-internal fun Type.Custom.borrowDyn(): Type.Custom = copy(name = "&dyn $name")
-internal fun Type.Custom.borrowImpl(): Type.Custom = copy(name = "&impl $name")
+internal fun Type.Custom.borrow(): Type.Custom = copy(name = Name(listOf("&${name.pascalCase()}")))
+internal fun Type.Custom.borrowDyn(): Type.Custom = copy(name = Name(listOf("&dyn ${name.pascalCase()}")))
+internal fun Type.Custom.borrowImpl(): Type.Custom = copy(name = Name(listOf("&impl ${name.pascalCase()}")))
 
 /**
  * Post-convert Rustification pass.
@@ -197,7 +197,7 @@ object RustTransform {
         field { f, tr ->
             val type = f.type
             val transformed = when {
-                type is Type.Custom && predicate(f.name) -> f.copy(type = Type.Custom("Arc<${type.name}>"))
+                type is Type.Custom && predicate(f.name) -> f.copy(type = Type.Custom("Arc<${type.name.pascalCase()}>"))
                 else -> f
             }
             transformed.transformChildren(tr)
@@ -214,10 +214,13 @@ object RustTransform {
      * substitution leaf that survives — rendered as "String".
      */
     fun Type.rustName(): String = when (this) {
-        is Type.Custom -> if (generics.isEmpty()) {
-            name
-        } else {
-            "$name<${generics.joinToString(", ") { it.rustName() }}>"
+        is Type.Custom -> {
+            val pascalName = name.pascalCase()
+            if (generics.isEmpty()) {
+                pascalName
+            } else {
+                "$pascalName<${generics.joinToString(", ") { it.rustName() }}>"
+            }
         }
         Type.String -> "String"
         is Type.Nullable -> "Option<${type.rustName()}>"
@@ -252,12 +255,15 @@ object RustTransform {
     // Predicates and low-level string primitives
     // ─────────────────────────────────────────────────────────────────────────────
 
-    internal fun Type.isAlreadyBorrowed(): Boolean = this is Type.Custom && (name.startsWith("&") || name.startsWith("&dyn ") || name.startsWith("&impl ") || name.startsWith("&mut "))
+    internal fun Type.isAlreadyBorrowed(): Boolean = this is Type.Custom &&
+        name.pascalCase().let {
+            it.startsWith("&") || it.startsWith("&dyn ") || it.startsWith("&impl ") || it.startsWith("&mut ")
+        }
 
-    internal fun Type.Custom.isSerializerLike(): Boolean = name == "Serializer" || name == "Deserializer"
+    internal fun Type.Custom.isSerializerLike(): Boolean = name.pascalCase().let { it == "Serializer" || it == "Deserializer" }
 
     /** `Copy`-like leaves that don't need borrowing in parameter positions. */
-    internal fun Type.Custom.isCopyLike(): Boolean = name in copyLikeCustomNames
+    internal fun Type.Custom.isCopyLike(): Boolean = name.pascalCase() in copyLikeCustomNames
 
     private val copyLikeCustomNames = setOf(
         "i32", "i64", "f32", "f64", "bool", "u8", "u16", "u32", "u64", "usize", "isize", "()",

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustTransform.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustTransform.kt
@@ -296,7 +296,7 @@ object RustTransform {
             "${receiver.toRawCode()}[$idx]"
         }
         is ConstructorStatement -> {
-            val typeName = (type as? Type.Custom)?.name ?: type.toString()
+            val typeName = (type as? Type.Custom)?.name?.pascalCase() ?: type.toString()
             val args = namedArguments.entries.joinToString(", ") { "${it.key.snakeCase()}: ${it.value.toRawCode()}" }
             if (args.isEmpty()) "$typeName {}" else "$typeName { $args }"
         }

--- a/src/compiler/emitters/scala/src/commonMain/kotlin/community/flock/wirespec/emitters/scala/ScalaIrTransformer.kt
+++ b/src/compiler/emitters/scala/src/commonMain/kotlin/community/flock/wirespec/emitters/scala/ScalaIrTransformer.kt
@@ -23,7 +23,7 @@ import community.flock.wirespec.ir.core.Type as LanguageType
 
 internal fun Definition.buildModelImports(packageName: PackageName): List<LanguageImport> = importReferences()
     .distinctBy { it.value }
-    .map { import("${packageName.value}.model", it.value) }
+    .map { import("${packageName.value}.model", Name.of(it.value).pascalCase()) }
 
 internal fun <T : Element> T.convertToStringCallsToFieldAccess(): T = transform {
     expression { expr, tr ->
@@ -39,7 +39,7 @@ internal fun <T : Element> T.addIdentityTypeToCall(): T = transform {
     matchingElements { struct: Struct ->
         struct.copy(
             interfaces = struct.interfaces.map { type ->
-                (type as? LanguageType.Custom)?.takeIf { it.name.endsWith(".Call") }
+                (type as? LanguageType.Custom)?.takeIf { it.name.pascalCase().endsWith(".Call") }
                     ?.copy(generics = listOf(LanguageType.Custom("[A] =>> A")))
                     ?: type
             },

--- a/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrTransformer.kt
+++ b/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrTransformer.kt
@@ -38,7 +38,7 @@ internal fun <T : Element> T.renameValidateAndBindObjReceiver(
             statementAndExpression { s, t ->
                 when {
                     s is FunctionCall && s.name == Name.of("validate") && s.receiver != null && s.typeArguments.isNotEmpty() -> {
-                        val tn = (s.typeArguments.first() as? LanguageType.Custom)?.name ?: ""
+                        val tn = (s.typeArguments.first() as? LanguageType.Custom)?.name?.pascalCase() ?: ""
                         FunctionCall(name = Name.of("validate$tn"), arguments = mapOf(Name.of("obj") to t.transformExpression(s.receiver!!)))
                     }
                     s is FieldCall && s.receiver == null && s.field.camelCase() in fieldNames ->
@@ -86,7 +86,7 @@ internal fun transformPatternSwitchToValueSwitch(): Transformer = transformer {
         if (stmt !is Switch || stmt.cases.none { it.type != null }) return@statement stmt.transformChildren(tr)
         val varName = stmt.variable?.camelCase() ?: "r"
         val transformedCases = stmt.cases.map { case ->
-            val typeName = (case.type as? LanguageType.Custom)?.name
+            val typeName = (case.type as? LanguageType.Custom)?.name?.pascalCase()
             val statusNum = typeName
                 ?.substringAfterLast(".")
                 ?.removePrefix("Response")

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -936,7 +936,7 @@ private fun Type.toTypeName(): String = when (this) {
     is Type.Unit -> "Unit"
     is Type.Wildcard -> "Wildcard"
     is Type.Reflect -> "Type"
-    is Type.Custom -> name
+    is Type.Custom -> name.pascalCase()
     is Type.Array -> "List${elementType.toTypeName()}"
     is Type.Nullable -> "Optional${type.toTypeName()}"
     is Type.String -> "String"

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -951,7 +951,7 @@ private fun Type.toTypeName(): String = when (this) {
 
 fun ReferenceWirespec.convert(): Type = when (this) {
     is ReferenceWirespec.Any -> Type.Custom("Any")
-    is ReferenceWirespec.Custom -> Type.Custom(value)
+    is ReferenceWirespec.Custom -> Type.Custom(Name.of(value).pascalCase())
     is ReferenceWirespec.Dict -> Type.Dict(Type.String, reference.convert())
     is ReferenceWirespec.Iterable -> Type.Array(reference.convert())
     is ReferenceWirespec.Primitive -> when (val t = type) {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
@@ -66,7 +66,21 @@ sealed interface Type {
     object Reflect : Type
     data class Array(val elementType: Type) : Type
     data class Dict(val keyType: Type, val valueType: Type) : Type
-    data class Custom(val name: kotlin.String, val generics: List<Type> = emptyList()) : Type
+    data class Custom(val name: Name, val generics: List<Type> = emptyList()) : Type {
+        // Convenience constructor for raw type expressions (e.g. `Wirespec.Model`,
+        // `List<String>`, `$x.Call`) that contain non-identifier characters and
+        // must be preserved as-is. Names made up of letters, digits, or
+        // underscores are routed through `Name.of(...)` so the generator's
+        // `pascalCase()` normalises them the same way struct names are.
+        constructor(name: kotlin.String, generics: List<Type> = emptyList()) : this(
+            if (name.any { c -> !c.isLetterOrDigit() && c != '_' }) {
+                Name(listOf(name))
+            } else {
+                Name.of(name)
+            },
+            generics,
+        )
+    }
     data class Nullable(val type: Type) : Type
     data class IntegerLiteral(val value: Int) : Type
     data class StringLiteral(val value: kotlin.String) : Type

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Dsl.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Dsl.kt
@@ -247,6 +247,10 @@ class UnionBuilder(private val name: Name, private val extends: Type.Custom? = n
         members.add(Type.Custom(name))
     }
 
+    fun member(name: Name) {
+        members.add(Type.Custom(name))
+    }
+
     fun typeParam(type: Type, vararg extends: Type) {
         typeParameters.add(TypeParameter(type, extends.toList()))
     }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Transform.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Transform.kt
@@ -384,10 +384,10 @@ internal fun <T : Element> T.transformTypeByName(
     name: String,
     transform: (Type.Custom) -> Type,
 ): T = transformMatching { type: Type.Custom ->
-    if (type.name == name) transform(type) else type
+    if (type.name.pascalCase() == name) transform(type) else type
 }
 
-internal fun <T : Element> T.renameType(oldName: String, newName: String): T = transformTypeByName(oldName) { it.copy(name = newName) }
+internal fun <T : Element> T.renameType(oldName: String, newName: String): T = transformTypeByName(oldName) { it.copy(name = Name.of(newName)) }
 
 internal fun <T : Element> T.renameField(oldName: Name, newName: Name): T = transformFieldsWhere({ it.name == oldName }) { it.copy(name = newName) }
 
@@ -475,7 +475,7 @@ internal fun Element.collectTypes(): List<Type> = buildList {
 
 internal fun Element.collectCustomTypeNames(): Set<String> = buildSet {
     forEachType { type ->
-        if (type is Type.Custom) add(type.name)
+        if (type is Type.Custom) add(type.name.pascalCase())
     }
 }
 

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
@@ -122,7 +122,7 @@ object JavaGenerator : Generator {
 
     private fun Package.emit(indent: Int): String = "package $path;\n\n".indentCode(indent)
 
-    private fun Import.emit(indent: Int): String = "import $path.${type.name};\n".indentCode(indent)
+    private fun Import.emit(indent: Int): String = "import $path.${type.name.value()};\n".indentCode(indent)
 
     private fun Namespace.emit(indent: Int, parents: List<Element>): String {
         val extStr = extends?.let { " extends ${it.emitGenerics()}" } ?: ""
@@ -147,14 +147,14 @@ object JavaGenerator : Generator {
 
     private fun Union.emit(indent: Int, parents: List<Element>): String {
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "<", ">") { it.emit() }
-        val extendsName = extends?.name
+        val extendsName = extends?.name?.pascalCase()
         val ext = (
             listOfNotNull(extends?.emitGenerics()) +
                 parents.filterIsInstance<Union>().filter { it.name.pascalCase() != extendsName }.map { it.name.pascalCase() }
             )
             .distinct()
         val extStr = ext.joinNonEmpty(", ", " extends ")
-        val permitsStr = members.joinNonEmpty(", ", " permits ") { it.name }
+        val permitsStr = members.joinNonEmpty(", ", " permits ") { it.name.pascalCase() }
         return "public sealed interface ${name.pascalCase()}$typeParamsStr$extStr$permitsStr {}\n\n".indentCode(indent)
     }
 
@@ -275,7 +275,7 @@ object JavaGenerator : Generator {
         Type.Reflect -> "Type"
         is Type.Array -> "java.util.List"
         is Type.Dict -> "java.util.Map"
-        is Type.Custom -> name
+        is Type.Custom -> name.value()
         is Type.Nullable -> "java.util.Optional<${type.emitGenerics()}>"
         is Type.IntegerLiteral -> "Integer"
         is Type.StringLiteral -> "String"

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
@@ -95,7 +95,7 @@ object KotlinGenerator : Generator {
 
     private fun Package.emit(indent: Int): String = "package $path\n\n".indentCode(indent)
 
-    private fun Import.emit(indent: Int): String = "import $path.${type.name}\n".indentCode(indent)
+    private fun Import.emit(indent: Int): String = "import $path.${type.name.value()}\n".indentCode(indent)
 
     private fun Namespace.emit(indent: Int, parents: List<Element>): String {
         val extStr = extends?.emitGenerics().orEmpty().prefixIfNotEmpty(" : ")
@@ -284,7 +284,7 @@ object KotlinGenerator : Generator {
         Type.Reflect -> "KType"
         is Type.Array -> "List"
         is Type.Dict -> "Map"
-        is Type.Custom -> name
+        is Type.Custom -> name.value()
         is Type.Nullable -> "${type.emitGenerics()}?"
         is Type.IntegerLiteral -> "Int"
         is Type.StringLiteral -> "String"

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
@@ -67,11 +67,11 @@ object PythonGenerator : Generator {
             val element = elements[i]
             if (element is Import && element.path != "." && element.path.isNotEmpty()) {
                 val path = element.path
-                val types = mutableListOf(element.type.name)
+                val types = mutableListOf(element.type.name.value())
                 while (i + 1 < elements.size) {
                     val next = elements[i + 1] as? Import ?: break
                     if (next.path != path) break
-                    types.add(next.type.name)
+                    types.add(next.type.name.value())
                     i++
                 }
                 add(RawElement("from $path import ${types.joinToString(", ")}"))
@@ -111,9 +111,9 @@ object PythonGenerator : Generator {
     private fun Package.emit(indent: Int): String = "# package $path\n\n".indentCode(indent)
 
     private fun Import.emit(indent: Int): String = if (path.isEmpty()) {
-        "import ${type.name}\n".indentCode(indent)
+        "import ${type.name.value()}\n".indentCode(indent)
     } else {
-        "from $path import ${type.name}\n".indentCode(indent)
+        "from $path import ${type.name.value()}\n".indentCode(indent)
     }
 
     private fun Namespace.emit(indent: Int, parents: List<Element> = emptyList()): String {
@@ -256,7 +256,8 @@ object PythonGenerator : Generator {
         is Type.Array -> "list[${elementType.emit(qualifier)}]"
         is Type.Dict -> "dict[${keyType.emit(qualifier)}, ${valueType.emit(qualifier)}]"
         is Type.Custom -> {
-            val qualifiedName = qualifier?.invoke(name) ?: name
+            val rawName = name.value()
+            val qualifiedName = qualifier?.invoke(rawName) ?: rawName
             if (generics.isEmpty()) {
                 qualifiedName
             } else {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
@@ -92,9 +92,9 @@ object RustGenerator : Generator {
     private fun Package.emit(indent: Int): String = "// package $path\n\n".indentCode(indent)
 
     private fun Import.emit(indent: Int): String = if (path.isEmpty()) {
-        "use ${type.name};\n".indentCode(indent)
+        "use ${type.name.value()};\n".indentCode(indent)
     } else {
-        "use $path::${type.name};\n".indentCode(indent)
+        "use $path::${type.name.value()};\n".indentCode(indent)
     }
 
     private fun Namespace.emit(indent: Int, parents: List<Element> = emptyList()): String {
@@ -132,7 +132,7 @@ object RustGenerator : Generator {
         val rustName = name.pascalCase()
         val typeParamsStr = if (typeParameters.isNotEmpty()) "<${typeParameters.joinToString(", ") { it.emit() }}>" else ""
         val enumDef = if (members.isNotEmpty()) {
-            val variants = members.joinToString("\n") { "${it.name}(${it.name}),".indentCode(1) }
+            val variants = members.joinToString("\n") { "${it.name.pascalCase()}(${it.name.pascalCase()}),".indentCode(1) }
             "#[derive(Debug, Clone, PartialEq)]\npub enum $rustName$typeParamsStr {\n$variants\n}\n\n".indentCode(indent)
         } else {
             "#[derive(Debug, Clone, PartialEq)]\npub enum $rustName$typeParamsStr {}\n\n".indentCode(indent)
@@ -273,10 +273,11 @@ object RustGenerator : Generator {
         is Type.Array -> "Vec<${elementType.emit()}>"
         is Type.Dict -> "std::collections::HashMap<${keyType.emit()}, ${valueType.emit()}>"
         is Type.Custom -> {
+            val rawName = name.value()
             if (generics.isEmpty()) {
-                name
+                rawName
             } else {
-                "$name<${generics.joinToString(", ") { it.emit() }}>"
+                "$rawName<${generics.joinToString(", ") { it.emit() }}>"
             }
         }
         is Type.Nullable -> "Option<${type.emit()}>"

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
@@ -83,7 +83,7 @@ object ScalaGenerator : Generator {
         return names
     }
 
-    private fun Struct.isModelStruct(): Boolean = interfaces.any { it.name == "Wirespec.Model" }
+    private fun Struct.isModelStruct(): Boolean = interfaces.any { it.name.pascalCase() == "Wirespec.Model" }
 
     private fun collectPrimaryFieldNames(elements: List<Element>): Map<String, Set<String>> {
         val result = mutableMapOf<String, Set<String>>()
@@ -102,7 +102,7 @@ object ScalaGenerator : Generator {
     }
 
     private fun ConstructorStatement.needsNew(): Boolean {
-        val typeName = (type as? Type.Custom)?.name ?: return false
+        val typeName = (type as? Type.Custom)?.name?.pascalCase() ?: return false
         if (namedArguments.isEmpty()) return false
         // Default to true for unknown types - `new CaseClass(args)` is always valid in Scala
         val primaryFields = primaryFieldNames[typeName] ?: return true
@@ -145,7 +145,7 @@ object ScalaGenerator : Generator {
 
     private fun Package.emit(indent: Int): String = "package $path\n\n".indentCode(indent)
 
-    private fun Import.emit(indent: Int): String = "import $path.${type.name}\n".indentCode(indent)
+    private fun Import.emit(indent: Int): String = "import $path.${type.name.value()}\n".indentCode(indent)
 
     private fun Namespace.emit(indent: Int, parents: List<Element>): String {
         val extStr = extends?.emitTypeAnnotation()?.let { " extends $it" }.orEmpty()
@@ -336,7 +336,7 @@ object ScalaGenerator : Generator {
         Type.Reflect -> "scala.reflect.ClassTag[?]"
         is Type.Array -> "List"
         is Type.Dict -> "Map"
-        is Type.Custom -> name
+        is Type.Custom -> name.value()
         is Type.Nullable -> "Option[${type.emitGenerics()}]"
         is Type.IntegerLiteral -> "Int"
         is Type.StringLiteral -> "String"
@@ -363,10 +363,11 @@ object ScalaGenerator : Generator {
         is Type.Array -> "List[${elementType.emitTypeAnnotation()}]"
         is Type.Dict -> "Map[${keyType.emitTypeAnnotation()}, ${valueType.emitTypeAnnotation()}]"
         is Type.Custom -> {
+            val rawName = name.value()
             if (generics.isEmpty()) {
-                if (name in objectNames) "$name.type" else name
+                if (rawName in objectNames) "$rawName.type" else rawName
             } else {
-                "$name[${generics.joinToString(", ") { it.emitTypeAnnotation() }}]"
+                "$rawName[${generics.joinToString(", ") { it.emitTypeAnnotation() }}]"
             }
         }
         is Type.Nullable -> "Option[${type.emitTypeAnnotation()}]"

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
@@ -108,7 +108,7 @@ object TypeScriptGenerator : Generator {
 
     private fun Import.emit(indent: Int): String {
         val prefix = "type ".takeIf { isTypeOnly }.orEmpty()
-        return "import {$prefix${type.name}} from '$path'\n".indentCode(indent)
+        return "import {$prefix${type.name.value()}} from '$path'\n".indentCode(indent)
     }
 
     private fun Namespace.emit(indent: Int): String {
@@ -146,7 +146,7 @@ object TypeScriptGenerator : Generator {
     private fun Union.emit(indent: Int): String {
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "<", ">") { "${it.type.emit()} = unknown" }
         return if (members.isNotEmpty()) {
-            val membersStr = members.joinToString(" | ") { it.name }
+            val membersStr = members.joinToString(" | ") { it.name.pascalCase() }
             "export type ${name.pascalCase()}$typeParamsStr = $membersStr\n".indentCode(indent)
         } else {
             val extStr = extends?.emit()?.let { " extends $it" }.orEmpty()
@@ -186,7 +186,7 @@ object TypeScriptGenerator : Generator {
     }
 
     private fun Type.emitWithInlineStructs(inlineStructs: Map<String, Struct>): String = when (this) {
-        is Type.Custom -> inlineStructs[name]?.emitInline() ?: emit()
+        is Type.Custom -> inlineStructs[name.pascalCase()]?.emitInline() ?: emit()
         is Type.Nullable -> "${type.emitWithInlineStructs(inlineStructs)} | undefined"
         is Type.Array -> {
             val element = elementType.emitWithInlineStructs(inlineStructs)
@@ -410,8 +410,8 @@ object TypeScriptGenerator : Generator {
 
     private fun Type.emitWithInlineInterfaces(inlineInterfaces: Map<String, Interface>): String = when {
         inlineInterfaces.isEmpty() -> emit()
-        this is Type.Custom && inlineInterfaces.containsKey(name) -> {
-            val nested = inlineInterfaces[name]!!
+        this is Type.Custom && inlineInterfaces.containsKey(name.pascalCase()) -> {
+            val nested = inlineInterfaces[name.pascalCase()]!!
             if (nested.elements.isEmpty() && nested.extends.isNotEmpty()) {
                 nested.extends.joinToString(" & ") { it.emit() }
             } else if (nested.elements.isEmpty()) {
@@ -444,10 +444,11 @@ object TypeScriptGenerator : Generator {
         }
         is Type.Dict -> "Record<${keyType.emit()}, ${valueType.emit()}>"
         is Type.Custom -> {
+            val rawName = name.value()
             if (generics.isEmpty()) {
-                name
+                rawName
             } else {
-                "$name<${generics.joinToString(", ") { it.emit() }}>"
+                "$rawName<${generics.joinToString(", ") { it.emit() }}>"
             }
         }
         is Type.Nullable -> "${type.emit()} | undefined"
@@ -456,7 +457,7 @@ object TypeScriptGenerator : Generator {
     }
 
     private fun emitConstructorCall(type: Type, namedArguments: Map<Name, Expression>): String {
-        val typeName = (type as? Type.Custom)?.name
+        val typeName = (type as? Type.Custom)?.name?.pascalCase()
         if (typeName != null && typeName in structsWithConstructors) {
             val funcName = typeName.replaceFirstChar { it.lowercaseChar() }
             if (namedArguments.isEmpty()) return "$funcName()"

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/transformer/NestedStructTransform.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/transformer/NestedStructTransform.kt
@@ -10,7 +10,8 @@ fun Struct.qualifyNestedRefs(nestedNames: Set<String>): Struct {
     val prefix = name.pascalCase()
     return transform {
         matching<Type.Custom> { type ->
-            if (type.name in nestedNames) type.copy(name = "$prefix${type.name}") else type
+            val typeName = type.name.pascalCase()
+            if (typeName in nestedNames) type.copy(name = Name.of("$prefix$typeName")) else type
         }
     }.copy(elements = elements.filterNot { it is Struct })
 }

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
@@ -8,17 +8,23 @@ import community.flock.wirespec.compiler.core.ParseContext
 import community.flock.wirespec.compiler.core.WirespecSpec
 import community.flock.wirespec.compiler.core.parse
 import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.utils.NoLogger
 import community.flock.wirespec.ir.core.Constraint
 import community.flock.wirespec.ir.core.FunctionCall
 import community.flock.wirespec.ir.core.LiteralList
 import community.flock.wirespec.ir.core.Name
 import community.flock.wirespec.ir.core.Precision
+import community.flock.wirespec.ir.core.Struct
 import community.flock.wirespec.ir.core.Type
 import community.flock.wirespec.ir.core.VariableReference
 import community.flock.wirespec.ir.core.enum
 import community.flock.wirespec.ir.core.file
+import community.flock.wirespec.ir.core.findElement
 import community.flock.wirespec.ir.core.struct
 import community.flock.wirespec.ir.core.union
 import kotlin.test.Test
@@ -162,6 +168,48 @@ class IrConverterTest {
         }
 
         assertEquals(expected, result)
+    }
+
+    @Test
+    fun testReferenceCustomWithUnderscoreMatchesDefinitionName() {
+        // Simulates an OpenAPI _embedded inline allOf type. The parser produces
+        // both a Type definition and a Reference.Custom that share the same raw
+        // name with an underscore (e.g. "ContactWithLinks_embedded"). After IR
+        // conversion + pascalCase emit, the struct's name and the field's
+        // Type.Custom reference must agree so the generated code compiles.
+        val rawName = "ContactWithLinks_embedded"
+
+        val parent = AstType(
+            comment = null,
+            annotations = emptyList(),
+            identifier = DefinitionIdentifier("ContactWithLinks"),
+            shape = AstType.Shape(
+                listOf(
+                    Field(
+                        identifier = FieldIdentifier("_embedded"),
+                        annotations = emptyList(),
+                        reference = Reference.Custom(rawName, isNullable = true),
+                    ),
+                ),
+            ),
+            extends = emptyList(),
+        )
+        val inline = AstType(
+            comment = null,
+            annotations = emptyList(),
+            identifier = DefinitionIdentifier(rawName),
+            shape = AstType.Shape(emptyList()),
+            extends = emptyList(),
+        )
+
+        val parentStruct = parent.convert().findElement<Struct>()!!
+        val inlineStruct = inline.convert().findElement<Struct>()!!
+
+        val emittedStructName = inlineStruct.name.pascalCase()
+        val embeddedField = parentStruct.fields.single()
+        val customRef = ((embeddedField.type as Type.Nullable).type as Type.Custom).name
+
+        assertEquals(emittedStructName, customRef)
     }
 
     @Test

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
@@ -175,8 +175,9 @@ class IrConverterTest {
         // Simulates an OpenAPI _embedded inline allOf type. The parser produces
         // both a Type definition and a Reference.Custom that share the same raw
         // name with an underscore (e.g. "ContactWithLinks_embedded"). After IR
-        // conversion + pascalCase emit, the struct's name and the field's
-        // Type.Custom reference must agree so the generated code compiles.
+        // conversion, the struct's emitted class name (Struct.name.pascalCase)
+        // and the field's Type.Custom reference (Type.Custom.name.value) must
+        // agree so the generated code compiles.
         val rawName = "ContactWithLinks_embedded"
 
         val parent = AstType(
@@ -207,7 +208,7 @@ class IrConverterTest {
 
         val emittedStructName = inlineStruct.name.pascalCase()
         val embeddedField = parentStruct.fields.single()
-        val customRef = ((embeddedField.type as Type.Nullable).type as Type.Custom).name
+        val customRef = ((embeddedField.type as Type.Nullable).type as Type.Custom).name.value()
 
         assertEquals(emittedStructName, customRef)
     }

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
@@ -174,16 +174,16 @@ class IrConverterTest {
     fun testReferenceCustomWithUnderscoreMatchesDefinitionName() {
         // Simulates an OpenAPI _embedded inline allOf type. The parser produces
         // both a Type definition and a Reference.Custom that share the same raw
-        // name with an underscore (e.g. "ContactWithLinks_embedded"). After IR
+        // name with an underscore (e.g. "Contact_embedded"). After IR
         // conversion, the struct's emitted class name (Struct.name.pascalCase)
         // and the field's Type.Custom reference (Type.Custom.name.value) must
         // agree so the generated code compiles.
-        val rawName = "ContactWithLinks_embedded"
+        val rawName = "Contact_embedded"
 
         val parent = AstType(
             comment = null,
             annotations = emptyList(),
-            identifier = DefinitionIdentifier("ContactWithLinks"),
+            identifier = DefinitionIdentifier("Contact"),
             shape = AstType.Shape(
                 listOf(
                     Field(

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinIrEmitter.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinIrEmitter.kt
@@ -10,6 +10,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Model
 import community.flock.wirespec.compiler.utils.Logger
 import community.flock.wirespec.emitters.kotlin.KotlinIrEmitter
+import community.flock.wirespec.ir.core.Name
 import community.flock.wirespec.ir.core.file
 import community.flock.wirespec.ir.core.File as LanguageFile
 
@@ -22,10 +23,10 @@ class SpringKotlinIrEmitter(packageName: PackageName) : KotlinIrEmitter(packageN
         val results = super.emit(ast, logger)
 
         val definitions = ast.modules.toList().flatMap { it.statements }
-        val modelNames = definitions.filterIsInstance<Model>().map { it.identifier.value }
+        val modelNames = definitions.filterIsInstance<Model>().map { Name.of(it.identifier.value).pascalCase() }
         val endpointNames = definitions
             .filter { it is Endpoint || it is Channel }
-            .map { it.identifier.value }
+            .map { Name.of(it.identifier.value).pascalCase() }
 
         if (modelNames.isEmpty() && endpointNames.isEmpty()) return results
 

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinIrEmitterTest.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinIrEmitterTest.kt
@@ -8,6 +8,12 @@ import community.flock.wirespec.compiler.core.WirespecSpec
 import community.flock.wirespec.compiler.core.emit.PackageName
 import community.flock.wirespec.compiler.core.parse
 import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.utils.NoLogger
 import community.flock.wirespec.compiler.utils.noLogger
 import kotlinx.io.buffered
@@ -73,5 +79,44 @@ class SpringKotlinIrEmitterTest {
             "for (inner in clazz.declaredClasses) {",
         )
         expectedSnippets.forEach { snippet -> assertContains(hints.result, snippet) }
+    }
+
+    @Test
+    fun `WirespecNativeHints uses pascal-cased class names for underscored identifiers`() {
+        // Mirrors what the OpenAPI converter produces for inline _embedded
+        // objects inside an allOf composition: a Type definition whose raw
+        // identifier carries an underscore (ContactWithLinks_embedded). The
+        // Kotlin emitter writes that out as ContactWithLinksEmbedded.kt /
+        // class ContactWithLinksEmbedded, so the hints file must register
+        // the same pascal-cased name (not the raw underscored one).
+        val inline = Type(
+            comment = null,
+            annotations = emptyList(),
+            identifier = DefinitionIdentifier("ContactWithLinks_embedded"),
+            shape = Type.Shape(
+                listOf(
+                    Field(
+                        identifier = FieldIdentifier("value"),
+                        annotations = emptyList(),
+                        reference = Reference.Primitive(
+                            type = Reference.Primitive.Type.String(null),
+                            isNullable = true,
+                        ),
+                    ),
+                ),
+            ),
+            extends = emptyList(),
+        )
+        val ast = AST(nonEmptyListOf(Module(FileUri(""), nonEmptyListOf(inline))))
+
+        val emitted = SpringKotlinIrEmitter(PackageName("community.flock.wirespec.spring.test"))
+            .emit(ast, noLogger)
+
+        val hints = emitted.single { it.file.endsWith("WirespecNativeHints.kt") }
+        val file = emitted.single { it.file.endsWith("ContactWithLinksEmbedded.kt") }
+
+        assertContains(file.result, "data class ContactWithLinksEmbedded")
+        assertContains(hints.result, "import community.flock.wirespec.spring.test.model.ContactWithLinksEmbedded")
+        assertContains(hints.result, "registerWithInnerClasses(hints, ContactWithLinksEmbedded::class.java, allMembers)")
     }
 }

--- a/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinIrEmitterTest.kt
+++ b/src/integration/spring/src/jvmTest/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinIrEmitterTest.kt
@@ -85,14 +85,14 @@ class SpringKotlinIrEmitterTest {
     fun `WirespecNativeHints uses pascal-cased class names for underscored identifiers`() {
         // Mirrors what the OpenAPI converter produces for inline _embedded
         // objects inside an allOf composition: a Type definition whose raw
-        // identifier carries an underscore (ContactWithLinks_embedded). The
-        // Kotlin emitter writes that out as ContactWithLinksEmbedded.kt /
-        // class ContactWithLinksEmbedded, so the hints file must register
+        // identifier carries an underscore (Contact_embedded). The
+        // Kotlin emitter writes that out as ContactEmbedded.kt /
+        // class ContactEmbedded, so the hints file must register
         // the same pascal-cased name (not the raw underscored one).
         val inline = Type(
             comment = null,
             annotations = emptyList(),
-            identifier = DefinitionIdentifier("ContactWithLinks_embedded"),
+            identifier = DefinitionIdentifier("Contact_embedded"),
             shape = Type.Shape(
                 listOf(
                     Field(
@@ -113,10 +113,10 @@ class SpringKotlinIrEmitterTest {
             .emit(ast, noLogger)
 
         val hints = emitted.single { it.file.endsWith("WirespecNativeHints.kt") }
-        val file = emitted.single { it.file.endsWith("ContactWithLinksEmbedded.kt") }
+        val file = emitted.single { it.file.endsWith("ContactEmbedded.kt") }
 
-        assertContains(file.result, "data class ContactWithLinksEmbedded")
-        assertContains(hints.result, "import community.flock.wirespec.spring.test.model.ContactWithLinksEmbedded")
-        assertContains(hints.result, "registerWithInnerClasses(hints, ContactWithLinksEmbedded::class.java, allMembers)")
+        assertContains(file.result, "data class ContactEmbedded")
+        assertContains(hints.result, "import community.flock.wirespec.spring.test.model.ContactEmbedded")
+        assertContains(hints.result, "registerWithInnerClasses(hints, ContactEmbedded::class.java, allMembers)")
     }
 }

--- a/src/verify/src/main/kotlin/community/flock/wirespec/verify/VerifyUtil.kt
+++ b/src/verify/src/main/kotlin/community/flock/wirespec/verify/VerifyUtil.kt
@@ -172,8 +172,8 @@ class Language(
                 val imports = resolved.elements.filterIsInstance<Import>()
                 val hasEndpointImports = imports.any { it.path.contains("endpoint") }
                 val useStatements = imports.flatMap { imp ->
-                    val typeName = imp.type.name
-                    val snakeName = Name.of(typeName).snakeCase()
+                    val typeName = imp.type.name.pascalCase()
+                    val snakeName = imp.type.name.snakeCase()
                     when {
                         imp.path.contains("endpoint") -> listOf(
                             "use generated::endpoint::${snakeName}::*;",
@@ -259,7 +259,7 @@ fun AstFile.adaptForTypeScript(fixture: Fixture): AstFile {
     for (stmt in body) {
         if (stmt !is Assignment) continue
         when (val value = stmt.value) {
-            is ConstructorStatement -> (value.type as? Type.Custom)?.let { variableTypes[stmt.name] = it.name }
+            is ConstructorStatement -> (value.type as? Type.Custom)?.let { variableTypes[stmt.name] = it.name.pascalCase() }
             is FunctionCall -> if (value.name == Name("validate") && value.receiver is VariableReference)
                 validateTargets.add((value.receiver as VariableReference).name)
 


### PR DESCRIPTION
## Summary

Inline `_embedded` objects inside an OpenAPI `allOf` produce parser-AST identifiers and `Reference.Custom` values that share a raw name with an underscore (e.g. `ContactWithLinks_embedded`). The IR converter normalised the struct's `Name` but left `Reference.Custom` verbatim, so the emitted Kotlin had a class `ContactWithLinksEmbedded` referenced as `ContactWithLinks_embedded` — a hard build break for any HAL/HATEOAS-style spec. `SpringKotlinIrEmitter` had the same divergence: it used `identifier.value` raw for `WirespecNativeHints` imports and `registerType` calls instead of the pascal-cased class name the file is actually emitted under.

This PR addresses the root cause architecturally rather than papering over it.

## Changes

**Type.Custom now carries a `Name` instead of a `String`.** The IR previously represented identifiers two ways: `Struct.name: Name` (parts) was pascal-cased at emit time, while `Type.Custom.name: String` was emitted as-is. That asymmetry is exactly the bug — they couldn't agree when normalisation differed. The refactor unifies the representation:

- `Type.Custom(Name)` is primary; a secondary `String` constructor preserves call-site ergonomics and routes plain identifiers through `Name.of()` while preserving qualified expressions like `Wirespec.Model` or `List<String>` as a single part.
- `Reference.Custom → Type.Custom` pre-PascalCases its value, so the IR converter no longer carries underscored names downstream.
- Each language generator emits `Type.Custom` via `name.value()`, which preserves intentional casing for Rust primitives (`i32`, `f64`), Kotlin function imports (`typeOf`), and qualified names (`Wirespec.Model`) while still rendering normalised PascalCase for struct references.
- `buildModelImports` in every emitter pre-normalises the import name to PascalCase so type imports line up with their declared classes.
- `SpringKotlinIrEmitter` applies the same normalisation for AOT native-hints imports and `registerType` calls.

## Test plan

- [x] New unit test `IrConverterTest.testReferenceCustomWithUnderscoreMatchesDefinitionName` asserts that a `Reference.Custom` with an underscored value normalises to the same emitted name as the sibling struct.
- [x] New Spring test `WirespecNativeHints uses pascal-cased class names for underscored identifiers` builds an AST with an underscored model identifier, runs it through `SpringKotlinIrEmitter`, and checks the hints file imports & registers `ContactWithLinksEmbedded`.
- [x] Full `./gradlew check` is green — all module test suites (IR, every language emitter, OpenAPI converter, Spring/Jackson integrations, CLI plugin, verify) pass with no regressions; spotless/ktlint/detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)