### PR TITLE
feat(integration/msw): add @flock/wirespec/msw for typed MSW mocks

### DIFF
--- a/examples/npm-typescript/README.md
+++ b/examples/npm-typescript/README.md
@@ -3,3 +3,29 @@
 ## Node Npm TypeScript Configuration
 
 According to the [actual package.json](package.json) file.
+
+## Mocking with MSW
+
+`@flock/wirespec/msw` turns a generated endpoint into a typed
+[Mock Service Worker](https://mswjs.io) request handler:
+
+```ts
+import { setupServer } from "msw/node";
+import { wirespec } from "@flock/wirespec/msw";
+import { GetTodoById } from "./gen/endpoint";
+
+const server = setupServer(
+  wirespec(GetTodoById.api, async (req) =>
+    GetTodoById.response200({ body: { id: req.path.id, /* ... */ } }),
+  ),
+);
+```
+
+The resolver receives the deserialized Wirespec request and must return one of
+that endpoint's responses — returning another endpoint's response is a compile
+error. Pass `{ baseUrl }` to pin a host or path prefix. See
+[`src/msw.ts`](src/msw.ts) for a runnable example and
+[`src/msw.test.ts`](src/msw.test.ts) for the behavioral tests.
+
+> `msw` is an optional peer dependency of `@flock/wirespec`; install it in your
+> project to use this integration.

--- a/examples/npm-typescript/package-lock.json
+++ b/examples/npm-typescript/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@flock/wirespec": "file://../../src/plugin/npm/build/dist/js/productionLibrary",
+        "msw": "^2.6.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.2",
         "vitest": "^3.2.4"
@@ -20,15 +21,20 @@
       "version": "0.0.0-SNAPSHOT",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "format-util": "^1.0.5"
-      },
       "bin": {
-        "wirespec": "wirespec-bin.mjs"
+        "wirespec": "wirespec-bin.mjs",
+        "wirespec-lsp": "wirespec-lsp.mjs"
       },
       "devDependencies": {
-        "source-map-support": "0.5.21",
-        "typescript": "5.5.4"
+        "typescript": "5.9.3"
+      },
+      "peerDependencies": {
+        "msw": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -490,6 +496,93 @@
       "resolved": "../../src/plugin/npm/build/dist/js/productionLibrary",
       "link": true
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -517,6 +610,56 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.45.1",
@@ -861,6 +1004,23 @@
         "undici-types": "~6.20.0"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1002,6 +1162,32 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1056,6 +1242,65 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -1100,6 +1345,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1150,6 +1402,16 @@
         "@esbuild/win32-x64": "0.25.6"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1168,6 +1430,33 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
       }
     },
     "node_modules/fdir": {
@@ -1199,6 +1488,54 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -1238,6 +1575,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1256,6 +1649,20 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1287,6 +1694,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1322,6 +1730,23 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.45.1",
@@ -1363,12 +1788,32 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1387,12 +1832,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-literal": {
       "version": "3.0.0",
@@ -1405,6 +1895,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -1468,6 +1971,39 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -1512,12 +2048,29 @@
         }
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1531,8 +2084,17 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
       "license": "MIT",
-      "peer": true
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -1547,6 +2109,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -1727,6 +2290,63 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yn": {

--- a/examples/npm-typescript/package.json
+++ b/examples/npm-typescript/package.json
@@ -21,6 +21,7 @@
   "description": "",
   "devDependencies": {
     "@flock/wirespec": "file://../../src/plugin/npm/build/dist/js/productionLibrary",
+    "msw": "^2.6.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2",
     "vitest": "^3.2.4"

--- a/examples/npm-typescript/src/msw.test.ts
+++ b/examples/npm-typescript/src/msw.test.ts
@@ -1,0 +1,72 @@
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
+import { wirespec } from "@flock/wirespec/msw";
+import { GetTodos } from "./gen/endpoint";
+import { server, todo } from "./msw";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test("GET /api/todos returns the typed list and response header", async () => {
+  const res = await fetch("http://localhost/api/todos");
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get("X-Total")).toBe("1");
+  expect(await res.json()).toEqual([todo]);
+});
+
+test("GET /api/todos/:id resolves the path param to a 200", async () => {
+  const res = await fetch(`http://localhost/api/todos/${todo.id}`);
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual(todo);
+});
+
+test("GET /api/todos/:id returns a typed 404 for an unknown id", async () => {
+  const res = await fetch(
+    "http://localhost/api/todos/00000000-0000-0000-0000-000000000000",
+  );
+
+  expect(res.status).toBe(404);
+  expect(await res.json()).toEqual({ code: 404, description: "not found" });
+});
+
+test("POST /api/todos deserializes the typed request body", async () => {
+  const body = {
+    name: "Walk dog",
+    done: true,
+    testInt0: 0,
+    testInt1: 1,
+    testInt2: 3,
+    testNum0: 0.0,
+    testNum1: 1.1,
+    testNum2: 3.5,
+  };
+
+  const res = await fetch("http://localhost/api/todos", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ id: todo.id, ...body });
+});
+
+test("baseUrl option matches requests under an absolute origin", async () => {
+  const scoped = setupServer(
+    wirespec(
+      GetTodos.api,
+      async () => GetTodos.response200({ "X-Total": 0, body: [] }),
+      { baseUrl: "https://api.example.com" },
+    ),
+  );
+  scoped.listen({ onUnhandledRequest: "error" });
+  try {
+    const res = await fetch("https://api.example.com/api/todos");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  } finally {
+    scoped.close();
+  }
+});

--- a/examples/npm-typescript/src/msw.ts
+++ b/examples/npm-typescript/src/msw.ts
@@ -1,0 +1,42 @@
+// Example: mock a Wirespec API with Mock Service Worker (MSW) using @flock/wirespec/msw.
+//
+// `wirespec(Endpoint.api, resolver)` turns a generated endpoint into a typed MSW
+// RequestHandler: the resolver receives the deserialized Wirespec request and must
+// return one of that endpoint's responses (a response from another endpoint is a
+// compile error).
+import { setupServer } from "msw/node";
+import { wirespec } from "@flock/wirespec/msw";
+import { GetTodoById, GetTodos, PostTodo } from "./gen/endpoint";
+import type { TodoDto } from "./gen/model";
+
+export const todo: TodoDto = {
+  id: "12345678-1234-1234-1234-123456789abc",
+  name: "Buy milk",
+  done: false,
+  testInt0: 0,
+  testInt1: 1,
+  testInt2: 3,
+  testNum0: 0.0,
+  testNum1: 1.1,
+  testNum2: 3.5,
+};
+
+export const handlers = [
+  wirespec(GetTodos.api, async () =>
+    GetTodos.response200({ "X-Total": 1, body: [todo] }),
+  ),
+
+  wirespec(GetTodoById.api, async (req) =>
+    req.path.id === todo.id
+      ? GetTodoById.response200({ body: todo })
+      : GetTodoById.response404({
+          body: { code: 404, description: "not found" },
+        }),
+  ),
+
+  wirespec(PostTodo.api, async (req) =>
+    PostTodo.response200({ body: { id: todo.id, ...req.body } }),
+  ),
+];
+
+export const server = setupServer(...handlers);

--- a/examples/npm-typescript/tsconfig.json
+++ b/examples/npm-typescript/tsconfig.json
@@ -5,6 +5,8 @@
     "target": "ES2015",
     "lib": ["es6", "WebWorker"],
     "strict": true,
-    "moduleResolution": "bundler"
-  }
+    "moduleResolution": "bundler",
+    "preserveSymlinks": true
+  },
+  "include": ["src"]
 }

--- a/examples/npm-typescript/vitest.config.ts
+++ b/examples/npm-typescript/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // @flock/wirespec is linked as a local `file:` dependency (a symlink to the built
+  // package), and declares `msw` as an optional peer dependency that lives in this
+  // project's node_modules. Inlining the package makes Vitest transform it (instead of
+  // letting Node load it natively from the real, dependency-less dist path), and
+  // preserveSymlinks resolves `import 'msw'` through the symlink so it is found here.
+  resolve: {
+    preserveSymlinks: true,
+  },
+  test: {
+    server: {
+      deps: {
+        inline: ["@flock/wirespec"],
+      },
+    },
+  },
+});

--- a/src/plugin/npm/build.gradle.kts
+++ b/src/plugin/npm/build.gradle.kts
@@ -46,8 +46,14 @@ kotlin {
                         "types" to "./wirespec-serialization.d.ts",
                         "default" to "./wirespec-serialization.mjs",
                     ),
+                    "./msw" to mapOf(
+                        "types" to "./wirespec-msw.d.ts",
+                        "default" to "./wirespec-msw.mjs",
+                    ),
                 ),
             )
+            customField("peerDependencies", mapOf("msw" to "^2.0.0"))
+            customField("peerDependenciesMeta", mapOf("msw" to mapOf("optional" to true)))
             customField("repository", mapOf("type" to "git", "url" to "https://github.com/flock-community/wirespec"))
             customField("license", "Apache-2.0")
         }

--- a/src/plugin/npm/src/jsMain/resources/wirespec-msw.d.ts
+++ b/src/plugin/npm/src/jsMain/resources/wirespec-msw.d.ts
@@ -1,0 +1,53 @@
+import type { RequestHandler } from 'msw'
+import type { Serialization } from './wirespec-serialization'
+
+// Mirrors the generated `Wirespec.RawRequest` / `RawResponse` so generated endpoint `api`
+// objects are assignable to WirespecMswEndpoint (the method union must match exactly).
+type Method = 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH' | 'TRACE'
+
+type RawRequest = {
+    method: Method
+    path: string[]
+    queries: Record<string, string>
+    headers: Record<string, string>
+    body?: string
+}
+
+type RawResponse = {
+    status: number
+    headers: Record<string, string>
+    body?: string
+}
+
+/**
+ * Structural mirror of the generated `Wirespec.Api<Req, Res>` type. The shipped module
+ * cannot import the consumer's per-project generated `Wirespec` namespace, so the shape
+ * is redeclared here; generated endpoint `api` objects are assignable to it.
+ */
+export type WirespecMswEndpoint<Req, Res> = {
+    method: string
+    path: string
+    server: (serialization: Serialization) => {
+        from: (request: RawRequest) => Req
+        to: (response: Res) => RawResponse
+    }
+}
+
+export type WirespecMswOptions = {
+    /** Host or path prefix prepended to the contract path, e.g. "https://api.example.com" or "/api". */
+    baseUrl?: string
+    /** Override the serialization used to (de)serialize requests/responses. */
+    serialization?: Serialization
+}
+
+/**
+ * Build a typed MSW request handler for a generated Wirespec endpoint.
+ *
+ * The generics are inferred from `api.server`, constraining `resolver` to the endpoint's
+ * own request/response types: returning a response from a different endpoint is a compile error.
+ */
+export declare function wirespec<Req, Res>(
+    api: WirespecMswEndpoint<Req, Res>,
+    resolver: (request: Req) => Res | Promise<Res>,
+    options?: WirespecMswOptions,
+): RequestHandler

--- a/src/plugin/npm/src/jsMain/resources/wirespec-msw.mjs
+++ b/src/plugin/npm/src/jsMain/resources/wirespec-msw.mjs
@@ -1,0 +1,83 @@
+import { http, HttpResponse } from 'msw'
+import { wirespecSerialization } from './wirespec-serialization.mjs'
+
+const METHODS = {
+    GET: 'get',
+    PUT: 'put',
+    POST: 'post',
+    DELETE: 'delete',
+    PATCH: 'patch',
+    HEAD: 'head',
+    OPTIONS: 'options',
+}
+
+const PARAM = /^:(.+)$/
+const BRACE = /^\{(.+)\}$/
+
+const segments = (path) => path.replace(/^\/+/, '').split('/').filter((s) => s.length > 0)
+
+// Normalize a Wirespec contract path into an MSW matcher: `{id}` -> `:id`, single leading slash.
+const normalizePath = (path) => {
+    const colon = path.replace(/\{([^/}]+)\}/g, ':$1')
+    return colon.startsWith('/') ? colon : `/${colon}`
+}
+
+// Without a baseUrl, prefix the contract path with `*` so it matches on any origin
+// (a bare relative path is not matched against absolute request URLs in Node). With a
+// baseUrl, pin the origin/prefix instead.
+const matcher = (baseUrl, path) => {
+    const normalized = normalizePath(path)
+    return baseUrl ? `${baseUrl.replace(/\/+$/, '')}${normalized}` : `*${normalized}`
+}
+
+// Rebuild the positional RawRequest.path from the contract template, substituting MSW's
+// matched params for `:name`/`{name}` segments. Using the template (not the raw URL) keeps
+// path-param indices aligned with the contract even when a baseUrl prefix is present.
+const buildPath = (templatePath, params) =>
+    segments(templatePath).map((segment) => {
+        const match = segment.match(PARAM) ?? segment.match(BRACE)
+        if (!match) return segment
+        const value = params[match[1]]
+        return Array.isArray(value) ? value[0] : value
+    })
+
+const readBody = async (request) => {
+    if (request.method === 'GET' || request.method === 'HEAD') return undefined
+    const text = await request.text()
+    return text.length > 0 ? text : undefined
+}
+
+/**
+ * Build an MSW request handler for a generated Wirespec endpoint `api`.
+ *
+ * The resolver receives the deserialized, typed Wirespec request and must return one of
+ * that endpoint's responses; a response from a different endpoint is a compile error.
+ *
+ * Options:
+ *  - baseUrl: host or path prefix to prepend to the contract path (e.g. "https://api.example.com").
+ *  - serialization: override the (de)serializer (defaults to wirespecSerialization).
+ */
+export function wirespec(api, resolver, options = {}) {
+    const serialization = options.serialization ?? wirespecSerialization
+    const pattern = matcher(options.baseUrl, api.path)
+    const method = METHODS[String(api.method).toUpperCase()] ?? 'all'
+    const endpoint = api.server(serialization)
+
+    return http[method](pattern, async ({ request, params }) => {
+        const url = new URL(request.url)
+        const rawRequest = {
+            method: request.method,
+            path: buildPath(api.path, params),
+            queries: Object.fromEntries(url.searchParams),
+            headers: Object.fromEntries(request.headers),
+            body: await readBody(request),
+        }
+        const typedRequest = endpoint.from(rawRequest)
+        const response = await resolver(typedRequest)
+        const rawResponse = endpoint.to(response)
+        return new HttpResponse(rawResponse.body ?? null, {
+            status: rawResponse.status,
+            headers: rawResponse.headers,
+        })
+    })
+}


### PR DESCRIPTION
## Summary

Adds a [Mock Service Worker](https://mswjs.io) integration for Wirespec, shipped as the **`@flock/wirespec/msw`** subpath export of the `@flock/wirespec` npm package — the JS/TS analogue of the JVM WireMock integration's typed `wirespec(...)` factory.

```ts
import { setupServer } from "msw/node";
import { wirespec } from "@flock/wirespec/msw";
import { GetTodoById } from "./gen/endpoint";

const server = setupServer(
  wirespec(GetTodoById.api, async (req) =>
    req.path.id === "1"
      ? GetTodoById.response200({ body: todo })
      : GetTodoById.response404({ body: { code: 404, description: "not found" } }),
  ),
);
```

`wirespec(api, resolver, options?)` reuses the generated per-endpoint `api` object: it builds the MSW matcher from `api.method`/`api.path`, deserializes the incoming request via `api.server(serialization).from`, hands the resolver a fully typed Wirespec `Request`, and serializes the returned `Response` via `.to` into an `HttpResponse`.

## Type safety

The generics are inferred from `api.server`, so the resolver is constrained to the endpoint's own `Request`/`Response`. Returning another endpoint's response is a compile error (verified: `TS2322`).

## Changes

- `wirespec-msw.mjs` / `wirespec-msw.d.ts` runtime helper in the npm package resources.
- `./msw` added to the package `exports`; `msw` (v2) declared as an **optional** peer dependency.
- Worked example (`src/msw.ts`) + behavioral vitest suite (`src/msw.test.ts`) in `examples/npm-typescript`, picked up by the existing `npm` CI job.

## Notes

- Default matcher uses a `*`-origin wildcard (msw v2.14 doesn't match a bare relative path against absolute request URLs in Node); `baseUrl` pins a host/prefix.
- The example's `vitest.config.ts` / `tsconfig.json` set `preserveSymlinks` + inline `@flock/wirespec` because it is a symlinked `file:` dependency with `msw` as an optional peer — a normally-installed consumer needs none of this.

## Testing

`npm run build` in `examples/npm-typescript` (generate + tsc + vitest): **34/34 tests pass**, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)