### PR TITLE
fix(integration/spring): accept IR emitter's toRawRequest/fromRawResponse names

### DIFF
--- a/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/client/WirespecWebClient.java
+++ b/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/client/WirespecWebClient.java
@@ -38,9 +38,9 @@ public class WirespecWebClient {
                         .findFirst()
                         .orElseThrow(() -> new IllegalStateException("Handler not found in " + cls));
                 return Arrays.stream(handlerClass.getDeclaredMethods())
-                        .filter(m -> m.getName().equals("toRequest") && Modifier.isStatic(m.getModifiers()))
+                        .filter(m -> (m.getName().equals("toRawRequest") || m.getName().equals("toRequest")) && Modifier.isStatic(m.getModifiers()))
                         .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("toRequest method not found in " + handlerClass));
+                        .orElseThrow(() -> new IllegalStateException("toRawRequest method not found in " + handlerClass));
             });
             Method fromResponse = fromResponseCache.computeIfAbsent(declaringClass, cls -> {
                 Class<?> handlerClass = Arrays.stream(cls.getDeclaredClasses())
@@ -48,9 +48,9 @@ public class WirespecWebClient {
                         .findFirst()
                         .orElseThrow(() -> new IllegalStateException("Handler not found in " + cls));
                 return Arrays.stream(handlerClass.getDeclaredMethods())
-                        .filter(m -> m.getName().equals("fromResponse") && Modifier.isStatic(m.getModifiers()))
+                        .filter(m -> (m.getName().equals("fromRawResponse") || m.getName().equals("fromResponse")) && Modifier.isStatic(m.getModifiers()))
                         .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("fromResponse method not found in " + handlerClass));
+                        .orElseThrow(() -> new IllegalStateException("fromRawResponse method not found in " + handlerClass));
             });
 
             Wirespec.RawRequest rawRequest = (Wirespec.RawRequest) toRequest.invoke(null, wirespecSerde, request);

--- a/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/web/WirespecMethodArgumentResolver.java
+++ b/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/web/WirespecMethodArgumentResolver.java
@@ -52,9 +52,9 @@ public class WirespecMethodArgumentResolver implements HandlerMethodArgumentReso
                     .findFirst()
                     .orElseThrow(() -> new IllegalStateException("Handler not found in " + cls));
             return Arrays.stream(handlerClass.getDeclaredMethods())
-                    .filter(m -> m.getName().equals("fromRequest") && Modifier.isStatic(m.getModifiers()))
+                    .filter(m -> (m.getName().equals("fromRawRequest") || m.getName().equals("fromRequest")) && Modifier.isStatic(m.getModifiers()))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalStateException("fromRequest method not found in " + handlerClass));
+                    .orElseThrow(() -> new IllegalStateException("fromRawRequest method not found in " + handlerClass));
         });
 
         Wirespec.RawRequest req = toRawRequest(servletRequest);

--- a/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/web/WirespecResponseBodyAdvice.java
+++ b/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/web/WirespecResponseBodyAdvice.java
@@ -51,9 +51,9 @@ public class WirespecResponseBodyAdvice implements ResponseBodyAdvice<Object> {
                         .findFirst()
                         .orElseThrow(() -> new IllegalStateException("Handler not found in " + cls));
                 return Arrays.stream(handlerClass.getDeclaredMethods())
-                        .filter(m -> m.getName().equals("toResponse") && Modifier.isStatic(m.getModifiers()))
+                        .filter(m -> (m.getName().equals("toRawResponse") || m.getName().equals("toResponse")) && Modifier.isStatic(m.getModifiers()))
                         .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("toResponse method not found in " + handlerClass));
+                        .orElseThrow(() -> new IllegalStateException("toRawResponse method not found in " + handlerClass));
             });
 
             if (body instanceof Wirespec.Response<?> wirespecResponse) {

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
@@ -24,10 +24,10 @@ class WirespecWebClient(
     suspend fun <Req : Wirespec.Request<*>, Res : Wirespec.Response<*>> send(request: Req): Res {
         val declaringClass = request::class.java.declaringClass
         val toRequest = toRequestCache.computeIfAbsent(declaringClass) { cls ->
-            cls.declaredMethods.first { it.name == "toRequest" }
+            cls.declaredMethods.first { it.name == "toRawRequest" || it.name == "toRequest" }
         }
         val fromResponse = fromResponseCache.computeIfAbsent(declaringClass) { cls ->
-            cls.declaredMethods.first { it.name == "fromResponse" }
+            cls.declaredMethods.first { it.name == "fromRawResponse" || it.name == "fromResponse" }
         }
         val instance = declaringClass.getDeclaredField("INSTANCE").get(null)
         val rawRequest = toRequest.invoke(instance, wirespecSerde, request) as Wirespec.RawRequest

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecMethodArgumentResolver.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecMethodArgumentResolver.kt
@@ -34,7 +34,7 @@ class WirespecMethodArgumentResolver(
         val servletRequest = webRequest.nativeRequest as HttpServletRequest
         val declaringClass = parameter.parameterType.declaringClass
         val fromRequest = fromRequestCache.computeIfAbsent(declaringClass) { cls ->
-            cls.declaredMethods.first { it.name == "fromRequest" }
+            cls.declaredMethods.first { it.name == "fromRawRequest" || it.name == "fromRequest" }
         }
         val instance = declaringClass.getDeclaredField("INSTANCE").get(null)
         val rawRequest = servletRequest.toRawRequest()

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecResponseBodyAdvice.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/web/WirespecResponseBodyAdvice.kt
@@ -33,7 +33,7 @@ class WirespecResponseBodyAdvice(
     ): Any? {
         val declaringClass = returnType.parameterType.declaringClass
         val toResponse = toResponseCache.computeIfAbsent(declaringClass) { cls ->
-            cls.declaredMethods.first { it.name == "toResponse" }
+            cls.declaredMethods.first { it.name == "toRawResponse" || it.name == "toResponse" }
         }
         val instance = declaringClass.getDeclaredField("INSTANCE").get(null)
         return when (body) {


### PR DESCRIPTION
## Summary
- The IR-based Java/Kotlin emitters renamed the endpoint conversion methods to `toRawRequest` / `fromRawRequest` / `toRawResponse` / `fromRawResponse`, but the reflective lookups in `WirespecWebClient`, `WirespecMethodArgumentResolver`, and `WirespecResponseBodyAdvice` (both Java and Kotlin sides) still searched only for the old text-emitter names (`toRequest` / `fromRequest` / `toResponse` / `fromResponse`). On an IR-generated endpoint, `cls.declaredMethods.first { it.name == \"toRequest\" }` throws `NoSuchElementException`.
- Each lookup now accepts either the new or the old name so both emitters are supported during the transition.

## Test plan
- [x] `./gradlew :src:integration:spring:jvmTest` — passes (existing fixtures still use text-emitter names, so the old branch of the OR keeps them working).
- [ ] Manually verify on an IR-emitter–generated endpoint (e.g. the yellowpages client in the reporter's project) that `WirespecWebClient.send(...)` now resolves `toRawRequest`/`fromRawResponse` instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)