### PR TITLE
feat: support scalar field defaults in the Wirespec language

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
@@ -9,6 +9,7 @@ import community.flock.wirespec.compiler.core.parse.TypeParser.parseType
 import community.flock.wirespec.compiler.core.parse.TypeParser.parseTypeShape
 import community.flock.wirespec.compiler.core.parse.ast.Annotation
 import community.flock.wirespec.compiler.core.parse.ast.Comment
+import community.flock.wirespec.compiler.core.parse.ast.DefaultValue
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Field
@@ -24,6 +25,7 @@ import community.flock.wirespec.compiler.core.tokenize.Equals
 import community.flock.wirespec.compiler.core.tokenize.Integer
 import community.flock.wirespec.compiler.core.tokenize.LeftCurly
 import community.flock.wirespec.compiler.core.tokenize.LeftParenthesis
+import community.flock.wirespec.compiler.core.tokenize.LiteralString
 import community.flock.wirespec.compiler.core.tokenize.Number
 import community.flock.wirespec.compiler.core.tokenize.Pipe
 import community.flock.wirespec.compiler.core.tokenize.Precision
@@ -296,20 +298,39 @@ private fun TokenProvider.parseField(identifier: FieldIdentifier, annotations: L
         else -> raiseWrongToken<Colon>().bind()
     }
 
-    when (token.type) {
-        is LeftCurly -> Field(
-            identifier = identifier,
-            reference = parseDict().bind(),
-            annotations = annotations,
-        )
-
-        is WirespecType -> Field(
-            identifier = identifier,
-            reference = parseType().bind(),
-            annotations = annotations,
-        )
-
+    val reference = when (token.type) {
+        is LeftCurly -> parseDict().bind()
+        is WirespecType -> parseType().bind()
         else -> raiseWrongToken<WirespecType>().bind()
+    }
+
+    val defaultValue = when (token.type) {
+        is Equals -> {
+            eatToken().bind()
+            parseDefaultValue().bind()
+        }
+        else -> null
+    }
+
+    Field(
+        identifier = identifier,
+        reference = reference,
+        annotations = annotations,
+        defaultValue = defaultValue,
+    )
+}
+
+private fun TokenProvider.parseDefaultValue() = parseToken { previousToken ->
+    when (previousToken.type) {
+        is LiteralString -> DefaultValue.StringValue(previousToken.value.removeSurrounding("\""))
+        is Integer -> DefaultValue.IntegerValue(previousToken.value)
+        is Number -> DefaultValue.NumberValue(previousToken.value)
+        is WirespecIdentifier -> when (previousToken.value) {
+            "true" -> DefaultValue.BooleanValue(true)
+            "false" -> DefaultValue.BooleanValue(false)
+            else -> raiseWrongToken<LiteralString>(previousToken).bind()
+        }
+        else -> raiseWrongToken<LiteralString>(previousToken).bind()
     }
 }
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
@@ -12,7 +12,15 @@ data class Field(
     override val annotations: List<Annotation>,
     val identifier: FieldIdentifier,
     val reference: Reference,
+    val defaultValue: DefaultValue? = null,
 ) : HasAnnotations
+
+sealed interface DefaultValue {
+    data class StringValue(val value: String) : DefaultValue
+    data class IntegerValue(val value: String) : DefaultValue
+    data class NumberValue(val value: String) : DefaultValue
+    data class BooleanValue(val value: Boolean) : DefaultValue
+}
 
 data class Endpoint(
     override val comment: Comment?,

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseTypeTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseTypeTest.kt
@@ -6,6 +6,7 @@ import community.flock.wirespec.compiler.core.ModuleContent
 import community.flock.wirespec.compiler.core.ParseContext
 import community.flock.wirespec.compiler.core.WirespecSpec
 import community.flock.wirespec.compiler.core.parse
+import community.flock.wirespec.compiler.core.parse.ast.DefaultValue
 import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
@@ -256,5 +257,53 @@ class ParseTypeTest {
                     ),
                 )
             }
+    }
+
+    @Test
+    fun testDefaultValueParser() {
+        val source =
+            // language=ws
+            """
+            |type Foo {
+            |    name: String = "anonymous",
+            |    count: Integer = 0,
+            |    ratio: Number = 1.5,
+            |    active: Boolean = true
+            |}
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight { it.head.message }
+            .shouldHaveSize(1)
+            .first()
+            .shouldBeInstanceOf<Type>()
+            .shape.value
+            .also { it shouldHaveSize 4 }
+            .map { it.identifier.value to it.defaultValue }
+            .let { defaults ->
+                defaults shouldBe listOf(
+                    "name" to DefaultValue.StringValue("anonymous"),
+                    "count" to DefaultValue.IntegerValue("0"),
+                    "ratio" to DefaultValue.NumberValue("1.5"),
+                    "active" to DefaultValue.BooleanValue(true),
+                )
+            }
+    }
+
+    @Test
+    fun testFieldWithoutDefaultValueIsNull() {
+        val source =
+            // language=ws
+            """
+            |type Foo { name: String }
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight { it.head.message }
+            .first()
+            .shouldBeInstanceOf<Type>()
+            .shape.value
+            .first()
+            .defaultValue shouldBe null
     }
 }

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinTypeDefinitionEmitter.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinTypeDefinitionEmitter.kt
@@ -2,6 +2,7 @@ package community.flock.wirespec.emitters.kotlin
 
 import community.flock.wirespec.compiler.core.emit.Spacer
 import community.flock.wirespec.compiler.core.emit.TypeDefinitionEmitter
+import community.flock.wirespec.compiler.core.parse.ast.DefaultValue
 import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
@@ -20,7 +21,24 @@ interface KotlinTypeDefinitionEmitter : TypeDefinitionEmitter, KotlinIdentifierE
 
     override fun Type.Shape.emit() = value.joinToString("\n") { "${Spacer}val ${it.emit()}," }.dropLast(1)
 
-    override fun Field.emit() = "${emit(identifier)}: ${reference.emit()}"
+    override fun Field.emit() = "${emit(identifier)}: ${reference.emit()}${defaultValue.emit(reference)}"
+
+    private fun DefaultValue?.emit(reference: Reference): String {
+        val precision = (reference as? Reference.Primitive)?.let {
+            when (val t = it.type) {
+                is Reference.Primitive.Type.Integer -> t.precision
+                is Reference.Primitive.Type.Number -> t.precision
+                else -> null
+            }
+        }
+        return when (this) {
+            null -> ""
+            is DefaultValue.StringValue -> " = \"$value\""
+            is DefaultValue.BooleanValue -> " = $value"
+            is DefaultValue.IntegerValue -> if (precision == Reference.Primitive.Type.Precision.P64) " = ${value}L" else " = $value"
+            is DefaultValue.NumberValue -> if (precision == Reference.Primitive.Type.Precision.P32) " = ${value}f" else " = $value"
+        }
+    }
 
     override fun Reference.emit(): String = when (this) {
         is Reference.Dict -> "Map<String, ${reference.emit()}>"

--- a/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEmitterTest.kt
+++ b/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEmitterTest.kt
@@ -16,9 +16,11 @@ import community.flock.wirespec.compiler.test.CompileRefinedTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.compiler.test.NodeFixtures
+import community.flock.wirespec.compiler.test.compile
 import community.flock.wirespec.compiler.utils.NoLogger
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlin.test.Test
 
 class KotlinEmitterTest {
@@ -595,6 +597,30 @@ class KotlinEmitterTest {
         """.trimMargin()
 
         CompileTypeTest.compiler { KotlinEmitter() } shouldBeRight kotlin
+    }
+
+    @Test
+    fun compileDefaultValuesTest() {
+        val source =
+            // language=ws
+            """
+            |type Defaults {
+            |  name: String = "anonymous",
+            |  count: Integer = 0,
+            |  count32: Integer32 = 0,
+            |  ratio: Number = 1.5,
+            |  ratio32: Number32 = 1.5,
+            |  active: Boolean = true
+            |}
+            """.trimMargin()
+
+        val result = compile(source)({ KotlinEmitter() }).shouldBeRight()
+        result shouldContain "val name: String = \"anonymous\""
+        result shouldContain "val count: Long = 0L"
+        result shouldContain "val count32: Int = 0"
+        result shouldContain "val ratio: Double = 1.5"
+        result shouldContain "val ratio32: Float = 1.5f"
+        result shouldContain "val active: Boolean = true"
     }
 
     @Test

--- a/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
+++ b/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
@@ -18,10 +18,12 @@ import community.flock.wirespec.compiler.test.CompileRefinedTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.compiler.test.NodeFixtures
+import community.flock.wirespec.compiler.test.compile
 import community.flock.wirespec.compiler.utils.NoLogger
 import community.flock.wirespec.ir.generator.KotlinGenerator
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlin.test.Test
 
 class KotlinIrEmitterTest {
@@ -117,6 +119,30 @@ class KotlinIrEmitterTest {
         val kotlin = EmitterFixtures.compileTypeTest
 
         CompileTypeTest.compiler { KotlinIrEmitter() } shouldBeRight kotlin
+    }
+
+    @Test
+    fun compileDefaultValuesTest() {
+        val source =
+            // language=ws
+            """
+            |type Defaults {
+            |  name: String = "anonymous",
+            |  count: Integer = 0,
+            |  count32: Integer32 = 0,
+            |  ratio: Number = 1.5,
+            |  ratio32: Number32 = 1.5,
+            |  active: Boolean = true
+            |}
+            """.trimMargin()
+
+        val result = compile(source)({ KotlinIrEmitter() }).shouldBeRight()
+        result shouldContain "val name: String = \"anonymous\""
+        result shouldContain "val count: Long = 0L"
+        result shouldContain "val count32: Int = 0"
+        result shouldContain "val ratio: Double = 1.5"
+        result shouldContain "val ratio32: Float = 1.5f"
+        result shouldContain "val active: Boolean = true"
     }
 
     @Test

--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonTypeDefinitionEmitter.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonTypeDefinitionEmitter.kt
@@ -3,6 +3,7 @@ package community.flock.wirespec.emitters.python
 import community.flock.wirespec.compiler.core.emit.Spacer
 import community.flock.wirespec.compiler.core.emit.TypeDefinitionEmitter
 import community.flock.wirespec.compiler.core.emit.importReferences
+import community.flock.wirespec.compiler.core.parse.ast.DefaultValue
 import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
@@ -29,7 +30,15 @@ interface PythonTypeDefinitionEmitter : TypeDefinitionEmitter, PythonIdentifierE
 
     override fun Type.Shape.emit() = value.joinToString("\n") { "${Spacer}${it.emit()}" }
 
-    override fun Field.emit() = "${emit(identifier)}: '${reference.emit()}'"
+    override fun Field.emit() = "${emit(identifier)}: '${reference.emit()}'${defaultValue.emit()}"
+
+    private fun DefaultValue?.emit() = when (this) {
+        null -> ""
+        is DefaultValue.StringValue -> " = '$value'"
+        is DefaultValue.IntegerValue -> " = $value"
+        is DefaultValue.NumberValue -> " = $value"
+        is DefaultValue.BooleanValue -> " = ${value.toString().replaceFirstChar { it.uppercase() }}"
+    }
 
     override fun Reference.emit() = emitType().let { if (isNullable) "Optional[$it]" else it }
 

--- a/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonEmitterTest.kt
+++ b/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonEmitterTest.kt
@@ -16,9 +16,11 @@ import community.flock.wirespec.compiler.test.CompileRefinedTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.compiler.test.NodeFixtures
+import community.flock.wirespec.compiler.test.compile
 import community.flock.wirespec.compiler.utils.NoLogger
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlin.test.Test
 
 class PythonEmitterTest {
@@ -1008,6 +1010,26 @@ class PythonEmitterTest {
             |
             """.trimMargin()
         result shouldBeRight expect
+    }
+
+    @Test
+    fun compileDefaultValuesTest() {
+        val source =
+            // language=ws
+            """
+            |type Defaults {
+            |  name: String = "anonymous",
+            |  count: Integer = 0,
+            |  ratio: Number = 1.5,
+            |  active: Boolean = true
+            |}
+            """.trimMargin()
+
+        val result = compile(source)({ PythonEmitter() }).shouldBeRight()
+        result shouldContain "name: 'str' = 'anonymous'"
+        result shouldContain "count: 'int' = 0"
+        result shouldContain "ratio: 'float' = 1.5"
+        result shouldContain "active: 'bool' = True"
     }
 
     private fun EmitContext.emitFirst(node: Definition) = emitters.map {

--- a/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
+++ b/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
@@ -18,10 +18,12 @@ import community.flock.wirespec.compiler.test.CompileRefinedTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.compiler.test.NodeFixtures
+import community.flock.wirespec.compiler.test.compile
 import community.flock.wirespec.compiler.utils.NoLogger
 import community.flock.wirespec.ir.generator.ScalaGenerator
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlin.test.Test
 
 class ScalaIrEmitterTest {
@@ -75,6 +77,26 @@ class ScalaIrEmitterTest {
         val scala = EmitterFixtures.compileTypeTest
 
         CompileTypeTest.compiler { ScalaIrEmitter() } shouldBeRight scala
+    }
+
+    @Test
+    fun compileDefaultValuesTest() {
+        val source =
+            // language=ws
+            """
+            |type Defaults {
+            |  name: String = "anonymous",
+            |  count: Integer = 0,
+            |  ratio32: Number32 = 1.5,
+            |  active: Boolean = true
+            |}
+            """.trimMargin()
+
+        val result = compile(source)({ ScalaIrEmitter() }).shouldBeRight()
+        result shouldContain "= \"anonymous\""
+        result shouldContain "= 0L"
+        result shouldContain "= 1.5f"
+        result shouldContain "= true"
     }
 
     @Test

--- a/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecTypeDefinitionEmitter.kt
+++ b/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecTypeDefinitionEmitter.kt
@@ -2,6 +2,7 @@ package community.flock.wirespec.emitters.wirespec
 
 import community.flock.wirespec.compiler.core.emit.Spacer
 import community.flock.wirespec.compiler.core.emit.TypeDefinitionEmitter
+import community.flock.wirespec.compiler.core.parse.ast.DefaultValue
 import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
@@ -17,7 +18,15 @@ interface WirespecTypeDefinitionEmitter : TypeDefinitionEmitter, WirespecIdentif
 
     override fun Type.Shape.emit() = value.joinToString(",\n") { "$Spacer${it.emit()}" }
 
-    override fun Field.emit() = "${emit(identifier)}: ${reference.emit()}"
+    override fun Field.emit() = "${emit(identifier)}: ${reference.emit()}${defaultValue.emit()}"
+
+    private fun DefaultValue?.emit() = when (this) {
+        null -> ""
+        is DefaultValue.StringValue -> " = \"$value\""
+        is DefaultValue.IntegerValue -> " = $value"
+        is DefaultValue.NumberValue -> " = $value"
+        is DefaultValue.BooleanValue -> " = $value"
+    }
 
     override fun Reference.emit(): String = when (this) {
         is Reference.Dict -> "{ ${reference.emit()} }"

--- a/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
+++ b/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
@@ -9,6 +9,7 @@ import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
+import community.flock.wirespec.compiler.test.compile
 import io.kotest.assertions.arrow.core.shouldBeRight
 import kotlin.test.Test
 
@@ -212,5 +213,22 @@ class WirespecEmitterTest {
         """.trimMargin()
 
         CompileComplexModelTest.compiler { WirespecEmitter() } shouldBeRight wirespec
+    }
+
+    @Test
+    fun compileDefaultValuesTest() {
+        val source =
+            // language=ws
+            """
+            |type Defaults {
+            |  name: String = "anonymous",
+            |  count: Integer = 0,
+            |  ratio: Number = 1.5,
+            |  active: Boolean = true
+            |}
+            |
+        """.trimMargin()
+
+        compile(source)({ WirespecEmitter() }) shouldBeRight source
     }
 }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -39,6 +39,7 @@ import community.flock.wirespec.ir.core.file
 import community.flock.wirespec.ir.core.`interface`
 import community.flock.wirespec.ir.core.transformMatchingElements
 import community.flock.wirespec.compiler.core.parse.ast.Channel as ChannelWirespec
+import community.flock.wirespec.compiler.core.parse.ast.DefaultValue as DefaultValueWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Definition as DefinitionWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint as EndpointWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Enum as EnumWirespec
@@ -270,7 +271,7 @@ fun TypeWirespec.convert() = file(identifier.toName()) {
         implements(Type.Custom("Wirespec.Model"))
         extends.map { it.convert() }.filterIsInstance<Type.Custom>().forEach { implements(it) }
         shape.value.forEach {
-            field(it.identifier.toName(), it.reference.convert())
+            field(it.identifier.toName(), it.reference.convert(), defaultValue = it.defaultValue?.toLiteral(it.reference))
         }
         function("validate", isOverride = true) {
             returnType(Type.Array(Type.String))
@@ -947,6 +948,16 @@ private fun Type.toTypeName(): String = when (this) {
     is Type.Dict -> "Map"
     is Type.IntegerLiteral -> "Integer"
     is Type.StringLiteral -> "String"
+}
+
+fun DefaultValueWirespec.toLiteral(reference: ReferenceWirespec): Literal {
+    val irType = reference.convert().let { if (it is Type.Nullable) it.type else it }
+    return when (this) {
+        is DefaultValueWirespec.StringValue -> Literal(value, Type.String)
+        is DefaultValueWirespec.BooleanValue -> Literal(value, Type.Boolean)
+        is DefaultValueWirespec.IntegerValue -> Literal(value, irType as? Type.Integer ?: Type.Integer(Precision.P64))
+        is DefaultValueWirespec.NumberValue -> Literal(value, irType as? Type.Number ?: Type.Number(Precision.P64))
+    }
 }
 
 fun ReferenceWirespec.convert(): Type = when (this) {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
@@ -130,6 +130,7 @@ data class Field(
     val name: Name,
     val type: Type,
     val isOverride: Boolean = false,
+    val defaultValue: Literal? = null,
 )
 
 data class Function(

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Dsl.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Dsl.kt
@@ -305,8 +305,8 @@ class StructBuilder(private val name: Name) : ContainerBuilder {
         fields.add(Field(Name.of(name), type, isOverride))
     }
 
-    fun field(name: Name, type: Type, isOverride: Boolean = false) {
-        fields.add(Field(name, type, isOverride))
+    fun field(name: Name, type: Type, isOverride: Boolean = false, defaultValue: Literal? = null) {
+        fields.add(Field(name, type, isOverride, defaultValue))
     }
 
     fun construct(type: Type, block: ConstructorBuilder.() -> Unit = {}): ConstructorStatement {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
@@ -199,7 +199,8 @@ object KotlinGenerator : Generator {
 
         val paramsStr = fields.joinNonEmpty(",\n", "(\n", "\n${")".indentCode(indent)}") {
             val overridePrefix = "override ".takeIf { _ -> it.isOverride }.orEmpty()
-            "${overridePrefix}val ${it.name.value().sanitize()}: ${it.type.emitGenerics()}".indentCode(indent + 1)
+            val default = it.defaultValue?.let { d -> " = ${d.emitDefaultValue()}" }.orEmpty()
+            "${overridePrefix}val ${it.name.value().sanitize()}: ${it.type.emitGenerics()}$default".indentCode(indent + 1)
         }
         val hasBody = customConstructors.isNotEmpty() || nestedContent.isNotEmpty()
         return if (hasBody) {
@@ -483,6 +484,14 @@ object KotlinGenerator : Generator {
 
     private fun Literal.emit(): String = when (type) {
         Type.String -> "\"$value\""
+        else -> value.toString()
+    }
+
+    private fun Literal.emitDefaultValue(): String = when (val t = type) {
+        Type.String -> "\"$value\""
+        Type.Boolean -> value.toString()
+        is Type.Integer -> if (t.precision == Precision.P64) "${value}L" else value.toString()
+        is Type.Number -> if (t.precision == Precision.P32) "${value}f" else value.toString()
         else -> value.toString()
     }
 

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
@@ -219,7 +219,10 @@ object PythonGenerator : Generator {
         return "def __init__(\n$selfParam$paramLines,\n$closeParen$content\n".indentCode(indent)
     }
 
-    private fun Field.emit(indent: Int, qualifier: ((String) -> String)? = null): String = "${name.value()}: ${type.emit(qualifier)}\n".indentCode(indent)
+    private fun Field.emit(indent: Int, qualifier: ((String) -> String)? = null): String {
+        val default = defaultValue?.let { " = ${it.emit()}" }.orEmpty()
+        return "${name.value()}: ${type.emit(qualifier)}$default\n".indentCode(indent)
+    }
 
     private fun AstFunction.emit(indent: Int, isInClass: Boolean = false, isStaticScope: Boolean = false, isInInterface: Boolean = false, qualifier: ((String) -> String)? = null): String {
         val params = parameters.joinToString(", ") {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
@@ -258,7 +258,8 @@ object ScalaGenerator : Generator {
         } else {
             fields.joinToString(",\n", "(\n", "\n${")".indentCode(indent)}") {
                 val overridePrefix = "override ".takeIf { _ -> it.isOverride }.orEmpty()
-                "${overridePrefix}val ${it.name.value().sanitize()}: ${it.type.emitTypeAnnotation()}".indentCode(indent + 1)
+                val default = it.defaultValue?.let { d -> " = ${d.emitDefaultValue()}" }.orEmpty()
+                "${overridePrefix}val ${it.name.value().sanitize()}: ${it.type.emitTypeAnnotation()}$default".indentCode(indent + 1)
             }
         }
         val hasBody = customConstructors.isNotEmpty() || nestedContent.isNotEmpty()
@@ -542,6 +543,14 @@ object ScalaGenerator : Generator {
     private fun Literal.emit(): String = when (type) {
         Type.String -> "\"$value\""
         is Type.Integer -> if (type.precision == Precision.P64) "${value}L" else value.toString()
+        else -> value.toString()
+    }
+
+    private fun Literal.emitDefaultValue(): String = when (val t = type) {
+        Type.String -> "\"$value\""
+        Type.Boolean -> value.toString()
+        is Type.Integer -> if (t.precision == Precision.P64) "${value}L" else value.toString()
+        is Type.Number -> if (t.precision == Precision.P32) "${value}f" else value.toString()
         else -> value.toString()
     }
 

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroConverter.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroConverter.kt
@@ -1,5 +1,6 @@
 package community.flock.wirespec.converter.avro
 
+import community.flock.wirespec.compiler.core.parse.ast.DefaultValue
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Enum
@@ -8,6 +9,10 @@ import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.longOrNull
 
 object AvroConverter {
 
@@ -61,10 +66,22 @@ object AvroConverter {
                     identifier = FieldIdentifier(it.name),
                     annotations = emptyList(),
                     reference = it.type.toReference(),
+                    defaultValue = it.default?.toDefaultValue(),
                 )
             },
         ),
     )
+
+    private fun kotlinx.serialization.json.JsonElement.toDefaultValue(): DefaultValue? {
+        val primitive = this as? JsonPrimitive ?: return null
+        return when {
+            primitive is JsonNull -> null
+            primitive.isString -> DefaultValue.StringValue(primitive.content)
+            primitive.booleanOrNull != null -> DefaultValue.BooleanValue(primitive.booleanOrNull!!)
+            primitive.longOrNull != null -> DefaultValue.IntegerValue(primitive.content)
+            else -> DefaultValue.NumberValue(primitive.content)
+        }
+    }
 
     private fun AvroModel.EnumType.toEnum() = Enum(
         comment = null,

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitter.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitter.kt
@@ -5,6 +5,7 @@ import community.flock.wirespec.compiler.core.emit.Emitted
 import community.flock.wirespec.compiler.core.emit.Emitter
 import community.flock.wirespec.compiler.core.emit.FileExtension
 import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.compiler.core.parse.ast.DefaultValue
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
@@ -48,9 +49,18 @@ object AvroIdlEmitter : Emitter {
     private fun renderRecord(type: Type): String {
         val doc = type.comment?.value?.let { renderDoc(it, INDENT) }.orEmpty()
         val fields = type.shape.value.joinToString("") { field ->
-            "$INDENT$INDENT${renderReference(field.reference)} ${field.identifier.value};\n"
+            val default = if (field.reference.isNullable) "" else field.defaultValue.renderDefault()
+            "$INDENT$INDENT${renderReference(field.reference)} ${field.identifier.value}$default;\n"
         }
         return "$doc${INDENT}record ${type.identifier.value} {\n$fields$INDENT}\n"
+    }
+
+    private fun DefaultValue?.renderDefault() = when (this) {
+        null -> ""
+        is DefaultValue.StringValue -> " = \"$value\""
+        is DefaultValue.IntegerValue -> " = $value"
+        is DefaultValue.NumberValue -> " = $value"
+        is DefaultValue.BooleanValue -> " = $value"
     }
 
     private fun renderEnum(enum: Enum): String {

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlParser.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroIdlParser.kt
@@ -8,6 +8,10 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.converter.avro.AvroConverter.flatten
 import community.flock.wirespec.converter.common.Parser
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
 
 object AvroIdlParser : Parser {
 
@@ -113,24 +117,29 @@ object AvroIdlParser : Parser {
             )
         }
 
-        private fun parseDefaultValue(): String {
+        private fun parseDefaultValue(): JsonElement {
             val token = peekToken() ?: error("Expected default value")
             return when (token) {
                 is AvroIdlToken.StringLiteral -> {
                     advance()
-                    token.value
+                    JsonPrimitive(token.value)
                 }
                 is AvroIdlToken.NumberLiteral -> {
                     advance()
-                    token.value
+                    Json.parseToJsonElement(token.value)
                 }
                 is AvroIdlToken.Identifier -> {
                     advance()
-                    token.value
+                    when (token.value) {
+                        "true" -> JsonPrimitive(true)
+                        "false" -> JsonPrimitive(false)
+                        "null" -> JsonNull
+                        else -> JsonPrimitive(token.value)
+                    }
                 }
                 is AvroIdlToken.Symbol -> when (token.value) {
-                    '[' -> readMatchedBlock('[', ']')
-                    '{' -> readMatchedBlock('{', '}')
+                    '[' -> Json.parseToJsonElement(readMatchedBlock('[', ']'))
+                    '{' -> Json.parseToJsonElement(readMatchedBlock('{', '}'))
                     else -> error("Unexpected symbol in default value: ${token.value}")
                 }
                 else -> error("Unexpected token in default value: $token")

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroJsonEmitter.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroJsonEmitter.kt
@@ -5,6 +5,7 @@ import community.flock.wirespec.compiler.core.emit.Emitted
 import community.flock.wirespec.compiler.core.emit.Emitter
 import community.flock.wirespec.compiler.core.emit.FileExtension
 import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.compiler.core.parse.ast.DefaultValue
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Field
@@ -16,6 +17,8 @@ import community.flock.wirespec.compiler.core.parse.ast.Union
 import community.flock.wirespec.compiler.utils.Logger
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 
 object AvroJsonEmitter : Emitter {
 
@@ -105,9 +108,19 @@ object AvroJsonEmitter : Emitter {
                 } else {
                     AvroModel.TypeList(field.emit(module, hasEmitted))
                 },
+                // Avro requires a union default to match its first branch (null for nullable
+                // fields), so a scalar default is only valid on a non-nullable field.
+                default = if (field.reference.isNullable) null else field.defaultValue?.toAvroDefault(),
             )
         },
     )
+
+    private fun DefaultValue.toAvroDefault(): JsonElement = when (this) {
+        is DefaultValue.StringValue -> JsonPrimitive(value)
+        is DefaultValue.BooleanValue -> JsonPrimitive(value)
+        is DefaultValue.IntegerValue -> JsonPrimitive(value.toLong())
+        is DefaultValue.NumberValue -> JsonPrimitive(value.toDouble())
+    }
 
     fun emit(module: Module): List<AvroModel.Type> {
         val hasEmitted = mutableListOf<String>()

--- a/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroModel.kt
+++ b/src/converter/avro/src/commonMain/kotlin/community/flock/wirespec/converter/avro/AvroModel.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
@@ -25,7 +26,7 @@ object AvroModel {
         val name: String,
         val type: TypeList,
         val doc: String? = null,
-        val default: String? = null,
+        val default: JsonElement? = null,
     )
 
     @Serializable(with = TypeListSerializer::class)

--- a/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitterTest.kt
+++ b/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroIdlEmitterTest.kt
@@ -47,6 +47,15 @@ class AvroIdlEmitterTest {
     }
 
     @Test
+    fun emitsDefaultValues() {
+        val ast = parse("type Pet { name: String = \"Rex\", age: Integer = 3, active: Boolean = true }")
+        val output = AvroIdlEmitter.emit(ast.modules.first(), "Test")
+        output shouldContain "string name = \"Rex\";"
+        output shouldContain "long age = 3;"
+        output shouldContain "boolean active = true;"
+    }
+
+    @Test
     fun emitsAllPrimitives() {
         val ast = parse(
             """

--- a/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroJsonEmitterTest.kt
+++ b/src/converter/avro/src/commonTest/kotlin/community/flock/wirespec/converter/avro/AvroJsonEmitterTest.kt
@@ -641,6 +641,41 @@ class AvroJsonEmitterTest {
     }
 
     @Test
+    fun testDefaultValues() {
+        val source =
+            // language=ws
+            """
+            |type Defaults {
+            |  name: String = "anonymous",
+            |  count: Integer = 0,
+            |  ratio: Number = 1.5,
+            |  active: Boolean = true
+            |}
+            """.trimMargin()
+
+        val ast = parse(source)
+        val actual = AvroJsonEmitter.emit(ast.modules.first()).let { json.encodeToString(it) }
+        val expected =
+            // language=json
+            """
+            |[
+            |    {
+            |        "type": "record",
+            |        "name": "Defaults",
+            |        "fields": [
+            |            { "name": "name", "type": "string", "default": "anonymous" },
+            |            { "name": "count", "type": "long", "default": 0 },
+            |            { "name": "ratio", "type": "double", "default": 1.5 },
+            |            { "name": "active", "type": "boolean", "default": true }
+            |        ]
+            |    }
+            |]
+            """.trimMargin()
+
+        actual shouldEqualJson expected
+    }
+
+    @Test
     fun compileTypeTest() {
         val result = CompileTypeTest.compiler { AvroJsonEmitter }
         val expect =

--- a/src/site/docs/docs/converters/avro.md
+++ b/src/site/docs/docs/converters/avro.md
@@ -27,9 +27,25 @@ Wirespec supports converting Avro schemas (.avsc) into Wirespec types.
 | `map` | `Dict` | Converted to a Dictionary (Map) |
 | `union` | `Union` | Converted to a Wirespec Union. Unions with `null` become nullable types. |
 
+## Defaults
+
+Scalar default values are preserved in both directions. Reading an Avro schema maps a field's
+`default` to a Wirespec field default, and emitting a schema writes the default back. A default is
+only written for non-nullable fields, since Avro requires a union default to match its first
+branch (`null` for nullable fields).
+
+```wirespec
+type Pet {
+  name: String = "Rex",
+  age: Integer = 3,
+  active: Boolean = true
+}
+```
+
 ## Limitations
 
-- **Defaults**: Avro default values are currently ignored and not preserved in the Wirespec output.
+- **Defaults**: Only scalar defaults (string, integer, number, boolean) are supported; complex
+  defaults (arrays, maps, records) are not preserved.
 - **Unions**: There are some restrictions on Unions involving multiple simple types.
 
 ## Playground


### PR DESCRIPTION
Add a `field: Type = value` default-value syntax for scalar fields
(String, Integer, Number, Boolean). Defaults flow through the parser AST
and the IR, are emitted natively where the target language supports them
(Kotlin, Python, Scala), are preserved on the Wirespec round-trip, and
are written to / read from Avro schemas (.avsc and .avdl). Java records,
TypeScript type aliases and Rust structs cannot express per-field
defaults, so their type declarations are left unchanged.

https://claude.ai/code/session_014V9V5ZXocEa6KJnvLBkjcP