### PR TITLE
feat(emitters): emit api instance on JVM endpoint namespaces

### DIFF
--- a/src/compiler/emitters/java/fixtures/compileFullEndpointTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileFullEndpointTest.txt
@@ -181,6 +181,7 @@ public interface PutTodo extends Wirespec.Endpoint {
   public interface Call extends Wirespec.Call {
     public java.util.concurrent.CompletableFuture<Response<?>> putTodo(String id, Boolean done, java.util.Optional<String> name, Token token, java.util.Optional<Token> refreshToken, PotentialTodoDto body);
   }
+  Handler.Handlers api = new Handler.Handlers();
 }
 
 package community.flock.wirespec.generated.model;

--- a/src/compiler/emitters/java/fixtures/compileMinimalEndpointTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileMinimalEndpointTest.txt
@@ -104,6 +104,7 @@ public interface GetTodos extends Wirespec.Endpoint {
   public interface Call extends Wirespec.Call {
     public java.util.concurrent.CompletableFuture<Response<?>> getTodos();
   }
+  Handler.Handlers api = new Handler.Handlers();
 }
 
 package community.flock.wirespec.generated.model;

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
@@ -170,6 +170,7 @@ open class JavaIrEmitter(
     override fun emit(endpoint: Endpoint): File = endpoint
         .convert()
         .injectHandleFunction(endpoint)
+        .injectApiField()
         .transformTypeDescriptors()
         .sanitizeNames(sanitizationConfig)
         .prependImports(endpoint.buildModelImports(packageName).takeIf { it.isNotEmpty() })

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrTransformer.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrTransformer.kt
@@ -13,6 +13,7 @@ import community.flock.wirespec.ir.core.FunctionCall
 import community.flock.wirespec.ir.core.Import
 import community.flock.wirespec.ir.core.Interface
 import community.flock.wirespec.ir.core.Name
+import community.flock.wirespec.ir.core.Namespace
 import community.flock.wirespec.ir.core.Precision
 import community.flock.wirespec.ir.core.RawElement
 import community.flock.wirespec.ir.core.RawExpression
@@ -70,6 +71,12 @@ internal fun <T : Element> T.injectHandleFunction(endpoint: Endpoint): T {
                 iface
             }
         }
+    }
+}
+
+internal fun <T : Element> T.injectApiField(): T = transform {
+    injectAfter { _: Namespace ->
+        listOf(RawElement("Handler.Handlers api = new Handler.Handlers();\n"))
     }
 }
 

--- a/src/compiler/emitters/kotlin/fixtures/compileFullEndpointTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileFullEndpointTest.txt
@@ -150,6 +150,7 @@ object PutTodo : Wirespec.Endpoint {
   interface Call : Wirespec.Call {
       suspend fun putTodo(id: String, done: Boolean, name: String?, token: Token, refreshToken: Token?, body: PotentialTodoDto): Response<*>
   }
+  val api = Handler
 }
 
 package community.flock.wirespec.generated.model

--- a/src/compiler/emitters/kotlin/fixtures/compileMinimalEndpointTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileMinimalEndpointTest.txt
@@ -75,6 +75,7 @@ object GetTodos : Wirespec.Endpoint {
   interface Call : Wirespec.Call {
       suspend fun getTodos(): Response<*>
   }
+  val api = Handler
 }
 
 package community.flock.wirespec.generated.model

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
@@ -147,7 +147,7 @@ open class KotlinIrEmitter(
     override fun emit(endpoint: Endpoint): File {
         val imports = endpoint.buildModelImports(packageName)
         val endpointNamespace = endpoint.convert().findElement<Namespace>()!!
-        val body = endpointNamespace.injectCompanionObject(endpoint)
+        val body = endpointNamespace.injectCompanionObject(endpoint).injectApiAlias()
         return LanguageFile(Name.of(endpoint.identifier.sanitize()), listOf(body))
             .sanitizeNames(sanitizationConfig)
             .prependImports(imports.takeIf { it.isNotEmpty() })

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrTransformer.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrTransformer.kt
@@ -23,6 +23,12 @@ internal fun Namespace.injectCompanionObject(endpoint: Endpoint): Namespace = tr
     }
 }
 
+internal fun Namespace.injectApiAlias(): Namespace = transform {
+    injectAfter { _: Namespace ->
+        listOf(raw("val api = Handler"))
+    }
+}
+
 private fun buildCompanionObject(endpoint: Endpoint): RawElement {
     val pathTemplate = "/" + endpoint.path.joinToString("/") {
         when (it) {


### PR DESCRIPTION
## What

Mirror the TypeScript emitter's `export const api` by exposing an `api` member on each endpoint namespace for the **Java** and **Kotlin** IR emitters. Scala was intentionally left out.

The `api` is an **alias to the existing handler** — no new runtime type, no `name` field:

- **Kotlin** — `val api = Handler` on the `GetTodos` object. `Handler` in value position resolves to its companion object (which implements `Wirespec.Server` + `Wirespec.Client`).
- **Java** — `Handler.Handlers api = new Handler.Handlers();` on the `GetTodos` interface (interface fields are implicitly `public static final`).

Both surface `method`, `pathTemplate`, `server(serialization)` and `client(serialization)` via `GetTodos.api`.

## How

- `KotlinIrTransformer.kt` — new `injectApiAlias()` using `injectAfter<Namespace>`; wired into `KotlinIrEmitter.emit(endpoint)` after `injectCompanionObject`.
- `JavaIrTransformer.kt` — new `injectApiField()` using `injectAfter<Namespace>`; wired into `JavaIrEmitter.emit(endpoint)` after `injectHandleFunction`. The `RawElement` carries a trailing newline because (unlike `KotlinGenerator`) `JavaGenerator` doesn't append one to raw elements — same convention as the existing `@FunctionalInterface\n` raw element.
- Regenerated the four affected fixtures (Java + Kotlin, minimal + full endpoint). No other fixtures changed.

## Verification

- `:src:compiler:emitters:java:jvmTest` and `:src:compiler:emitters:kotlin:jvmTest` — pass.
- `:src:integration:wiremock:jvmTest` — passes. This regenerates Java + Kotlin sources from `.ws` files using the **local** emitters and compiles them into the test set, so both new `api` members were proven to actually compile (not just string-matched), and the existing `wirespec(GetTodos.Handler)` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)