### PR TITLE
feat(integration/wiremock): typesafe willReturn + IR-emitter codegen

### DIFF
--- a/examples/maven-wiremock/src/test/java/community/flock/wirespec/example/maven/wiremock/TodoStubTest.java
+++ b/examples/maven-wiremock/src/test/java/community/flock/wirespec/example/maven/wiremock/TodoStubTest.java
@@ -20,10 +20,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Demonstrates the wiremock integration. The {@code wirespec(GetTodos.class)} factory mirrors WireMock's own
- * {@code get(urlEqualTo(...))} pattern: it returns a stub builder driven by the endpoint's path template and HTTP
- * method. {@code willReturn(response)} then turns a typed Wirespec response into the stub's body, status, and headers —
- * using a Jackson-backed serializer by default.
+ * Demonstrates the wiremock integration. The {@code wirespec(...)} factory mirrors WireMock's own
+ * {@code get(urlEqualTo(...))} pattern: it takes the generated endpoint's {@code Handler.Handlers} and returns a stub
+ * builder driven by the endpoint's path template and HTTP method. {@code willReturn(response)} then turns a typed
+ * Wirespec response into the stub's body, status, and headers — using a Jackson-backed serializer by default. Only
+ * responses that belong to that endpoint type-check, so a mismatch is caught at compile time.
  */
 class TodoStubTest {
 
@@ -46,7 +47,7 @@ class TodoStubTest {
     void stubsTheListEndpoint() throws Exception {
         var todos = List.of(new Todo("1", "Buy milk", false));
 
-        server.stubFor(wirespec(GetTodos.class).willReturn(new GetTodos.Response200(todos)));
+        server.stubFor(wirespec(new GetTodos.Handler.Handlers()).willReturn(new GetTodos.Response200(todos)));
 
         var response = get("/api/todos");
 
@@ -58,7 +59,7 @@ class TodoStubTest {
     void stubsAPathParamEndpoint() throws Exception {
         var todo = new Todo("abc", "Walk dog", true);
 
-        server.stubFor(wirespec(GetTodoById.class).willReturn(new GetTodoById.Response200(todo)));
+        server.stubFor(wirespec(new GetTodoById.Handler.Handlers()).willReturn(new GetTodoById.Response200(todo)));
 
         var response = get("/api/todos/abc");
 
@@ -70,7 +71,7 @@ class TodoStubTest {
     void stubsAnErrorResponse() throws Exception {
         var error = new Error(404L, "not found");
 
-        server.stubFor(wirespec(GetTodoById.class).willReturn(new GetTodoById.Response404(error)));
+        server.stubFor(wirespec(new GetTodoById.Handler.Handlers()).willReturn(new GetTodoById.Response404(error)));
 
         var response = get("/api/todos/missing");
 

--- a/src/integration/wiremock/src/jvmCodegen/kotlin/community/flock/wirespec/integration/wiremock/codegen/Main.kt
+++ b/src/integration/wiremock/src/jvmCodegen/kotlin/community/flock/wirespec/integration/wiremock/codegen/Main.kt
@@ -9,8 +9,8 @@ import community.flock.wirespec.compiler.core.emit.PackageName
 import community.flock.wirespec.compiler.core.parse
 import community.flock.wirespec.compiler.utils.NoLogger
 import community.flock.wirespec.compiler.utils.noLogger
-import community.flock.wirespec.emitters.java.JavaEmitter
-import community.flock.wirespec.emitters.kotlin.KotlinEmitter
+import community.flock.wirespec.emitters.java.JavaIrEmitter
+import community.flock.wirespec.emitters.kotlin.KotlinIrEmitter
 import java.io.File
 
 /**
@@ -36,10 +36,10 @@ fun main(args: Array<String>) {
     val javaRoot = outputDir.resolve("java")
     val kotlinRoot = outputDir.resolve("kotlin")
 
-    JavaEmitter(PackageName("$basePackage.java.generated")).emit(ast, noLogger).forEach {
+    JavaIrEmitter(PackageName("$basePackage.java.generated")).emit(ast, noLogger).forEach {
         javaRoot.resolve(it.file).apply { parentFile.mkdirs() }.writeText(it.result)
     }
-    KotlinEmitter(PackageName("$basePackage.kotlin.generated")).emit(ast, noLogger).forEach {
+    KotlinIrEmitter(PackageName("$basePackage.kotlin.generated")).emit(ast, noLogger).forEach {
         kotlinRoot.resolve(it.file).apply { parentFile.mkdirs() }.writeText(it.result)
     }
 }

--- a/src/integration/wiremock/src/jvmMain/java/community/flock/wirespec/integration/wiremock/java/WirespecWireMock.java
+++ b/src/integration/wiremock/src/jvmMain/java/community/flock/wirespec/integration/wiremock/java/WirespecWireMock.java
@@ -8,31 +8,22 @@ import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import community.flock.wirespec.integration.jackson.java.WirespecSerialization;
 import community.flock.wirespec.java.Wirespec;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
  * Start building a WireMock stub for a Wirespec endpoint. Mirrors WireMock's own
  * {@code get(urlEqualTo(...))} / {@code post(urlEqualTo(...))} factories — the returned
- * builder then accepts a typed Wirespec {@link Wirespec.Response} via
- * {@link WirespecMappingBuilder#willReturn(Wirespec.Response)}.
- *
- * <p>Two calling styles:
+ * builder accepts only {@link Wirespec.Response} values that belong to the same endpoint:
  *
  * <pre>
  *     import static community.flock.wirespec.integration.wiremock.java.WirespecWireMock.wirespec;
  *
- *     // Pass an explicit Server instance:
  *     server.stubFor(wirespec(new GetTodos.Handler.Handlers())
  *             .willReturn(new GetTodos.Response200(todos)));
- *
- *     // Or pass the endpoint class and let the integration find the Server reflectively
- *     // (the Java equivalent of Kotlin's reified wirespec&lt;GetTodos&gt;()):
- *     server.stubFor(wirespec(GetTodos.class)
- *             .willReturn(new GetTodos.Response200(todos)));
  * </pre>
+ *
+ * Passing a response from a different endpoint is a compile error.
  *
  * The endpoint's HTTP method and path template drive the WireMock request matcher
  * (path parameters match any non-slash segment).
@@ -44,29 +35,16 @@ public final class WirespecWireMock {
 
     private WirespecWireMock() {}
 
-    public static WirespecMappingBuilder wirespec(Wirespec.Server<?, ?> endpoint) {
-        return new WirespecMappingBuilder(endpoint, requestBuilder(endpoint));
+    public static <Req extends Wirespec.Request<?>, Res extends Wirespec.Response<?>> WirespecMappingBuilder<Res> wirespec(
+            Wirespec.Server<Req, Res> endpoint) {
+        return new WirespecMappingBuilder<>(endpoint, requestBuilder(endpoint));
     }
 
-    /**
-     * Reflection-based overload — {@code wirespec(GetTodos.class)} locates the
-     * {@link Wirespec.Server} implementation generated inside the endpoint class.
-     */
-    public static <E extends Wirespec.Endpoint> WirespecMappingBuilder wirespec(Class<E> endpointClass) {
-        Wirespec.Server<?, ?> server = findServer(endpointClass);
-        if (server == null) {
-            throw new IllegalArgumentException(
-                    "No Wirespec.Server implementation found inside " + endpointClass.getName()
-                            + ". Expected the generated <Endpoint>.Handler structure.");
-        }
-        return wirespec(server);
-    }
-
-    public static final class WirespecMappingBuilder {
-        private final Wirespec.Server<?, ?> endpoint;
+    public static final class WirespecMappingBuilder<Res extends Wirespec.Response<?>> {
+        private final Wirespec.Server<?, Res> endpoint;
         private final MappingBuilder mapping;
 
-        WirespecMappingBuilder(Wirespec.Server<?, ?> endpoint, MappingBuilder mapping) {
+        WirespecMappingBuilder(Wirespec.Server<?, Res> endpoint, MappingBuilder mapping) {
             this.endpoint = endpoint;
             this.mapping = mapping;
         }
@@ -77,7 +55,7 @@ public final class WirespecWireMock {
          * so callers can keep chaining WireMock methods (e.g. {@code .atPriority(...)},
          * {@code .inScenario(...)}).
          */
-        public MappingBuilder willReturn(Wirespec.Response<?> response) {
+        public MappingBuilder willReturn(Res response) {
             return willReturn(response, DEFAULT_SERIALIZATION);
         }
 
@@ -86,39 +64,9 @@ public final class WirespecWireMock {
          * Pass your own {@link Wirespec.Serialization} to customize the ObjectMapper or swap in a
          * different serializer.
          */
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        public MappingBuilder willReturn(Wirespec.Response<?> response, Wirespec.Serialization serialization) {
-            Wirespec.Server typed = endpoint;
-            return mapping.willReturn(responseBuilder(typed.getServer(serialization).to(response)));
+        public MappingBuilder willReturn(Res response, Wirespec.Serialization serialization) {
+            return mapping.willReturn(responseBuilder(endpoint.getServer(serialization).to(response)));
         }
-    }
-
-    private static Wirespec.Server<?, ?> findServer(Class<?> klass) {
-        if (Wirespec.Server.class.isAssignableFrom(klass) && !klass.isInterface()) {
-            // Kotlin companion objects expose a static INSTANCE field; Java-emitted Handlers
-            // are records with a public no-arg constructor.
-            try {
-                Field instanceField = klass.getDeclaredField("INSTANCE");
-                instanceField.setAccessible(true);
-                return (Wirespec.Server<?, ?>) instanceField.get(null);
-            } catch (ReflectiveOperationException ignored) {
-                // fall through
-            }
-            try {
-                Constructor<?> ctor = klass.getDeclaredConstructor();
-                ctor.setAccessible(true);
-                return (Wirespec.Server<?, ?>) ctor.newInstance();
-            } catch (ReflectiveOperationException ignored) {
-                // fall through
-            }
-        }
-        for (Class<?> nested : klass.getDeclaredClasses()) {
-            Wirespec.Server<?, ?> found = findServer(nested);
-            if (found != null) {
-                return found;
-            }
-        }
-        return null;
     }
 
     private static MappingBuilder requestBuilder(Wirespec.Server<?, ?> endpoint) {

--- a/src/integration/wiremock/src/jvmMain/kotlin/community/flock/wirespec/integration/wiremock/kotlin/WirespecWireMock.kt
+++ b/src/integration/wiremock/src/jvmMain/kotlin/community/flock/wirespec/integration/wiremock/kotlin/WirespecWireMock.kt
@@ -11,31 +11,23 @@ import community.flock.wirespec.kotlin.Wirespec
 /**
  * Start building a WireMock stub for a Wirespec endpoint. Mirrors WireMock's own
  * `get(urlEqualTo(...))` / `post(urlEqualTo(...))` factories — the returned builder
- * then accepts a typed Wirespec [Wirespec.Response] via [WirespecMappingBuilder.willReturn].
- *
- * Two calling styles:
+ * accepts only [Wirespec.Response] values that belong to the same endpoint:
  *
  * ```
- * // Pass the endpoint's Server companion directly:
  * server.stubFor(wirespec(GetTodos.Handler).willReturn(GetTodos.Response200(todos)))
- *
- * // Or use the reified-type overload to skip the .Handler:
- * server.stubFor(wirespec<GetTodos>().willReturn(GetTodos.Response200(todos)))
  * ```
+ *
+ * Passing a response from a different endpoint is a compile error.
  *
  * The endpoint's HTTP method and path template drive the WireMock request matcher
  * (path parameters match any non-slash segment).
  */
-fun wirespec(endpoint: Wirespec.Server<*, *>): WirespecMappingBuilder = WirespecMappingBuilder(endpoint, requestBuilder(endpoint))
+fun <Req : Wirespec.Request<*>, Res : Wirespec.Response<*>> wirespec(
+    endpoint: Wirespec.Server<Req, Res>,
+): WirespecMappingBuilder<Res> = WirespecMappingBuilder(endpoint, requestBuilder(endpoint))
 
-/**
- * Reified-type overload — `wirespec<GetTodos>()` reflectively locates the
- * [Wirespec.Server] implementation generated inside the endpoint type.
- */
-inline fun <reified E : Wirespec.Endpoint> wirespec(): WirespecMappingBuilder = wirespec(findServer(E::class.java))
-
-class WirespecMappingBuilder internal constructor(
-    private val endpoint: Wirespec.Server<*, *>,
+class WirespecMappingBuilder<Res : Wirespec.Response<*>> internal constructor(
+    private val endpoint: Wirespec.Server<*, Res>,
     private val mapping: MappingBuilder,
 ) {
     /**
@@ -45,44 +37,10 @@ class WirespecMappingBuilder internal constructor(
      * [MappingBuilder] so callers can keep chaining WireMock methods (e.g. `.atPriority(...)`,
      * `.inScenario(...)`).
      */
-    @Suppress("UNCHECKED_CAST")
     fun willReturn(
-        response: Wirespec.Response<*>,
+        response: Res,
         serialization: Wirespec.Serialization = defaultSerialization,
-    ): MappingBuilder {
-        val typed = endpoint as Wirespec.Server<*, Wirespec.Response<*>>
-        return mapping.willReturn(responseBuilder(typed.server(serialization).to(response)))
-    }
-}
-
-@PublishedApi
-internal fun findServer(endpointClass: Class<*>): Wirespec.Server<*, *> = findServerRecursive(endpointClass)
-    ?: throw IllegalArgumentException(
-        "No Wirespec.Server implementation with a no-arg constructor found inside ${endpointClass.name}. " +
-            "Expected the generated <Endpoint>.Handler structure.",
-    )
-
-private fun findServerRecursive(klass: Class<*>): Wirespec.Server<*, *>? {
-    if (Wirespec.Server::class.java.isAssignableFrom(klass) && !klass.isInterface) {
-        // Kotlin companion objects expose a static INSTANCE field; Java-emitted Handlers
-        // are records with a public no-arg constructor.
-        runCatching {
-            val instanceField = klass.getDeclaredField("INSTANCE")
-            instanceField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            return instanceField.get(null) as Wirespec.Server<*, *>
-        }
-        runCatching {
-            val constructor = klass.getDeclaredConstructor()
-            constructor.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            return constructor.newInstance() as Wirespec.Server<*, *>
-        }
-    }
-    klass.declaredClasses.forEach { nested ->
-        findServerRecursive(nested)?.let { return it }
-    }
-    return null
+    ): MappingBuilder = mapping.willReturn(responseBuilder(endpoint.server(serialization).to(response)))
 }
 
 private val defaultSerialization: Wirespec.Serialization by lazy { WirespecSerialization(ObjectMapper()) }

--- a/src/integration/wiremock/src/jvmTest/java/community/flock/wirespec/integration/wiremock/java/StubForTest.java
+++ b/src/integration/wiremock/src/jvmTest/java/community/flock/wirespec/integration/wiremock/java/StubForTest.java
@@ -39,10 +39,10 @@ public class StubForTest {
     }
 
     @Test
-    public void stubsStaticPathEndpointWithReflection() throws Exception {
+    public void stubsStaticPathEndpoint() throws Exception {
         List<TodoDto> todos = List.of(new TodoDto("1", "Buy milk", false));
 
-        server.stubFor(wirespec(GetTodos.class).willReturn(new GetTodos.Response200(todos)));
+        server.stubFor(wirespec(new GetTodos.Handler.Handlers()).willReturn(new GetTodos.Response200(todos)));
 
         HttpResponse<String> response = get("/api/todos");
 
@@ -68,7 +68,7 @@ public class StubForTest {
     public void stubsNon2xxResponse() throws Exception {
         Error err = new Error(404L, "not found");
 
-        server.stubFor(wirespec(GetTodoById.class).willReturn(new GetTodoById.Response404(err)));
+        server.stubFor(wirespec(new GetTodoById.Handler.Handlers()).willReturn(new GetTodoById.Response404(err)));
 
         HttpResponse<String> response = get("/api/todos/anything");
 

--- a/src/integration/wiremock/src/jvmTest/kotlin/community/flock/wirespec/integration/wiremock/kotlin/StubForTest.kt
+++ b/src/integration/wiremock/src/jvmTest/kotlin/community/flock/wirespec/integration/wiremock/kotlin/StubForTest.kt
@@ -35,19 +35,7 @@ class StubForTest {
     }
 
     @Test
-    fun `stubs a static-path endpoint via the reified wirespec form`() {
-        val todos = listOf(TodoDto(id = "1", name = "Buy milk", done = false))
-
-        server.stubFor(wirespec<GetTodos>().willReturn(GetTodos.Response200(todos)))
-
-        val response = get("/api/todos")
-
-        assertEquals(200, response.statusCode())
-        assertEquals("""[{"id":"1","name":"Buy milk","done":false}]""", response.body())
-    }
-
-    @Test
-    fun `stubs a static-path endpoint via the explicit-server form`() {
+    fun `stubs a static-path endpoint`() {
         val todos = listOf(TodoDto(id = "1", name = "Buy milk", done = false))
 
         server.stubFor(wirespec(GetTodos.Handler).willReturn(GetTodos.Response200(todos)))

--- a/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
+++ b/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
@@ -7,13 +7,16 @@ import java.util.Map;
 import java.util.Optional;
 
 public interface Wirespec {
+    interface Model { List<String> validate(); }
     interface Enum { String label(); }
     interface Endpoint {}
+    interface Channel {}
     interface Refined<T> { T value(); }
     interface Path {}
     interface Queries {}
     interface Headers {}
     interface Handler {}
+    interface Call {}
     interface ServerEdge<Req extends Request<?>, Res extends Response<?>> {
         Req from(RawRequest request);
         RawResponse to(Res response);

--- a/src/site/docs/docs/integration/integration-wiremock.mdx
+++ b/src/site/docs/docs/integration/integration-wiremock.mdx
@@ -10,6 +10,9 @@ The WireMock integration lets you stub Wirespec endpoints in tests with **typed*
 URL patterns and JSON bodies, you pass a generated endpoint and a typed `Response` instance — the integration derives
 the HTTP method, URL pattern, status code, and serialized body for you.
 
+`willReturn` only accepts responses that belong to the endpoint you passed to `wirespec(...)`, so a mismatch — say,
+returning a `GetTodos.Response200` from a `GetUsers` stub — is a compile error rather than a runtime surprise.
+
 The result is a stub that stays in sync with your contract: change the endpoint or response shape and the
 stub stops compiling, rather than silently drifting from production.
 
@@ -82,7 +85,7 @@ Stubbing those endpoints in a JUnit test:
     void stubsTheListEndpoint() throws Exception {
         var todos = List.of(new Todo("1", "Buy milk", false));
 
-        server.stubFor(wirespec(GetTodos.class).willReturn(new GetTodos.Response200(todos)));
+        server.stubFor(wirespec(new GetTodos.Handler.Handlers()).willReturn(new GetTodos.Response200(todos)));
 
         var response = http.send(
             HttpRequest.newBuilder().uri(URI.create(server.baseUrl() + "/api/todos")).GET().build(),
@@ -101,7 +104,7 @@ Stubbing those endpoints in a JUnit test:
     fun `stubs the list endpoint`() {
         val todos = listOf(Todo(id = "1", name = "Buy milk", done = false))
 
-        server.stubFor(wirespec<GetTodos>().willReturn(GetTodos.Response200(todos)))
+        server.stubFor(wirespec(GetTodos.Handler).willReturn(GetTodos.Response200(todos)))
 
         val response = client.send(
             HttpRequest.newBuilder().uri(URI.create("${server.baseUrl()}/api/todos")).GET().build(),
@@ -123,41 +126,37 @@ returns a `MappingBuilder`-compatible value that plugs straight into `server.stu
 
 ### `wirespec(...)` — start a stub
 
-Two calling styles, both return a `WirespecMappingBuilder`:
+Pass the generated `Server` instance for your endpoint:
 
 <Tabs groupId="language">
   <TabItem value="java" label="Java">
     ```java
-    // Reflection: pass the endpoint class, the integration locates the generated Server.
-    wirespec(GetTodos.class)
-
-    // Explicit: pass a Server instance directly.
     wirespec(new GetTodos.Handler.Handlers())
     ```
   </TabItem>
   <TabItem value="kotlin" label="Kotlin">
     ```kotlin
-    // Reified: locate the generated Server via the endpoint type parameter.
-    wirespec<GetTodos>()
-
-    // Explicit: pass the Handler companion directly.
     wirespec(GetTodos.Handler)
     ```
   </TabItem>
 </Tabs>
 
-The endpoint's HTTP method and path template drive the WireMock request matcher. Path parameters such as `{id}` are
-translated into a `[^/]+` segment, so the stub matches any single-segment value but won't accidentally match across
-slashes.
+The returned `WirespecMappingBuilder<Res>` is parameterized by the endpoint's response type, which is what gives
+`willReturn` its compile-time check. The endpoint's HTTP method and path template drive the WireMock request matcher;
+path parameters such as `{id}` are translated into a `[^/]+` segment, so the stub matches any single-segment value but
+won't accidentally match across slashes.
 
 ### `willReturn(response)` — attach a typed response
 
-Pass any typed `Response` from the generated endpoint:
+Pass any typed `Response` from the same endpoint:
 
 ```kotlin
-wirespec<GetTodoById>().willReturn(GetTodoById.Response200(todo))
-wirespec<GetTodoById>().willReturn(GetTodoById.Response404(Error(404, "not found")))
+wirespec(GetTodoById.Handler).willReturn(GetTodoById.Response200(todo))
+wirespec(GetTodoById.Handler).willReturn(GetTodoById.Response404(Error(404, "not found")))
 ```
+
+Passing a response from a different endpoint, e.g. `wirespec(GetTodoById.Handler).willReturn(GetTodos.Response200(...))`,
+fails to compile.
 
 The integration:
 
@@ -169,7 +168,7 @@ The integration:
 
 ```kotlin
 server.stubFor(
-    wirespec<GetTodos>()
+    wirespec(GetTodos.Handler)
         .willReturn(GetTodos.Response200(todos))
         .atPriority(1)
         .inScenario("happy path")
@@ -186,7 +185,7 @@ customize the mapper (for example, to register additional modules or change nami
     ```java
     var serialization = new WirespecSerialization(new ObjectMapper().registerModule(new JavaTimeModule()));
 
-    server.stubFor(wirespec(GetTodoById.class)
+    server.stubFor(wirespec(new GetTodoById.Handler.Handlers())
         .willReturn(new GetTodoById.Response200(todo), serialization));
     ```
   </TabItem>


### PR DESCRIPTION
## Summary

Two related cleanups to the wiremock integration, bundled because they touch overlapping files.

### 1. Typesafe `willReturn`
- Parameterize `WirespecMappingBuilder<Res>` so `willReturn` only accepts responses that belong to the endpoint passed to `wirespec(...)`. A mismatch like `wirespec(GetTodoById.Handler).willReturn(GetTodos.Response200(...))` is now a compile error (`Type mismatch: inferred type is GetTodos.Response200 but GetTodoById.Response<*> was expected`).
- Drop the reflection-based factories (`wirespec<E>()` in Kotlin, `wirespec(Class<E>)` in Java) and their `findServer` helpers (~100 lines gone). Only the explicit-server form remains, which carries full type info.
- Migrate the Kotlin/Java tests, the `maven-wiremock` example, and the integration docs to `wirespec(GetTodos.Handler)` / `wirespec(new GetTodos.Handler.Handlers())`.

### 2. IR-emitter codegen
- Switch the wiremock module's test-source codegen `Main.kt` from the legacy `JavaEmitter`/`KotlinEmitter` to `JavaIrEmitter`/`KotlinIrEmitter` so the generated test fixtures go through the same pipeline as the rest of the toolchain.
- Add marker interfaces `Model`, `Channel`, `Call` to the hand-written Java `Wirespec` runtime in `:src:integration:wirespec`. The IR emitter generates references to them (records implement `Wirespec.Model`, endpoints declare a nested `Call` interface) and the Kotlin runtime already exposes them; this aligns Java with Kotlin. Pure addition — existing consumers are unaffected.

## Test plan
- [x] `./gradlew :src:integration:wiremock:allTests` — BUILD SUCCESSFUL
- [x] `./gradlew :src:integration:spring:allTests :src:integration:jackson:allTests` — BUILD SUCCESSFUL (the other consumers of the Java Wirespec runtime are unaffected by the additive interfaces)
- [x] Verified compile-time rejection of a cross-endpoint response with an ad-hoc test file (removed after verification)
- [ ] Maintainer to confirm:
  - The breaking change to the reflection-based factories is acceptable given the integration was added in #642 / #646
  - The `Model`/`Channel`/`Call` additions to Java runtime are OK

## Out of scope
- `RawResponse.statusCode` `int` → `Integer` divergence between the hand-written Java runtime and the IR-emitted shared file. Not needed for the wiremock tests (autoboxing handles both sides at source level) and a real ABI shift; deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)