### PR TITLE
feat(compiler): add type spread operator (...) for composite types

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
@@ -37,6 +37,7 @@ import community.flock.wirespec.compiler.core.tokenize.RightParenthesis
 import community.flock.wirespec.compiler.core.tokenize.ScreamingKebabCaseIdentifier
 import community.flock.wirespec.compiler.core.tokenize.ScreamingSnakeCaseIdentifier
 import community.flock.wirespec.compiler.core.tokenize.SnakeCaseIdentifier
+import community.flock.wirespec.compiler.core.tokenize.Spread
 import community.flock.wirespec.compiler.core.tokenize.TokenType
 import community.flock.wirespec.compiler.core.tokenize.TypeDefinition
 import community.flock.wirespec.compiler.core.tokenize.TypeIdentifier
@@ -80,6 +81,7 @@ object WirespecSpec : LanguageSpec {
         Regex("^\\|") to Pipe,
         Regex("^:") to Colon,
         Regex("^,") to Comma,
+        Regex("^\\.\\.\\.") to Spread,
         Regex("^\\?") to QuestionMark,
         Regex("^#") to Hash,
         Regex("^\\[\\]") to Brackets,

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/ValidationError.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/ValidationError.kt
@@ -39,3 +39,15 @@ class DuplicateChannelError(typeName: String) :
         coordinates = Token.Coordinates(),
         message = "Channel '$typeName' is already defined",
     )
+
+class SpreadTypeError(typeName: String) :
+    ValidationError(
+        coordinates = Token.Coordinates(),
+        message = "Cannot spread '$typeName' because it is not a record type",
+    )
+
+class SpreadCycleError(typeName: String) :
+    ValidationError(
+        coordinates = Token.Coordinates(),
+        message = "Spread cycle detected for type '$typeName'",
+    )

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
@@ -6,7 +6,6 @@ import community.flock.wirespec.compiler.core.exceptions.WirespecException
 import community.flock.wirespec.compiler.core.parse.AnnotationParser.parseAnnotations
 import community.flock.wirespec.compiler.core.parse.TypeParser.parseDict
 import community.flock.wirespec.compiler.core.parse.TypeParser.parseType
-import community.flock.wirespec.compiler.core.parse.TypeParser.parseTypeShape
 import community.flock.wirespec.compiler.core.parse.ast.Annotation
 import community.flock.wirespec.compiler.core.parse.ast.Comment
 import community.flock.wirespec.compiler.core.parse.ast.Definition
@@ -33,6 +32,7 @@ import community.flock.wirespec.compiler.core.tokenize.RegExp
 import community.flock.wirespec.compiler.core.tokenize.RightCurly
 import community.flock.wirespec.compiler.core.tokenize.RightParenthesis
 import community.flock.wirespec.compiler.core.tokenize.SpecificType
+import community.flock.wirespec.compiler.core.tokenize.Spread
 import community.flock.wirespec.compiler.core.tokenize.Token
 import community.flock.wirespec.compiler.core.tokenize.TokenType
 import community.flock.wirespec.compiler.core.tokenize.TypeDefinitionStart
@@ -57,26 +57,7 @@ object TypeParser {
     }
 
     fun TokenProvider.parseTypeShape(): Either<WirespecException, Type.Shape> = parseToken {
-        mutableListOf<Field>().apply {
-            val firstFieldAnnotations = parseAnnotations().bind()
-            when (token.type) {
-                is WirespecIdentifier -> add(parseField(FieldIdentifier(token.value), firstFieldAnnotations).bind())
-                else -> raiseWrongToken<WirespecIdentifier>().bind()
-            }
-            while (token.type is Comma) {
-                eatToken().bind()
-                val fieldAnnotations = parseAnnotations().bind()
-                when (token.type) {
-                    is WirespecIdentifier -> add(parseField(FieldIdentifier(token.value), fieldAnnotations).bind())
-                    else -> raiseWrongToken<WirespecIdentifier>().bind()
-                }
-            }
-        }.also {
-            when (token.type) {
-                is RightCurly -> eatToken().bind()
-                else -> raiseWrongToken<RightCurly>().bind()
-            }
-        }.let(Type::Shape)
+        parseShapeEntries(allowSpread = false).bind().let { Type.Shape(it.fields) }
     }
 
     fun TokenProvider.parseDict(): Either<WirespecException, Reference.Dict> = parseToken {
@@ -133,15 +114,71 @@ object TypeParser {
 private fun TokenProvider.parseTypeDefinition(comment: Comment?, annotations: List<Annotation>, typeName: DefinitionIdentifier) = parseToken {
     when (token.type) {
         is Equals -> parseRefinedOrUnion(comment, annotations, typeName).bind()
-        is LeftCurly -> Type(
-            comment = comment,
-            annotations = annotations,
-            identifier = typeName,
-            shape = parseTypeShape().bind(),
-            extends = emptyList(),
-        )
+        is LeftCurly -> parseSpreadableTypeShape().bind().let { parsed ->
+            Type(
+                comment = comment,
+                annotations = annotations,
+                identifier = typeName,
+                shape = Type.Shape(parsed.fields),
+                extends = emptyList(),
+                spread = parsed.spreads,
+            )
+        }
 
         else -> raiseWrongToken<TypeDefinitionStart>().bind()
+    }
+}
+
+private class ParsedShape(val fields: List<Field>, val spreads: List<Type.Spread>)
+
+private sealed interface ShapeEntry {
+    data class FieldEntry(val field: Field) : ShapeEntry
+    data class SpreadEntry(val reference: Reference) : ShapeEntry
+}
+
+private fun TokenProvider.parseSpreadableTypeShape(): Either<WirespecException, ParsedShape> = parseToken {
+    parseShapeEntries(allowSpread = true).bind()
+}
+
+private fun TokenProvider.parseShapeEntries(allowSpread: Boolean): Either<WirespecException, ParsedShape> = either {
+    val entries = mutableListOf<ShapeEntry>()
+    entries.add(parseShapeEntry(allowSpread).bind())
+    while (token.type is Comma) {
+        eatToken().bind()
+        entries.add(parseShapeEntry(allowSpread).bind())
+    }
+    when (token.type) {
+        is RightCurly -> eatToken().bind()
+        else -> raiseWrongToken<RightCurly>().bind()
+    }
+    val fields = mutableListOf<Field>()
+    val spreads = mutableListOf<Type.Spread>()
+    entries.forEach { entry ->
+        when (entry) {
+            is ShapeEntry.FieldEntry -> fields.add(entry.field)
+            is ShapeEntry.SpreadEntry -> spreads.add(Type.Spread(entry.reference, fields.size))
+        }
+    }
+    ParsedShape(fields, spreads)
+}
+
+private fun TokenProvider.parseShapeEntry(allowSpread: Boolean): Either<WirespecException, ShapeEntry> = either {
+    val annotations = parseAnnotations().bind()
+    when (token.type) {
+        is Spread -> {
+            if (!allowSpread) raiseWrongToken<WirespecIdentifier>().bind()
+            eatToken().bind()
+            when (token.type) {
+                is TypeIdentifier -> ShapeEntry.SpreadEntry(
+                    Reference.Custom(token.shouldBeDefined().bind().value, false),
+                ).also { eatToken().bind() }
+
+                else -> raiseWrongToken<TypeIdentifier>().bind()
+            }
+        }
+
+        is WirespecIdentifier -> ShapeEntry.FieldEntry(parseField(FieldIdentifier(token.value), annotations).bind())
+        else -> raiseWrongToken<WirespecIdentifier>().bind()
     }
 }
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
@@ -56,8 +56,14 @@ data class Type(
     override val identifier: DefinitionIdentifier,
     val shape: Shape,
     val extends: List<Reference>,
+    val spread: List<Spread> = emptyList(),
 ) : Model {
     data class Shape(override val value: List<Field>) : Value<List<Field>>
+
+    // Carries `...Type` spread targets from the parser until the validator flattens them
+    // into `shape`. `index` is the number of own fields preceding the spread, which
+    // preserves the textual ordering of fields once the referenced fields are spliced in.
+    data class Spread(val reference: Reference, val index: Int)
 }
 
 data class Enum(

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
@@ -10,6 +10,7 @@ data object RightBracket : TokenType
 
 data object Colon : TokenType
 data object Comma : TokenType
+data object Spread : TokenType
 data object QuestionMark : TokenType
 data object Hash : TokenType
 data object Brackets : TokenType

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/validate/Validator.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/validate/Validator.kt
@@ -5,11 +5,14 @@ import arrow.core.EitherNel
 import arrow.core.left
 import arrow.core.nel
 import arrow.core.raise.either
+import arrow.core.raise.ensure
 import arrow.core.right
 import arrow.core.toNonEmptyListOrNull
 import community.flock.wirespec.compiler.core.exceptions.DuplicateChannelError
 import community.flock.wirespec.compiler.core.exceptions.DuplicateEndpointError
 import community.flock.wirespec.compiler.core.exceptions.DuplicateTypeError
+import community.flock.wirespec.compiler.core.exceptions.SpreadCycleError
+import community.flock.wirespec.compiler.core.exceptions.SpreadTypeError
 import community.flock.wirespec.compiler.core.exceptions.UnionError
 import community.flock.wirespec.compiler.core.exceptions.WirespecException
 import community.flock.wirespec.compiler.core.parse.ParseOptions
@@ -17,6 +20,7 @@ import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
@@ -26,12 +30,52 @@ import community.flock.wirespec.compiler.core.parse.ast.Union
 
 object Validator {
 
-    fun validate(options: ParseOptions, ast: AST): EitherNel<WirespecException, AST> = zipOrAccumulate(
-        validateWithOptions(ast, options),
-        validateEndpoints(ast),
-        validateTypes(ast),
-        validateChannels(ast),
-    ) { a, _, _, _ -> a }
+    fun validate(options: ParseOptions, ast: AST): EitherNel<WirespecException, AST> = either {
+        val validated = zipOrAccumulate(
+            validateWithOptions(ast, options),
+            validateEndpoints(ast),
+            validateTypes(ast),
+            validateChannels(ast),
+        ) { a, _, _, _ -> a }.bind()
+        validated.resolveSpreads().bind()
+    }
+
+    private fun AST.resolveSpreads(): EitherNel<WirespecException, AST> = either {
+        val typesByName = modules
+            .flatMap { it.statements }
+            .filterIsInstance<Type>()
+            .associateBy { it.identifier.value }
+        AST(
+            modules.map { module ->
+                module.copy(
+                    statements = module.statements.map { definition ->
+                        when (definition) {
+                            is Type -> definition.flattenSpread(typesByName, emptySet()).bind()
+                            else -> definition
+                        }
+                    },
+                )
+            },
+        )
+    }
+
+    private fun Type.flattenSpread(typesByName: Map<String, Type>, visiting: Set<String>): EitherNel<WirespecException, Type> = either {
+        if (spread.isEmpty()) {
+            this@flattenSpread
+        } else {
+            ensure(identifier.value !in visiting) { SpreadCycleError(identifier.value).nel() }
+            val ownFields = shape.value
+            val merged = mutableListOf<Field>()
+            (0..ownFields.size).forEach { position ->
+                spread.filter { it.index == position }.forEach { sp ->
+                    val target = typesByName[sp.reference.value] ?: raise(SpreadTypeError(sp.reference.value).nel())
+                    merged.addAll(target.flattenSpread(typesByName, visiting + identifier.value).bind().shape.value)
+                }
+                if (position < ownFields.size) merged.add(ownFields[position])
+            }
+            copy(shape = Type.Shape(merged), spread = emptyList())
+        }
+    }
 
     private fun validateWithOptions(ast: AST, options: ParseOptions): EitherNel<WirespecException, AST> = ast.modules
         .map { (uri, statements) -> runValidateOptions(options)(statements).map { Module(uri, it) } }

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseTypeTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseTypeTest.kt
@@ -188,6 +188,64 @@ class ParseTypeTest {
     }
 
     @Test
+    fun testTypeSpread() {
+        val source =
+            // language=ws
+            """
+            |type Pagination { page: Integer?, size: Integer? }
+            |type SomeQuery { ...Pagination, query: String? }
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight { it.head.message }
+            .shouldHaveSize(2)[1]
+            .shouldBeInstanceOf<Type>()
+            .also { it.identifier.value shouldBe "SomeQuery" }
+            .shape.value
+            .map { it.identifier.value }
+            .shouldBe(listOf("page", "size", "query"))
+    }
+
+    @Test
+    fun testTypeSpreadPreservesFieldOrder() {
+        val source =
+            // language=ws
+            """
+            |type Base { a: String }
+            |type Mixed { x: String, ...Base, y: String }
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight { it.head.message }
+            .shouldHaveSize(2)[1]
+            .shouldBeInstanceOf<Type>()
+            .also { it.identifier.value shouldBe "Mixed" }
+            .shape.value
+            .map { it.identifier.value }
+            .shouldBe(listOf("x", "a", "y"))
+    }
+
+    @Test
+    fun testTypeSpreadIsTransitive() {
+        val source =
+            // language=ws
+            """
+            |type A { a: String }
+            |type B { ...A, b: String }
+            |type C { ...B, c: String }
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight { it.head.message }
+            .shouldHaveSize(3)[2]
+            .shouldBeInstanceOf<Type>()
+            .also { it.identifier.value shouldBe "C" }
+            .shape.value
+            .map { it.identifier.value }
+            .shouldBe(listOf("a", "b", "c"))
+    }
+
+    @Test
     fun testIntegerNumberParser() {
         val source =
             // language=ws

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/validate/ValidatorTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/validate/ValidatorTest.kt
@@ -9,6 +9,8 @@ import community.flock.wirespec.compiler.core.WirespecSpec
 import community.flock.wirespec.compiler.core.exceptions.DuplicateChannelError
 import community.flock.wirespec.compiler.core.exceptions.DuplicateEndpointError
 import community.flock.wirespec.compiler.core.exceptions.DuplicateTypeError
+import community.flock.wirespec.compiler.core.exceptions.SpreadCycleError
+import community.flock.wirespec.compiler.core.exceptions.SpreadTypeError
 import community.flock.wirespec.compiler.core.exceptions.WirespecException
 import community.flock.wirespec.compiler.core.parse
 import community.flock.wirespec.compiler.core.parse.ast.AST
@@ -218,6 +220,52 @@ class ValidatorTest {
                     DuplicateChannelError::class,
                 ),
             )
+    }
+
+    @Test
+    fun spreadNonRecordType() {
+        val source =
+            // language=ws
+            """
+            |type Bar = String
+            |type Foo { ...Bar, x: String }
+            """.trimMargin()
+
+        validate(source)
+            .shouldBeLeft()
+            .head.shouldBeInstanceOf<SpreadTypeError>()
+    }
+
+    @Test
+    fun spreadCycle() {
+        val source =
+            // language=ws
+            """
+            |type A { ...B }
+            |type B { ...A }
+            """.trimMargin()
+
+        validate(source)
+            .shouldBeLeft()
+            .head.shouldBeInstanceOf<SpreadCycleError>()
+    }
+
+    @Test
+    fun spreadAcrossFiles() {
+        val source1 =
+            // language=ws
+            """
+            |type Pagination { page: Integer?, size: Integer? }
+            """.trimMargin()
+
+        val source2 =
+            // language=ws
+            """
+            |type SomeQuery { ...Pagination, query: String? }
+            """.trimMargin()
+
+        validate(source1, source2)
+            .shouldBeRight()
     }
 
     @Test

--- a/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEmitterTest.kt
+++ b/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinEmitterTest.kt
@@ -16,6 +16,7 @@ import community.flock.wirespec.compiler.test.CompileRefinedTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.compiler.test.NodeFixtures
+import community.flock.wirespec.compiler.test.compile
 import community.flock.wirespec.compiler.utils.NoLogger
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.matchers.shouldBe
@@ -576,6 +577,41 @@ class KotlinEmitterTest {
         """.trimMargin()
 
         CompileRefinedTest.compiler { KotlinEmitter() } shouldBeRight kotlin
+    }
+
+    @Test
+    fun compileTypeSpreadTest() {
+        val source = """
+            |type Pagination {
+            |  page: Integer?,
+            |  size: Integer?
+            |}
+            |type SomeQuery {
+            |  ...Pagination,
+            |  query: String?
+            |}
+        """.trimMargin()
+
+        val kotlin = """
+            |package community.flock.wirespec.generated.model
+            |
+            |data class Pagination(
+            |  val page: Long?,
+            |  val size: Long?
+            |)
+            |
+            |package community.flock.wirespec.generated.model
+            |
+            |data class SomeQuery(
+            |  val page: Long?,
+            |  val size: Long?,
+            |  val query: String?
+            |)
+            |
+        """.trimMargin()
+
+        val compiler = compile(source)
+        compiler { KotlinEmitter() } shouldBeRight kotlin
     }
 
     @Test

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
@@ -30,6 +30,7 @@ import community.flock.wirespec.compiler.core.tokenize.RegExp
 import community.flock.wirespec.compiler.core.tokenize.RightBracket
 import community.flock.wirespec.compiler.core.tokenize.RightCurly
 import community.flock.wirespec.compiler.core.tokenize.RightParenthesis
+import community.flock.wirespec.compiler.core.tokenize.Spread
 import community.flock.wirespec.compiler.core.tokenize.Token
 import community.flock.wirespec.compiler.core.tokenize.TokenType
 import community.flock.wirespec.compiler.core.tokenize.TokenizeOptions
@@ -98,6 +99,7 @@ class Lexer : IntellijLexer() {
             RightCurly::class to Types.RIGHT_CURLY,
             Colon::class to Types.COLON,
             Comma::class to Types.COMMA,
+            Spread::class to Types.SPREAD,
             QuestionMark::class to Types.QUESTION_MARK,
             Hash::class to Types.HASH,
             Annotation::class to Types.ANNOTATION,

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/SyntaxHighlighter.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/SyntaxHighlighter.kt
@@ -3,6 +3,7 @@ package community.flock.wirespec.ide.intellij
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors.BRACKETS
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors.COMMA
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors.DOC_COMMENT_MARKUP
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors.DOT
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors.IDENTIFIER
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors.KEYWORD
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors.LINE_COMMENT
@@ -27,6 +28,7 @@ class SyntaxHighlighter : SyntaxHighlighterBase() {
         Types.RIGHT_BRACKET -> arrayOf(BRACKETS)
         Types.COLON -> arrayOf(SEMICOLON)
         Types.COMMA -> arrayOf(COMMA)
+        Types.SPREAD -> arrayOf(DOT)
         Types.WIRESPEC_IDENTIFIER -> arrayOf(PARAMETER)
         Types.TYPE_IDENTIFIER -> arrayOf(IDENTIFIER)
         Types.WS_BOOLEAN -> arrayOf(KEYWORD)

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
@@ -12,6 +12,7 @@ interface Types {
         val RIGHT_PARENTHESES = ElementType("RIGHT_PARENTHESES")
         val COLON = ElementType("COLON")
         val COMMA = ElementType("COMMA")
+        val SPREAD = ElementType("SPREAD")
         val QUESTION_MARK = ElementType("QUESTION_MARK")
         val HASH = ElementType("HASH")
         val FORWARD_SLASH = ElementType("FORWARD_SLASH")

--- a/src/site/docs/docs/language/types.mdx
+++ b/src/site/docs/docs/language/types.mdx
@@ -120,6 +120,37 @@ type Person {
 }
 ```
 
+### Spread
+
+When several types share the same fields you can avoid repeating them by spreading another type into a composite type
+using the `...` operator. The fields of the referenced type are spliced in at the position of the spread, keeping the
+order in which fields are declared:
+
+```wirespec
+type Pagination {
+    page: Integer?,
+    size: Integer?
+}
+
+type SomeQuery {
+    ...Pagination,
+    query: String?
+}
+```
+
+The example above is equivalent to writing all of the fields out by hand:
+
+```wirespec
+type SomeQuery {
+    page: Integer?,
+    size: Integer?,
+    query: String?
+}
+```
+
+A spread can only reference a composite type, and spreads are resolved recursively, so a type that is spread in may
+itself spread other types. Cyclic spreads (a type that spreads itself, directly or indirectly) are reported as an error.
+
 ## Enum
 
 Enums (enumerations) in Wirespec are used to define a type that can only take on one of a predefined set of named


### PR DESCRIPTION
Allow splicing the fields of one composite type into another using the
`...Type` notation, e.g. `type SomeQuery { ...Pagination, query: String? }`.
This avoids duplicating shared fields when Wirespec has no generics.

The tokenizer recognizes a new `...` token, the type parser collects spread
targets per type definition (preserving field order via the spread position),
and the validator flattens spreads into the field list recursively. Spreads of
non-record types and cyclic spreads are reported as validation errors. Because
resolution happens before any downstream consumer runs, emitters and converters
see an ordinary field list and need no changes.

https://claude.ai/code/session_01Km8Nsu5nkJi2BJYS8x2zai