### PR TITLE
fix(emitters): emit Wirespec import for Type and Channel files

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/LanguageEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/LanguageEmitter.kt
@@ -45,6 +45,9 @@ abstract class LanguageEmitter :
         fun String.firstToUpper() = replaceFirstChar(Char::uppercase)
         fun String.firstToLower() = replaceFirstChar(Char::lowercase)
         fun Module.needImports() = statements.any { it is Endpoint || it is Enum || it is Refined }
+        fun Module.irNeedsWirespecImport() = statements.any {
+            it is Endpoint || it is Enum || it is Refined || it is Type || it is Channel
+        }
         fun Module.hasEndpoints() = statements.any { it is Endpoint }
         fun String.isStatusCode() = toIntOrNull()?.let { it in 100..599 } ?: false
     }

--- a/src/compiler/emitters/java/fixtures/compileChannelTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileChannelTest.txt
@@ -1,4 +1,5 @@
 package community.flock.wirespec.generated.channel;
+import community.flock.wirespec.java.Wirespec;
 @FunctionalInterface
 public interface Queue extends Wirespec.Channel {
   public void invoke(String message);

--- a/src/compiler/emitters/java/fixtures/compileTypeTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileTypeTest.txt
@@ -1,4 +1,5 @@
 package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
 public record Request (
   String type,
   String url,

--- a/src/compiler/emitters/java/fixtures/compileUnionTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileUnionTest.txt
@@ -1,7 +1,9 @@
 package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
 public sealed interface UserAccount permits UserAccountPassword, UserAccountToken {}
 
 package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
 public record UserAccountPassword (
   String username,
   String password
@@ -13,6 +15,7 @@ public record UserAccountPassword (
 };
 
 package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
 public record UserAccountToken (
   String token
 ) implements Wirespec.Model, UserAccount {
@@ -23,6 +26,7 @@ public record UserAccountToken (
 };
 
 package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
 public record User (
   String username,
   UserAccount account

--- a/src/compiler/emitters/java/fixtures/testEmitterEmptyType.txt
+++ b/src/compiler/emitters/java/fixtures/testEmitterEmptyType.txt
@@ -1,4 +1,5 @@
 package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
 public record TodoWithoutProperties () implements Wirespec.Model {
   @Override
   public java.util.List<String> validate() {

--- a/src/compiler/emitters/java/fixtures/testEmitterType.txt
+++ b/src/compiler/emitters/java/fixtures/testEmitterType.txt
@@ -1,4 +1,5 @@
 package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
 public record Todo (
   String name,
   java.util.Optional<String> description,

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
@@ -7,7 +7,7 @@ import community.flock.wirespec.compiler.core.emit.FileExtension
 import community.flock.wirespec.compiler.core.emit.HasPackageName
 import community.flock.wirespec.compiler.core.emit.Keywords
 import community.flock.wirespec.compiler.core.emit.LanguageEmitter.Companion.firstToUpper
-import community.flock.wirespec.compiler.core.emit.LanguageEmitter.Companion.needImports
+import community.flock.wirespec.compiler.core.emit.LanguageEmitter.Companion.irNeedsWirespecImport
 import community.flock.wirespec.compiler.core.emit.PackageName
 import community.flock.wirespec.compiler.core.emit.importReferences
 import community.flock.wirespec.compiler.core.emit.plus
@@ -135,7 +135,7 @@ open class JavaIrEmitter(
     override fun emit(definition: Definition, module: Module, logger: Logger): File {
         val file = super.emit(definition, module, logger)
         return file.copy(name = Name.of(file.name.pascalCase().sanitizeSymbol()))
-            .prependImports(wirespecImports.takeIf { module.needImports() })
+            .prependImports(wirespecImports.takeIf { module.irNeedsWirespecImport() })
             .placeInPackage(packageName = packageName, definition = definition)
     }
 

--- a/src/compiler/emitters/kotlin/fixtures/compileChannelTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileChannelTest.txt
@@ -1,4 +1,6 @@
 package community.flock.wirespec.generated.channel
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
 interface Queue : Wirespec.Channel {
   fun invoke(message: String)
 }

--- a/src/compiler/emitters/kotlin/fixtures/compileTypeTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileTypeTest.txt
@@ -1,4 +1,6 @@
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
 data class Request(
   val type: String,
   val url: String,

--- a/src/compiler/emitters/kotlin/fixtures/compileUnionTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileUnionTest.txt
@@ -1,7 +1,11 @@
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
 sealed interface UserAccount
 
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
 data class UserAccountPassword(
   val username: String,
   val password: String
@@ -11,6 +15,8 @@ data class UserAccountPassword(
 }
 
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
 data class UserAccountToken(
   val token: String
 ) : Wirespec.Model, UserAccount {
@@ -19,6 +25,8 @@ data class UserAccountToken(
 }
 
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
 data class User(
   val username: String,
   val account: UserAccount

--- a/src/compiler/emitters/kotlin/fixtures/testEmitterEmptyType.txt
+++ b/src/compiler/emitters/kotlin/fixtures/testEmitterEmptyType.txt
@@ -1,4 +1,6 @@
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
 data object TodoWithoutProperties : Wirespec.Model {
   override fun validate(): List<String> =
     emptyList<String>()

--- a/src/compiler/emitters/kotlin/fixtures/testEmitterType.txt
+++ b/src/compiler/emitters/kotlin/fixtures/testEmitterType.txt
@@ -1,4 +1,6 @@
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
 data class Todo(
   val name: String,
   val description: String?,

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
@@ -21,7 +21,7 @@ import community.flock.wirespec.ir.emit.placeInPackage
 import community.flock.wirespec.ir.emit.prependImports
 import community.flock.wirespec.compiler.core.emit.Keywords
 import community.flock.wirespec.compiler.core.emit.LanguageEmitter.Companion.firstToUpper
-import community.flock.wirespec.compiler.core.emit.LanguageEmitter.Companion.needImports
+import community.flock.wirespec.compiler.core.emit.LanguageEmitter.Companion.irNeedsWirespecImport
 import community.flock.wirespec.compiler.core.emit.PackageName
 import community.flock.wirespec.compiler.core.emit.importReferences
 import community.flock.wirespec.compiler.core.emit.plus
@@ -120,7 +120,7 @@ open class KotlinIrEmitter(
     override fun emit(definition: Definition, module: Module, logger: Logger): File {
         val file = super.emit(definition, module, logger)
         return file
-            .prependImports(wirespecImports.takeIf { module.needImports() })
+            .prependImports(wirespecImports.takeIf { module.irNeedsWirespecImport() })
             .placeInPackage(packageName = packageName, definition = definition)
     }
 

--- a/src/compiler/emitters/scala/fixtures/compileChannelTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileChannelTest.txt
@@ -1,4 +1,6 @@
 package community.flock.wirespec.generated.channel
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
 trait Queue extends Wirespec.Channel {
   def invoke(message: String): Unit
 }

--- a/src/compiler/emitters/scala/fixtures/compileTypeTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileTypeTest.txt
@@ -1,4 +1,6 @@
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
 case class Request(
   val `type`: String,
   val url: String,

--- a/src/compiler/emitters/scala/fixtures/compileUnionTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileUnionTest.txt
@@ -1,7 +1,11 @@
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
 sealed trait UserAccount
 
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
 case class UserAccountPassword(
   val username: String,
   val password: String
@@ -11,6 +15,8 @@ case class UserAccountPassword(
 }
 
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
 case class UserAccountToken(
   val token: String
 ) extends Wirespec.Model with UserAccount {
@@ -19,6 +25,8 @@ case class UserAccountToken(
 }
 
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
 case class User(
   val username: String,
   val account: UserAccount

--- a/src/compiler/emitters/scala/fixtures/testEmitterEmptyType.txt
+++ b/src/compiler/emitters/scala/fixtures/testEmitterEmptyType.txt
@@ -1,4 +1,6 @@
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
 case class TodoWithoutProperties() extends Wirespec.Model {
   override def validate(): List[String] =
     List.empty[String]

--- a/src/compiler/emitters/scala/fixtures/testEmitterType.txt
+++ b/src/compiler/emitters/scala/fixtures/testEmitterType.txt
@@ -1,4 +1,6 @@
 package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
 case class Todo(
   val name: String,
   val description: Option[String],

--- a/src/compiler/emitters/scala/src/commonMain/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitter.kt
+++ b/src/compiler/emitters/scala/src/commonMain/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitter.kt
@@ -8,7 +8,7 @@ import community.flock.wirespec.compiler.core.emit.FileExtension
 import community.flock.wirespec.compiler.core.emit.HasPackageName
 import community.flock.wirespec.compiler.core.emit.Keywords
 import community.flock.wirespec.compiler.core.emit.LanguageEmitter.Companion.firstToUpper
-import community.flock.wirespec.compiler.core.emit.LanguageEmitter.Companion.needImports
+import community.flock.wirespec.compiler.core.emit.LanguageEmitter.Companion.irNeedsWirespecImport
 import community.flock.wirespec.compiler.core.emit.PackageName
 import community.flock.wirespec.compiler.core.emit.importReferences
 import community.flock.wirespec.compiler.core.emit.plus
@@ -180,7 +180,7 @@ open class ScalaIrEmitter(
     override fun emit(definition: Definition, module: Module, logger: Logger): File {
         val file = super.emit(definition, module, logger)
         return file
-            .prependImports(wirespecImports.takeIf { module.needImports() })
+            .prependImports(wirespecImports.takeIf { module.irNeedsWirespecImport() })
             .placeInPackage(packageName = packageName, definition = definition)
     }
 


### PR DESCRIPTION
## Summary
- The Kotlin/Java/Scala IR emitters generated `Wirespec.Model` for every Type and `Wirespec.Channel` for every Channel, but reused the legacy `Module.needImports()` helper to decide whether to prepend the `Wirespec` runtime import. That helper only checked for `Endpoint`, `Enum`, or `Refined`, so a module containing only Types and Channels (e.g. `channel Queue -> Foo` plus a `type Foo` referenced only by the channel) emitted files that referenced `Wirespec.*` without the matching import, breaking `compileTestKotlin` and its Java/Scala equivalents.
- Add a new `Module.irNeedsWirespecImport()` helper that also includes `Type` and `Channel`, and switch `KotlinIrEmitter`, `JavaIrEmitter`, and `ScalaIrEmitter` to use it. Leave the legacy `needImports()` alone so the legacy string-template emitters (which do not extend `Wirespec.Model` on plain types) keep their lean output.
- Regenerated the Kotlin/Java/Scala emitter fixtures for `compileChannelTest`, `compileTypeTest`, `compileUnionTest`, `testEmitterType`, and `testEmitterEmptyType` — they now include the previously-missing `Wirespec` import.

## Test plan
- [x] `./gradlew :src:compiler:emitters:kotlin:allTests :src:compiler:emitters:java:allTests :src:compiler:emitters:scala:allTests`
- [x] `./gradlew allTests` (full project, all 370 tasks green)
- [x] Manually inspected the regenerated fixtures: every `Wirespec.*` reference now has the matching `import community.flock.wirespec.<lang>.Wirespec` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)