### PR TITLE
Add rpc definition to the Wirespec language

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
@@ -2,6 +2,7 @@ package community.flock.wirespec.compiler.core
 
 import community.flock.wirespec.compiler.core.tokenize.Annotation
 import community.flock.wirespec.compiler.core.tokenize.Arrow
+import community.flock.wirespec.compiler.core.tokenize.Bang
 import community.flock.wirespec.compiler.core.tokenize.Brackets
 import community.flock.wirespec.compiler.core.tokenize.CaseVariant
 import community.flock.wirespec.compiler.core.tokenize.ChannelDefinition
@@ -78,6 +79,7 @@ object WirespecSpec : LanguageSpec {
         Regex("^\\(") to LeftParenthesis,
         Regex("^\\)") to RightParenthesis,
         Regex("^->") to Arrow,
+        Regex("^!") to Bang,
         Regex("^=") to Equals,
         Regex("^\\|") to Pipe,
         Regex("^:") to Colon,

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
@@ -34,6 +34,7 @@ import community.flock.wirespec.compiler.core.tokenize.QuestionMark
 import community.flock.wirespec.compiler.core.tokenize.RightBracket
 import community.flock.wirespec.compiler.core.tokenize.RightCurly
 import community.flock.wirespec.compiler.core.tokenize.RightParenthesis
+import community.flock.wirespec.compiler.core.tokenize.RpcDefinition
 import community.flock.wirespec.compiler.core.tokenize.ScreamingKebabCaseIdentifier
 import community.flock.wirespec.compiler.core.tokenize.ScreamingSnakeCaseIdentifier
 import community.flock.wirespec.compiler.core.tokenize.SnakeCaseIdentifier
@@ -69,6 +70,7 @@ object WirespecSpec : LanguageSpec {
         Regex("^\\benum\\b") to EnumTypeDefinition,
         Regex("^\\bendpoint\\b") to EndpointDefinition,
         Regex("^\\bchannel\\b") to ChannelDefinition,
+        Regex("^\\brpc\\b") to RpcDefinition,
         Regex("^[^\\S\\r\\n]+") to WhiteSpaceExceptNewLine,
         Regex("^[\\r\\n]") to NewLine,
         Regex("^\\{") to LeftCurly,

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/Defaults.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/Defaults.kt
@@ -5,6 +5,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Model
 import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 
 const val DEFAULT_PACKAGE = "community.flock.wirespec"
 const val DEFAULT_SHARED_PACKAGE_STRING = DEFAULT_PACKAGE
@@ -13,6 +14,7 @@ const val DEFAULT_GENERATED_PACKAGE_STRING = "$DEFAULT_PACKAGE.generated"
 fun Definition.namespace() = when (this) {
     is Endpoint -> "endpoint"
     is Channel -> "channel"
+    is Rpc -> "rpc"
     is Model -> "model"
 }
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/EmitterExtensions.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/EmitterExtensions.kt
@@ -6,6 +6,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
 
@@ -26,6 +27,10 @@ fun Definition.importReferences(): List<Reference.Custom> = when (this) {
             .distinct()
     is Union -> entries.filterIsInstance<Reference.Custom>()
     is Channel -> if (reference is Reference.Custom) listOf(reference) else emptyList()
+    is Rpc -> (requestParameters.map { it.reference } + response)
+        .map { it.flattenListDict() }
+        .filterIsInstance<Reference.Custom>()
+        .distinct()
     is Enum -> emptyList()
     is Refined -> emptyList()
 }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/LanguageEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/LanguageEmitter.kt
@@ -8,6 +8,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
 import community.flock.wirespec.compiler.utils.Logger
@@ -38,6 +39,7 @@ abstract class LanguageEmitter :
             is Refined -> Emitted(emit(definition.identifier), emit(definition))
             is Union -> Emitted(emit(definition.identifier), emit(definition))
             is Channel -> Emitted(emit(definition.identifier), emit(definition))
+            is Rpc -> Emitted(emit(definition.identifier), notYetImplemented())
         }
     }
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/ValidationError.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/ValidationError.kt
@@ -39,3 +39,9 @@ class DuplicateChannelError(typeName: String) :
         coordinates = Token.Coordinates(),
         message = "Channel '$typeName' is already defined",
     )
+
+class DuplicateRpcError(typeName: String) :
+    ValidationError(
+        coordinates = Token.Coordinates(),
+        message = "Rpc '$typeName' is already defined",
+    )

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Parser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Parser.kt
@@ -22,6 +22,7 @@ import community.flock.wirespec.compiler.core.tokenize.ChannelDefinition
 import community.flock.wirespec.compiler.core.tokenize.Comment
 import community.flock.wirespec.compiler.core.tokenize.EndpointDefinition
 import community.flock.wirespec.compiler.core.tokenize.EnumTypeDefinition
+import community.flock.wirespec.compiler.core.tokenize.RpcDefinition
 import community.flock.wirespec.compiler.core.tokenize.Token
 import community.flock.wirespec.compiler.core.tokenize.TokenType
 import community.flock.wirespec.compiler.core.tokenize.TypeDefinition
@@ -103,6 +104,7 @@ private fun TokenProvider.parseDefinition() = either {
             is EnumTypeDefinition -> with(EnumParser) { parseEnum(comment, annotations) }.bind()
             is EndpointDefinition -> with(EndpointParser) { parseEndpoint(comment, annotations) }.bind()
             is ChannelDefinition -> with(ChannelParser) { parseChannel(comment, annotations) }.bind()
+            is RpcDefinition -> with(RpcParser) { parseRpc(comment, annotations) }.bind()
         }
 
         else -> raiseWrongToken<WirespecDefinition>().bind()

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/RpcParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/RpcParser.kt
@@ -1,0 +1,99 @@
+package community.flock.wirespec.compiler.core.parse
+
+import arrow.core.Either
+import arrow.core.raise.either
+import community.flock.wirespec.compiler.core.exceptions.WirespecException
+import community.flock.wirespec.compiler.core.parse.TypeParser.parseDict
+import community.flock.wirespec.compiler.core.parse.TypeParser.parseType
+import community.flock.wirespec.compiler.core.parse.ast.Annotation
+import community.flock.wirespec.compiler.core.parse.ast.Comment
+import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
+import community.flock.wirespec.compiler.core.tokenize.Arrow
+import community.flock.wirespec.compiler.core.tokenize.Colon
+import community.flock.wirespec.compiler.core.tokenize.Comma
+import community.flock.wirespec.compiler.core.tokenize.LeftCurly
+import community.flock.wirespec.compiler.core.tokenize.LeftParenthesis
+import community.flock.wirespec.compiler.core.tokenize.RightParenthesis
+import community.flock.wirespec.compiler.core.tokenize.WirespecIdentifier
+import community.flock.wirespec.compiler.core.tokenize.WirespecType
+
+object RpcParser {
+
+    fun TokenProvider.parseRpc(comment: Comment?, annotations: List<Annotation>): Either<WirespecException, Rpc> = parseToken {
+        when (token.type) {
+            is WirespecType -> parseRpcDefinition(comment, annotations, DefinitionIdentifier(token.value)).bind()
+            else -> raiseWrongToken<WirespecType>().bind()
+        }
+    }
+
+    private fun TokenProvider.parseRpcDefinition(comment: Comment?, annotations: List<Annotation>, identifier: DefinitionIdentifier) = parseToken {
+        val requestParameters = parseRpcParameters().bind()
+
+        when (token.type) {
+            is Arrow -> eatToken().bind()
+            else -> raiseWrongToken<Arrow>().bind()
+        }
+
+        val response = with(TypeParser) {
+            when (token.type) {
+                is LeftCurly -> parseDict().bind()
+                is WirespecType -> parseType().bind()
+                else -> raiseWrongToken<WirespecType>().bind()
+            }
+        }
+
+        Rpc(
+            comment = comment,
+            annotations = annotations,
+            identifier = identifier,
+            requestParameters = requestParameters,
+            response = response,
+        )
+    }
+
+    private fun TokenProvider.parseRpcParameters(): Either<WirespecException, List<Field>> = either {
+        when (token.type) {
+            is LeftParenthesis -> eatToken().bind()
+            else -> raiseWrongToken<LeftParenthesis>().bind()
+        }
+        mutableListOf<Field>().apply {
+            if (token.type !is RightParenthesis) {
+                add(parseRpcParameter().bind())
+                while (token.type is Comma) {
+                    eatToken().bind()
+                    add(parseRpcParameter().bind())
+                }
+            }
+            when (token.type) {
+                is RightParenthesis -> eatToken().bind()
+                else -> raiseWrongToken<RightParenthesis>().bind()
+            }
+        }
+    }
+
+    private fun TokenProvider.parseRpcParameter(): Either<WirespecException, Field> = either {
+        val identifier = when (token.type) {
+            is WirespecIdentifier -> FieldIdentifier(token.value).also { eatToken().bind() }
+            else -> raiseWrongToken<WirespecIdentifier>().bind()
+        }
+        when (token.type) {
+            is Colon -> eatToken().bind()
+            else -> raiseWrongToken<Colon>().bind()
+        }
+        val reference = with(TypeParser) {
+            when (token.type) {
+                is LeftCurly -> parseDict().bind()
+                is WirespecType -> parseType().bind()
+                else -> raiseWrongToken<WirespecType>().bind()
+            }
+        }
+        Field(
+            annotations = emptyList(),
+            identifier = identifier,
+            reference = reference,
+        )
+    }
+}

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/RpcParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/RpcParser.kt
@@ -12,6 +12,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.tokenize.Arrow
+import community.flock.wirespec.compiler.core.tokenize.Bang
 import community.flock.wirespec.compiler.core.tokenize.Colon
 import community.flock.wirespec.compiler.core.tokenize.Comma
 import community.flock.wirespec.compiler.core.tokenize.LeftCurly
@@ -45,12 +46,28 @@ object RpcParser {
             }
         }
 
+        val error = when (token.type) {
+            is Bang -> {
+                eatToken().bind()
+                with(TypeParser) {
+                    when (token.type) {
+                        is LeftCurly -> parseDict().bind()
+                        is WirespecType -> parseType().bind()
+                        else -> raiseWrongToken<WirespecType>().bind()
+                    }
+                }
+            }
+
+            else -> null
+        }
+
         Rpc(
             comment = comment,
             annotations = annotations,
             identifier = identifier,
             requestParameters = requestParameters,
             response = response,
+            error = error,
         )
     }
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
@@ -54,6 +54,7 @@ data class Rpc(
     override val identifier: DefinitionIdentifier,
     val requestParameters: List<Field>,
     val response: Reference,
+    val error: Reference? = null,
 ) : Definition
 
 sealed interface Model : Definition

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
@@ -48,6 +48,14 @@ data class Channel(
     val reference: Reference,
 ) : Definition
 
+data class Rpc(
+    override val comment: Comment?,
+    override val annotations: List<Annotation>,
+    override val identifier: DefinitionIdentifier,
+    val requestParameters: List<Field>,
+    val response: Reference,
+) : Definition
+
 sealed interface Model : Definition
 
 data class Type(

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
@@ -20,6 +20,7 @@ data object Integer : TokenType
 data object Underscore : TokenType
 data object Character : TokenType
 data object Arrow : TokenType
+data object Bang : TokenType
 data object Pipe : TokenType
 data object LiteralString : TokenType
 data object EndOfProgram : TokenType {

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
@@ -59,6 +59,7 @@ data object TypeDefinition : WirespecDefinition
 data object EnumTypeDefinition : WirespecDefinition
 data object ChannelDefinition : WirespecDefinition
 data object EndpointDefinition : WirespecDefinition
+data object RpcDefinition : WirespecDefinition
 
 sealed interface ChannelTokenType : TokenType
 data object Method : ChannelTokenType

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/validate/Validator.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/validate/Validator.kt
@@ -9,6 +9,7 @@ import arrow.core.right
 import arrow.core.toNonEmptyListOrNull
 import community.flock.wirespec.compiler.core.exceptions.DuplicateChannelError
 import community.flock.wirespec.compiler.core.exceptions.DuplicateEndpointError
+import community.flock.wirespec.compiler.core.exceptions.DuplicateRpcError
 import community.flock.wirespec.compiler.core.exceptions.DuplicateTypeError
 import community.flock.wirespec.compiler.core.exceptions.UnionError
 import community.flock.wirespec.compiler.core.exceptions.WirespecException
@@ -20,6 +21,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Statements
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
@@ -31,7 +33,8 @@ object Validator {
         validateEndpoints(ast),
         validateTypes(ast),
         validateChannels(ast),
-    ) { a, _, _, _ -> a }
+        validateRpcs(ast),
+    ) { a, _, _, _, _ -> a }
 
     private fun validateWithOptions(ast: AST, options: ParseOptions): EitherNel<WirespecException, AST> = ast.modules
         .map { (uri, statements) -> runValidateOptions(options)(statements).map { Module(uri, it) } }
@@ -46,6 +49,7 @@ object Validator {
         map { definition ->
             when (definition) {
                 is Channel -> definition
+                is Rpc -> definition
                 is Endpoint -> definition
                 is Enum -> definition
                 is Refined -> definition
@@ -97,6 +101,16 @@ object Validator {
         .groupBy { it.identifier.value }
         .filter { it.value.size > 1 }
         .map { (name, channels) -> channels.map { DuplicateChannelError(name) } }
+        .flatten()
+        .toNonEmptyListOrNull()
+        ?.left()
+        ?: ast.right()
+
+    private fun validateRpcs(ast: AST): EitherNel<WirespecException, AST> = ast.modules.toList()
+        .flatMap { it.statements.filterIsInstance<Rpc>() }
+        .groupBy { it.identifier.value }
+        .filter { it.value.size > 1 }
+        .map { (name, rpcs) -> rpcs.map { DuplicateRpcError(name) } }
         .flatten()
         .toNonEmptyListOrNull()
         ?.left()

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseRpcTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseRpcTest.kt
@@ -72,6 +72,44 @@ class ParseRpcTest {
     }
 
     @Test
+    fun testRpcParserWithError() {
+        val source =
+            // language=ws
+            """
+            |type Todo { name: String }
+            |type Error { code: String }
+            |rpc CreateTodo(todo: Todo) -> Todo ! Error
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(3)[2]
+            .shouldBeInstanceOf<Rpc>()
+            .run {
+                identifier.value shouldBe "CreateTodo"
+                response.value shouldBe "Todo"
+                error?.value shouldBe "Error"
+                error?.isNullable shouldBe false
+            }
+    }
+
+    @Test
+    fun testRpcParserWithoutErrorHasNullError() {
+        val source =
+            // language=ws
+            """
+            |type Todo { name: String }
+            |rpc CreateTodo(todo: Todo) -> Todo
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(2)[1]
+            .shouldBeInstanceOf<Rpc>()
+            .run { error shouldBe null }
+    }
+
+    @Test
     fun testRpcParserNoParametersAndUnitResponse() {
         val source =
             // language=ws

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseRpcTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseRpcTest.kt
@@ -1,0 +1,92 @@
+package community.flock.wirespec.compiler.core.parse
+
+import arrow.core.nonEmptyListOf
+import community.flock.wirespec.compiler.core.FileUri
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.core.ParseContext
+import community.flock.wirespec.compiler.core.WirespecSpec
+import community.flock.wirespec.compiler.core.parse
+import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
+import community.flock.wirespec.compiler.utils.NoLogger
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+
+class ParseRpcTest {
+
+    private fun parser(source: String) = object : ParseContext, NoLogger {
+        override val spec = WirespecSpec
+    }.parse(nonEmptyListOf(ModuleContent(FileUri("test.ws"), source))).map { it.modules.flatMap(Module::statements) }
+
+    @Test
+    fun testRpcParser() {
+        val source =
+            // language=ws
+            """
+            |type Todo { name: String }
+            |rpc CreateTodo(todo: Todo) -> Todo
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(2)[1]
+            .shouldBeInstanceOf<Rpc>()
+            .run {
+                comment?.value shouldBe null
+                identifier.value shouldBe "CreateTodo"
+                requestParameters shouldHaveSize 1
+                requestParameters[0].identifier.value shouldBe "todo"
+                requestParameters[0].reference.value shouldBe "Todo"
+                response.value shouldBe "Todo"
+                response.isNullable shouldBe false
+            }
+    }
+
+    @Test
+    fun testRpcParserMultipleParameters() {
+        val source =
+            // language=ws
+            """
+            |type Todo { name: String }
+            |type TodoId { id: String }
+            |rpc UpdateTodo(id: TodoId, todo: Todo) -> Todo
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(3)[2]
+            .shouldBeInstanceOf<Rpc>()
+            .run {
+                identifier.value shouldBe "UpdateTodo"
+                requestParameters shouldHaveSize 2
+                requestParameters[0].identifier.value shouldBe "id"
+                requestParameters[0].reference.value shouldBe "TodoId"
+                requestParameters[1].identifier.value shouldBe "todo"
+                requestParameters[1].reference.value shouldBe "Todo"
+                response.value shouldBe "Todo"
+            }
+    }
+
+    @Test
+    fun testRpcParserNoParametersAndUnitResponse() {
+        val source =
+            // language=ws
+            """
+            |rpc Ping() -> Unit
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(1)[0]
+            .shouldBeInstanceOf<Rpc>()
+            .run {
+                identifier.value shouldBe "Ping"
+                requestParameters shouldHaveSize 0
+                response.shouldBeInstanceOf<Reference.Unit>()
+            }
+    }
+}

--- a/src/compiler/emitters/java/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileRpcTest.txt
@@ -12,6 +12,6 @@ public record Todo (
 package community.flock.wirespec.generated.rpc;
 import community.flock.wirespec.java.Wirespec;
 import community.flock.wirespec.generated.model.Todo;
-public interface CreateTodo {
+public interface CreateTodo extends Wirespec.Rpc {
   public Todo createTodo(Todo todo);
 }

--- a/src/compiler/emitters/java/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileRpcTest.txt
@@ -23,6 +23,8 @@ public record Error (
 package community.flock.wirespec.generated.rpc;
 import community.flock.wirespec.java.Wirespec;
 import community.flock.wirespec.generated.model.Todo;
-public interface CreateTodo extends Wirespec.Rpc {
-  public Wirespec.Either<Error, Todo> createTodo(Todo todo);
+public interface CreateTodo {
+  public interface Service extends Wirespec.Rpc {
+    public Wirespec.Either<Error, Todo> createTodo(Todo todo);
+  }
 }

--- a/src/compiler/emitters/java/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileRpcTest.txt
@@ -23,8 +23,8 @@ public record Error (
 package community.flock.wirespec.generated.rpc;
 import community.flock.wirespec.java.Wirespec;
 import community.flock.wirespec.generated.model.Todo;
-public interface CreateTodo {
-  public interface Service extends Wirespec.Rpc {
+public interface CreateTodo extends Wirespec.Rpc {
+  public interface Service {
     public Wirespec.Either<Error, Todo> createTodo(Todo todo);
   }
 }

--- a/src/compiler/emitters/java/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileRpcTest.txt
@@ -1,0 +1,17 @@
+package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
+public record Todo (
+  String name
+) implements Wirespec.Model {
+  @Override
+  public java.util.List<String> validate() {
+    return java.util.List.<String>of();
+  }
+};
+
+package community.flock.wirespec.generated.rpc;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.Todo;
+public interface CreateTodo {
+  public Todo invoke(Todo todo);
+}

--- a/src/compiler/emitters/java/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileRpcTest.txt
@@ -13,5 +13,5 @@ package community.flock.wirespec.generated.rpc;
 import community.flock.wirespec.java.Wirespec;
 import community.flock.wirespec.generated.model.Todo;
 public interface CreateTodo {
-  public Todo invoke(Todo todo);
+  public Todo createTodo(Todo todo);
 }

--- a/src/compiler/emitters/java/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileRpcTest.txt
@@ -9,9 +9,20 @@ public record Todo (
   }
 };
 
+package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
+public record Error (
+  String code
+) implements Wirespec.Model {
+  @Override
+  public java.util.List<String> validate() {
+    return java.util.List.<String>of();
+  }
+};
+
 package community.flock.wirespec.generated.rpc;
 import community.flock.wirespec.java.Wirespec;
 import community.flock.wirespec.generated.model.Todo;
 public interface CreateTodo extends Wirespec.Rpc {
-  public Todo createTodo(Todo todo);
+  public Wirespec.Either<Error, Todo> createTodo(Todo todo);
 }

--- a/src/compiler/emitters/java/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/java/fixtures/sharedOutputTest.txt
@@ -14,6 +14,8 @@ public interface Wirespec {
   }
   public interface Channel {
   }
+  public interface Rpc {
+  }
   public interface Refined<T> {
     T value();
     public Boolean validate();

--- a/src/compiler/emitters/java/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/java/fixtures/sharedOutputTest.txt
@@ -16,6 +16,10 @@ public interface Wirespec {
   }
   public interface Rpc {
   }
+  public interface Either<L, R> {
+    java.util.Optional<L> error();
+    java.util.Optional<R> value();
+  }
   public interface Refined<T> {
     T value();
     public Boolean validate();

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
@@ -13,6 +13,7 @@ import community.flock.wirespec.compiler.core.emit.importReferences
 import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Module
@@ -185,6 +186,10 @@ open class JavaIrEmitter(
             .sanitizeNames(sanitizationConfig)
             .applyFunctionalInterface(fullyQualifiedPrefix)
     }
+
+    override fun emit(rpc: Rpc): File = rpc.convert()
+        .sanitizeNames(sanitizationConfig)
+        .prependImports(rpc.buildModelImports(packageName).takeIf { it.isNotEmpty() })
 
     override fun emitEndpointClient(endpoint: Endpoint): File {
         val imports = endpoint.buildModelImports(packageName)

--- a/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitterTest.kt
+++ b/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitterTest.kt
@@ -15,6 +15,7 @@ import community.flock.wirespec.compiler.test.CompileFullEndpointTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
+import community.flock.wirespec.compiler.test.CompileRpcTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.compiler.test.NodeFixtures
@@ -58,6 +59,11 @@ class JavaIrEmitterTest {
     @Test
     fun compileChannelTest() {
         CompileChannelTest.compiler { JavaIrEmitter() } shouldBeRight EmitterFixtures.compileChannelTest
+    }
+
+    @Test
+    fun compileRpcTest() {
+        CompileRpcTest.compiler { JavaIrEmitter() } shouldBeRight EmitterFixtures.compileRpcTest
     }
 
     @Test

--- a/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
@@ -8,10 +8,20 @@ data class Todo(
     emptyList<String>()
 }
 
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+data class Error(
+  val code: String
+) : Wirespec.Model {
+  override fun validate(): List<String> =
+    emptyList<String>()
+}
+
 package community.flock.wirespec.generated.rpc
 import community.flock.wirespec.kotlin.Wirespec
 import kotlin.reflect.typeOf
 import community.flock.wirespec.generated.model.Todo
 interface CreateTodo : Wirespec.Rpc {
-  fun createTodo(todo: Todo): Todo
+  fun createTodo(todo: Todo): Wirespec.Either<Error, Todo>
 }

--- a/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
@@ -22,6 +22,8 @@ package community.flock.wirespec.generated.rpc
 import community.flock.wirespec.kotlin.Wirespec
 import kotlin.reflect.typeOf
 import community.flock.wirespec.generated.model.Todo
-interface CreateTodo : Wirespec.Rpc {
-  fun createTodo(todo: Todo): Wirespec.Either<Error, Todo>
+object CreateTodo {
+  interface Service : Wirespec.Rpc {
+      fun createTodo(todo: Todo): Wirespec.Either<Error, Todo>
+  }
 }

--- a/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
@@ -12,6 +12,6 @@ package community.flock.wirespec.generated.rpc
 import community.flock.wirespec.kotlin.Wirespec
 import kotlin.reflect.typeOf
 import community.flock.wirespec.generated.model.Todo
-interface CreateTodo {
+interface CreateTodo : Wirespec.Rpc {
   fun createTodo(todo: Todo): Todo
 }

--- a/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
@@ -22,8 +22,8 @@ package community.flock.wirespec.generated.rpc
 import community.flock.wirespec.kotlin.Wirespec
 import kotlin.reflect.typeOf
 import community.flock.wirespec.generated.model.Todo
-object CreateTodo {
-  interface Service : Wirespec.Rpc {
+object CreateTodo : Wirespec.Rpc {
+  interface Service {
       fun createTodo(todo: Todo): Wirespec.Either<Error, Todo>
   }
 }

--- a/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
@@ -13,5 +13,5 @@ import community.flock.wirespec.kotlin.Wirespec
 import kotlin.reflect.typeOf
 import community.flock.wirespec.generated.model.Todo
 interface CreateTodo {
-  fun invoke(todo: Todo): Todo
+  fun createTodo(todo: Todo): Todo
 }

--- a/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileRpcTest.txt
@@ -1,0 +1,17 @@
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+data class Todo(
+  val name: String
+) : Wirespec.Model {
+  override fun validate(): List<String> =
+    emptyList<String>()
+}
+
+package community.flock.wirespec.generated.rpc
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.Todo
+interface CreateTodo {
+  fun invoke(todo: Todo): Todo
+}

--- a/src/compiler/emitters/kotlin/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/sharedOutputTest.txt
@@ -10,6 +10,10 @@ object Wirespec {
   interface Endpoint
   interface Channel
   interface Rpc
+  interface Either<L: Any, R: Any> {
+      val error: L?
+      val value: R?
+  }
   interface Refined<T: Any> {
       val value: T
       fun validate(): Boolean

--- a/src/compiler/emitters/kotlin/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/sharedOutputTest.txt
@@ -9,6 +9,7 @@ object Wirespec {
   }
   interface Endpoint
   interface Channel
+  interface Rpc
   interface Refined<T: Any> {
       val value: T
       fun validate(): Boolean

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
@@ -27,6 +27,7 @@ import community.flock.wirespec.compiler.core.emit.importReferences
 import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
@@ -157,6 +158,11 @@ open class KotlinIrEmitter(
         .convert()
         .sanitizeNames(sanitizationConfig)
         .prependImports(channel.buildModelImports(packageName).takeIf { it.isNotEmpty() })
+
+    override fun emit(rpc: Rpc): File = rpc
+        .convert()
+        .sanitizeNames(sanitizationConfig)
+        .prependImports(rpc.buildModelImports(packageName).takeIf { it.isNotEmpty() })
 
     override fun emitEndpointClient(endpoint: Endpoint): File {
         val imports = endpoint.buildModelImports(packageName)

--- a/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
+++ b/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
@@ -15,6 +15,7 @@ import community.flock.wirespec.compiler.test.CompileFullEndpointTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
+import community.flock.wirespec.compiler.test.CompileRpcTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.compiler.test.NodeFixtures
@@ -82,6 +83,13 @@ class KotlinIrEmitterTest {
         val kotlin = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { KotlinIrEmitter() } shouldBeRight kotlin
+    }
+
+    @Test
+    fun compileRpcTest() {
+        val kotlin = EmitterFixtures.compileRpcTest
+
+        CompileRpcTest.compiler { KotlinIrEmitter() } shouldBeRight kotlin
     }
 
     @Test

--- a/src/compiler/emitters/python/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileRpcTest.txt
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Any, Generic, List, Optional
 import enum
 from ..wirespec import T, Wirespec, _raise
-class CreateTodo(ABC):
+class CreateTodo(Wirespec.Rpc, ABC):
     @abstractmethod
     def create_todo(self, todo: Todo) -> Todo:
         ...

--- a/src/compiler/emitters/python/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileRpcTest.txt
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+@dataclass
+class Todo(Wirespec.Model):
+    name: str
+    def validate(self) -> list[str]:
+        return []
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+class CreateTodo(ABC):
+    @abstractmethod
+    def invoke(self, todo: Todo) -> Todo:
+        ...
+
+from . import model
+from . import endpoint
+from . import wirespec
+
+
+
+
+
+

--- a/src/compiler/emitters/python/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileRpcTest.txt
@@ -31,8 +31,8 @@ from dataclasses import dataclass
 from typing import Any, Generic, List, Optional
 import enum
 from ..wirespec import T, Wirespec, _raise
-class CreateTodo:
-    class Service(Wirespec.Rpc, ABC):
+class CreateTodo(Wirespec.Rpc):
+    class Service(ABC):
         @abstractmethod
         def create_todo(self, todo: Todo) -> Wirespec.Either[Error, Todo]:
             ...

--- a/src/compiler/emitters/python/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileRpcTest.txt
@@ -18,9 +18,22 @@ from dataclasses import dataclass
 from typing import Any, Generic, List, Optional
 import enum
 from ..wirespec import T, Wirespec, _raise
+@dataclass
+class Error(Wirespec.Model):
+    code: str
+    def validate(self) -> list[str]:
+        return []
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
 class CreateTodo(Wirespec.Rpc, ABC):
     @abstractmethod
-    def create_todo(self, todo: Todo) -> Todo:
+    def create_todo(self, todo: Todo) -> Wirespec.Either[Error, Todo]:
         ...
 
 from . import model

--- a/src/compiler/emitters/python/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileRpcTest.txt
@@ -20,7 +20,7 @@ import enum
 from ..wirespec import T, Wirespec, _raise
 class CreateTodo(ABC):
     @abstractmethod
-    def invoke(self, todo: Todo) -> Todo:
+    def create_todo(self, todo: Todo) -> Todo:
         ...
 
 from . import model

--- a/src/compiler/emitters/python/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileRpcTest.txt
@@ -31,10 +31,11 @@ from dataclasses import dataclass
 from typing import Any, Generic, List, Optional
 import enum
 from ..wirespec import T, Wirespec, _raise
-class CreateTodo(Wirespec.Rpc, ABC):
-    @abstractmethod
-    def create_todo(self, todo: Todo) -> Wirespec.Either[Error, Todo]:
-        ...
+class CreateTodo:
+    class Service(Wirespec.Rpc, ABC):
+        @abstractmethod
+        def create_todo(self, todo: Todo) -> Wirespec.Either[Error, Todo]:
+            ...
 
 from . import model
 from . import endpoint

--- a/src/compiler/emitters/python/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/python/fixtures/sharedOutputTest.txt
@@ -20,6 +20,9 @@ class Wirespec:
         pass
     class Rpc(ABC):
         pass
+    class Either(ABC, Generic[L, R]):
+        error: Optional[L]
+        value: Optional[R]
     class Refined(ABC, Generic[T]):
         value: T
         @abstractmethod

--- a/src/compiler/emitters/python/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/python/fixtures/sharedOutputTest.txt
@@ -18,6 +18,8 @@ class Wirespec:
         pass
     class Channel(ABC):
         pass
+    class Rpc(ABC):
+        pass
     class Refined(ABC, Generic[T]):
         value: T
         @abstractmethod

--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonEmitter.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonEmitter.kt
@@ -16,6 +16,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Model
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
 import community.flock.wirespec.compiler.utils.Logger
@@ -59,6 +60,7 @@ open class PythonEmitter(
         is Union -> 4
         is Endpoint -> 5
         is Channel -> 6
+        is Rpc -> 7
     }
 
     override fun emit(module: Module, logger: Logger): NonEmptyList<Emitted> {

--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitter.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitter.kt
@@ -198,6 +198,7 @@ open class PythonIrEmitter(
 
     override fun emit(rpc: Rpc): File =
         rpc.convert()
+            .snakeCaseFunctionNames()
             .sanitizeNames(sanitizationConfig)
 
     override fun emitEndpointClient(endpoint: Endpoint): File {

--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitter.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitter.kt
@@ -12,6 +12,7 @@ import community.flock.wirespec.compiler.core.emit.importReferences
 import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
@@ -193,6 +194,10 @@ open class PythonIrEmitter(
 
     override fun emit(channel: Channel): File =
         channel.convert()
+            .sanitizeNames(sanitizationConfig)
+
+    override fun emit(rpc: Rpc): File =
+        rpc.convert()
             .sanitizeNames(sanitizationConfig)
 
     override fun emitEndpointClient(endpoint: Endpoint): File {

--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
@@ -67,6 +67,12 @@ internal fun File.splitEndpointStructsToModuleLevel(): File {
     return LanguageFile(namespace.name, moduleElements + endpointClass)
 }
 
+internal fun <T : Element> T.snakeCaseFunctionNames(): T = transform {
+    matchingElements { func: LanguageFunction ->
+        func.copy(name = Name.of(func.name.snakeCase()))
+    }
+}
+
 internal fun <T : Element> T.snakeCaseHandlerAndCallMethods(): T = transform {
     matchingElements { iface: Interface ->
         if (iface.name != Name.of("Handler") && iface.name != Name.of("Call")) return@matchingElements iface

--- a/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitterTest.kt
+++ b/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitterTest.kt
@@ -8,6 +8,7 @@ import community.flock.wirespec.compiler.test.CompileFullEndpointTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
+import community.flock.wirespec.compiler.test.CompileRpcTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.ir.generator.PythonGenerator
@@ -29,6 +30,13 @@ class PythonIrEmitterTest {
         val python = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { PythonIrEmitter() } shouldBeRight python
+    }
+
+    @Test
+    fun compileRpcTest() {
+        val python = EmitterFixtures.compileRpcTest
+
+        CompileRpcTest.compiler { PythonIrEmitter() } shouldBeRight python
     }
 
     @Test

--- a/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
@@ -26,7 +26,7 @@ use super::super::wirespec::*;
 use regex;
 pub mod CreateTodo {
     use super::*;
-    pub trait Service: Wirespec.Rpc {
+    pub trait Service {
         fn create_todo(todo: Todo) -> Wirespec.Either<Error, Todo>;
     }
 }

--- a/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
@@ -13,7 +13,7 @@ impl Todo {
 use super::super::wirespec::*;
 use regex;
 pub trait CreateTodo {
-    fn invoke(todo: Todo) -> Todo;
+    fn create_todo(todo: Todo) -> Todo;
 }
 
 #![allow(warnings)]

--- a/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
@@ -24,8 +24,11 @@ impl Error {
 
 use super::super::wirespec::*;
 use regex;
-pub trait CreateTodo: Wirespec.Rpc {
-    fn create_todo(todo: Todo) -> Wirespec.Either<Error, Todo>;
+pub mod CreateTodo {
+    use super::*;
+    pub trait Service: Wirespec.Rpc {
+        fn create_todo(todo: Todo) -> Wirespec.Either<Error, Todo>;
+    }
 }
 
 #![allow(warnings)]

--- a/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
@@ -1,0 +1,22 @@
+use super::super::wirespec::*;
+use regex;
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Todo {
+    pub name: String,
+}
+impl Todo {
+    pub fn validate(&self) -> Vec<String> {
+        return Vec::<String>::new();
+    }
+}
+
+use super::super::wirespec::*;
+use regex;
+pub trait CreateTodo {
+    fn invoke(todo: Todo) -> Todo;
+}
+
+#![allow(warnings)]
+pub mod model;
+pub mod endpoint;
+pub mod wirespec;

--- a/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
@@ -12,7 +12,7 @@ impl Todo {
 
 use super::super::wirespec::*;
 use regex;
-pub trait CreateTodo {
+pub trait CreateTodo: Wirespec.Rpc {
     fn create_todo(todo: Todo) -> Todo;
 }
 

--- a/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileRpcTest.txt
@@ -12,8 +12,20 @@ impl Todo {
 
 use super::super::wirespec::*;
 use regex;
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Error {
+    pub code: String,
+}
+impl Error {
+    pub fn validate(&self) -> Vec<String> {
+        return Vec::<String>::new();
+    }
+}
+
+use super::super::wirespec::*;
+use regex;
 pub trait CreateTodo: Wirespec.Rpc {
-    fn create_todo(todo: Todo) -> Todo;
+    fn create_todo(todo: Todo) -> Wirespec.Either<Error, Todo>;
 }
 
 #![allow(warnings)]

--- a/src/compiler/emitters/rust/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/rust/fixtures/sharedOutputTest.txt
@@ -10,6 +10,10 @@ pub trait Enum: Sized {
 pub trait Endpoint {}
 pub trait Channel {}
 pub trait Rpc {}
+pub trait Either<L, R> {
+    fn error(&self) -> Option<L>;
+    fn value(&self) -> Option<R>;
+}
 pub trait Refined<T> {
     fn value(&self) -> &T;
     fn validate(&self) -> bool;

--- a/src/compiler/emitters/rust/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/rust/fixtures/sharedOutputTest.txt
@@ -9,6 +9,7 @@ pub trait Enum: Sized {
 }
 pub trait Endpoint {}
 pub trait Channel {}
+pub trait Rpc {}
 pub trait Refined<T> {
     fn value(&self) -> &T;
     fn validate(&self) -> bool;

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
@@ -13,6 +13,7 @@ import community.flock.wirespec.compiler.core.emit.importReferences
 import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
@@ -387,6 +388,9 @@ open class RustIrEmitter(
 
     override fun emit(channel: Channel): File =
         channel.convert()
+
+    override fun emit(rpc: Rpc): File =
+        rpc.convert()
 
     override fun emitEndpointClient(endpoint: Endpoint): File {
         val endpointName = endpoint.identifier.value

--- a/src/compiler/emitters/rust/src/commonTest/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitterTest.kt
+++ b/src/compiler/emitters/rust/src/commonTest/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitterTest.kt
@@ -8,6 +8,7 @@ import community.flock.wirespec.compiler.test.CompileFullEndpointTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
+import community.flock.wirespec.compiler.test.CompileRpcTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.ir.generator.RustGenerator
@@ -36,6 +37,13 @@ class RustIrEmitterTest {
         val rust = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { RustIrEmitter() } shouldBeRight rust
+    }
+
+    @Test
+    fun compileRpcTest() {
+        val rust = EmitterFixtures.compileRpcTest
+
+        CompileRpcTest.compiler { RustIrEmitter() } shouldBeRight rust
     }
 
     @Test

--- a/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
@@ -8,10 +8,20 @@ case class Todo(
     List.empty[String]
 }
 
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+case class Error(
+  val code: String
+) extends Wirespec.Model {
+  override def validate(): List[String] =
+    List.empty[String]
+}
+
 package community.flock.wirespec.generated.rpc
 import community.flock.wirespec.scala.Wirespec
 import scala.reflect.ClassTag
 import community.flock.wirespec.generated.model.Todo
 trait CreateTodo extends Wirespec.Rpc {
-  def createTodo(todo: Todo): Todo
+  def createTodo(todo: Todo): Wirespec.Either[Error, Todo]
 }

--- a/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
@@ -13,5 +13,5 @@ import community.flock.wirespec.scala.Wirespec
 import scala.reflect.ClassTag
 import community.flock.wirespec.generated.model.Todo
 trait CreateTodo {
-  def invoke(todo: Todo): Todo
+  def createTodo(todo: Todo): Todo
 }

--- a/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
@@ -1,0 +1,17 @@
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+case class Todo(
+  val name: String
+) extends Wirespec.Model {
+  override def validate(): List[String] =
+    List.empty[String]
+}
+
+package community.flock.wirespec.generated.rpc
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+import community.flock.wirespec.generated.model.Todo
+trait CreateTodo {
+  def invoke(todo: Todo): Todo
+}

--- a/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
@@ -22,8 +22,8 @@ package community.flock.wirespec.generated.rpc
 import community.flock.wirespec.scala.Wirespec
 import scala.reflect.ClassTag
 import community.flock.wirespec.generated.model.Todo
-object CreateTodo {
-  trait Service extends Wirespec.Rpc {
+object CreateTodo extends Wirespec.Rpc {
+  trait Service {
       def createTodo(todo: Todo): Wirespec.Either[Error, Todo]
   }
 }

--- a/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
@@ -12,6 +12,6 @@ package community.flock.wirespec.generated.rpc
 import community.flock.wirespec.scala.Wirespec
 import scala.reflect.ClassTag
 import community.flock.wirespec.generated.model.Todo
-trait CreateTodo {
+trait CreateTodo extends Wirespec.Rpc {
   def createTodo(todo: Todo): Todo
 }

--- a/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileRpcTest.txt
@@ -22,6 +22,8 @@ package community.flock.wirespec.generated.rpc
 import community.flock.wirespec.scala.Wirespec
 import scala.reflect.ClassTag
 import community.flock.wirespec.generated.model.Todo
-trait CreateTodo extends Wirespec.Rpc {
-  def createTodo(todo: Todo): Wirespec.Either[Error, Todo]
+object CreateTodo {
+  trait Service extends Wirespec.Rpc {
+      def createTodo(todo: Todo): Wirespec.Either[Error, Todo]
+  }
 }

--- a/src/compiler/emitters/scala/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/scala/fixtures/sharedOutputTest.txt
@@ -9,6 +9,10 @@ object Wirespec {
   trait Endpoint
   trait Channel
   trait Rpc
+  trait Either[L, R] {
+      def error: Option[L]
+      def value: Option[R]
+  }
   trait Refined[T] {
       def value: T
       def validate(): Boolean

--- a/src/compiler/emitters/scala/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/scala/fixtures/sharedOutputTest.txt
@@ -8,6 +8,7 @@ object Wirespec {
   }
   trait Endpoint
   trait Channel
+  trait Rpc
   trait Refined[T] {
       def value: T
       def validate(): Boolean

--- a/src/compiler/emitters/scala/src/commonMain/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitter.kt
+++ b/src/compiler/emitters/scala/src/commonMain/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitter.kt
@@ -14,6 +14,7 @@ import community.flock.wirespec.compiler.core.emit.importReferences
 import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
@@ -219,6 +220,11 @@ open class ScalaIrEmitter(
         .convert()
         .sanitizeNames(sanitizationConfig)
         .prependImports(channel.buildModelImports(packageName).takeIf { it.isNotEmpty() })
+
+    override fun emit(rpc: Rpc): File = rpc
+        .convert()
+        .sanitizeNames(sanitizationConfig)
+        .prependImports(rpc.buildModelImports(packageName).takeIf { it.isNotEmpty() })
 
     override fun emitEndpointClient(endpoint: Endpoint): File {
         val imports = endpoint.buildModelImports(packageName)

--- a/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
+++ b/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
@@ -15,6 +15,7 @@ import community.flock.wirespec.compiler.test.CompileFullEndpointTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
+import community.flock.wirespec.compiler.test.CompileRpcTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.compiler.test.NodeFixtures
@@ -103,6 +104,13 @@ class ScalaIrEmitterTest {
         val scala = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { ScalaIrEmitter() } shouldBeRight scala
+    }
+
+    @Test
+    fun compileRpcTest() {
+        val scala = EmitterFixtures.compileRpcTest
+
+        CompileRpcTest.compiler { ScalaIrEmitter() } shouldBeRight scala
     }
 
     @Test

--- a/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
@@ -1,0 +1,15 @@
+import {Wirespec} from '../Wirespec'
+export type Todo = {
+  "name": string,
+}
+export function validateTodo(obj: Todo): string[] {
+  return [] as string[];
+}
+
+import {Wirespec} from '../Wirespec'
+export interface CreateTodo {
+  invoke(todo: Todo): Todo;
+}
+
+export {Todo} from './Todo'
+export {CreateTodo} from './CreateTodo'

--- a/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
@@ -16,7 +16,7 @@ export function validateError(obj: Error): string[] {
 
 import {Wirespec} from '../Wirespec'
 export namespace CreateTodo {
-  export interface Service extends Wirespec.Rpc {
+  export interface Service {
     createTodo(todo: Todo): Wirespec.Either<Error, Todo>;
   }
 }

--- a/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
@@ -8,7 +8,7 @@ export function validateTodo(obj: Todo): string[] {
 
 import {Wirespec} from '../Wirespec'
 export interface CreateTodo {
-  invoke(todo: Todo): Todo;
+  createTodo(todo: Todo): Todo;
 }
 
 export {Todo} from './Todo'

--- a/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
@@ -7,7 +7,7 @@ export function validateTodo(obj: Todo): string[] {
 }
 
 import {Wirespec} from '../Wirespec'
-export interface CreateTodo {
+export interface CreateTodo extends Wirespec.Rpc {
   createTodo(todo: Todo): Todo;
 }
 

--- a/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
@@ -15,8 +15,10 @@ export function validateError(obj: Error): string[] {
 }
 
 import {Wirespec} from '../Wirespec'
-export interface CreateTodo extends Wirespec.Rpc {
-  createTodo(todo: Todo): Wirespec.Either<Error, Todo>;
+export namespace CreateTodo {
+  export interface Service extends Wirespec.Rpc {
+    createTodo(todo: Todo): Wirespec.Either<Error, Todo>;
+  }
 }
 
 export {Todo} from './Todo'

--- a/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/compileRpcTest.txt
@@ -7,9 +7,18 @@ export function validateTodo(obj: Todo): string[] {
 }
 
 import {Wirespec} from '../Wirespec'
+export type Error = {
+  "code": string,
+}
+export function validateError(obj: Error): string[] {
+  return [] as string[];
+}
+
+import {Wirespec} from '../Wirespec'
 export interface CreateTodo extends Wirespec.Rpc {
-  createTodo(todo: Todo): Todo;
+  createTodo(todo: Todo): Wirespec.Either<Error, Todo>;
 }
 
 export {Todo} from './Todo'
+export {Error} from './Error'
 export {CreateTodo} from './CreateTodo'

--- a/src/compiler/emitters/typescript/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/sharedOutputTest.txt
@@ -8,6 +8,7 @@ export namespace Wirespec {
   }
   export interface Endpoint {}
   export interface Channel {}
+  export interface Rpc {}
   export interface Refined<T> {
     value: T;
     validate(): boolean;

--- a/src/compiler/emitters/typescript/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/sharedOutputTest.txt
@@ -9,6 +9,10 @@ export namespace Wirespec {
   export interface Endpoint {}
   export interface Channel {}
   export interface Rpc {}
+  export interface Either<L, R> {
+    error: L | undefined;
+    value: R | undefined;
+  }
   export interface Refined<T> {
     value: T;
     validate(): boolean;

--- a/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitter.kt
+++ b/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitter.kt
@@ -12,6 +12,7 @@ import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Identifier
 import community.flock.wirespec.compiler.core.parse.ast.Module
@@ -226,6 +227,10 @@ open class TypeScriptIrEmitter : IrEmitter {
 
     override fun emit(channel: Channel): File =
         channel.convert()
+            .sanitizeNames(sanitizationConfig)
+
+    override fun emit(rpc: Rpc): File =
+        rpc.convert()
             .sanitizeNames(sanitizationConfig)
 
     override fun emitEndpointClient(endpoint: Endpoint): File {

--- a/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitterTest.kt
+++ b/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitterTest.kt
@@ -7,6 +7,7 @@ import community.flock.wirespec.compiler.test.CompileFullEndpointTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
+import community.flock.wirespec.compiler.test.CompileRpcTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.ir.generator.TypeScriptGenerator
@@ -28,6 +29,13 @@ class TypeScriptIrEmitterTest {
         val typescript = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { TypeScriptIrEmitter() } shouldBeRight typescript
+    }
+
+    @Test
+    fun compileRpcTest() {
+        val typescript = EmitterFixtures.compileRpcTest
+
+        CompileRpcTest.compiler { TypeScriptIrEmitter() } shouldBeRight typescript
     }
 
     @Test

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -511,14 +511,16 @@ fun ChannelWirespec.convert() = file(identifier.toName()) {
 }
 
 fun RpcWirespec.convert() = file(identifier.toName()) {
-    `interface`(identifier.toName()) {
-        extends(type("Wirespec.Rpc"))
-        function(identifier.toName()) {
-            requestParameters.forEach { arg(it.identifier.toName(), it.reference.convert()) }
-            returnType(
-                error?.let { type("Wirespec.Either", it.convert(), response.convert()) }
-                    ?: response.convert(),
-            )
+    namespace(identifier.toName()) {
+        `interface`("Service") {
+            extends(type("Wirespec.Rpc"))
+            function(identifier.toName()) {
+                requestParameters.forEach { arg(it.identifier.toName(), it.reference.convert()) }
+                returnType(
+                    error?.let { type("Wirespec.Either", it.convert(), response.convert()) }
+                        ?: response.convert(),
+                )
+            }
         }
     }
 }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -505,7 +505,7 @@ fun ChannelWirespec.convert() = file(identifier.toName()) {
 
 fun RpcWirespec.convert() = file(identifier.toName()) {
     `interface`(identifier.toName()) {
-        function("invoke") {
+        function(identifier.toName()) {
             requestParameters.forEach { arg(it.identifier.toName(), it.reference.convert()) }
             returnType(response.convert())
         }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -45,6 +45,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Enum as EnumWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Field as FieldWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Reference as ReferenceWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Refined as RefinedWirespec
+import community.flock.wirespec.compiler.core.parse.ast.Rpc as RpcWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Type as TypeWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Union as UnionWirespec
 import community.flock.wirespec.ir.core.Constraint as LanguageConstraint
@@ -55,6 +56,7 @@ fun DefinitionWirespec.convert(): File = when (this) {
     is UnionWirespec -> convert()
     is RefinedWirespec -> convert()
     is ChannelWirespec -> convert()
+    is RpcWirespec -> convert()
     is EndpointWirespec -> convert()
 }
 
@@ -497,6 +499,15 @@ fun ChannelWirespec.convert() = file(identifier.toName()) {
         function("invoke") {
             arg("message", reference.convert())
             returnType(unit)
+        }
+    }
+}
+
+fun RpcWirespec.convert() = file(identifier.toName()) {
+    `interface`(identifier.toName()) {
+        function("invoke") {
+            requestParameters.forEach { arg(it.identifier.toName(), it.reference.convert()) }
+            returnType(response.convert())
         }
     }
 }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -511,9 +511,8 @@ fun ChannelWirespec.convert() = file(identifier.toName()) {
 }
 
 fun RpcWirespec.convert() = file(identifier.toName()) {
-    namespace(identifier.toName()) {
+    namespace(identifier.toName(), type("Wirespec.Rpc")) {
         `interface`("Service") {
-            extends(type("Wirespec.Rpc"))
             function(identifier.toName()) {
                 requestParameters.forEach { arg(it.identifier.toName(), it.reference.convert()) }
                 returnType(

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -75,6 +75,12 @@ fun PackageName.convert(): File = file("Wirespec") {
         `interface`("Endpoint")
         `interface`("Channel")
         `interface`("Rpc")
+        `interface`("Either") {
+            typeParam(type("L"))
+            typeParam(type("R"))
+            field("error", type("L").nullable())
+            field("value", type("R").nullable())
+        }
         `interface`("Refined") {
             typeParam(type("T"))
             field("value", type("T"))
@@ -509,7 +515,10 @@ fun RpcWirespec.convert() = file(identifier.toName()) {
         extends(type("Wirespec.Rpc"))
         function(identifier.toName()) {
             requestParameters.forEach { arg(it.identifier.toName(), it.reference.convert()) }
-            returnType(response.convert())
+            returnType(
+                error?.let { type("Wirespec.Either", it.convert(), response.convert()) }
+                    ?: response.convert(),
+            )
         }
     }
 }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -74,6 +74,7 @@ fun PackageName.convert(): File = file("Wirespec") {
         }
         `interface`("Endpoint")
         `interface`("Channel")
+        `interface`("Rpc")
         `interface`("Refined") {
             typeParam(type("T"))
             field("value", type("T"))
@@ -505,6 +506,7 @@ fun ChannelWirespec.convert() = file(identifier.toName()) {
 
 fun RpcWirespec.convert() = file(identifier.toName()) {
     `interface`(identifier.toName()) {
+        extends(type("Wirespec.Rpc"))
         function(identifier.toName()) {
             requestParameters.forEach { arg(it.identifier.toName(), it.reference.convert()) }
             returnType(response.convert())

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/emit/IrEmitter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/emit/IrEmitter.kt
@@ -10,6 +10,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
 import community.flock.wirespec.compiler.utils.Logger
@@ -55,6 +56,7 @@ interface IrEmitter : Emitter {
             is Refined -> emit(definition)
             is Union -> emit(definition)
             is Channel -> emit(definition)
+            is Rpc -> emit(definition)
         }
     }
 
@@ -75,6 +77,7 @@ interface IrEmitter : Emitter {
     fun emit(endpoint: Endpoint): File
     fun emit(union: Union): File
     fun emit(channel: Channel): File
+    fun emit(rpc: Rpc): File
 
     fun transformTestFile(file: File): File = file
 }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/transformer/SharedTransforms.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/transformer/SharedTransforms.kt
@@ -5,6 +5,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
 import community.flock.wirespec.ir.core.Constructor
@@ -95,4 +96,5 @@ fun Definition.sortKey(): Int = when (this) {
     is Union -> 4
     is Endpoint -> 5
     is Channel -> 6
+    is Rpc -> 7
 }

--- a/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
+++ b/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
@@ -18,6 +18,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Reference.Primitive.Type.Precision.P32
 import community.flock.wirespec.compiler.core.parse.ast.Reference.Primitive.Type.Precision.P64
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
 
@@ -37,6 +38,7 @@ fun WsDefinition.consume(): Definition = when (this) {
     is WsType -> consume()
     is WsUnion -> consume()
     is WsChannel -> consume()
+    is WsRpc -> consume()
 }
 
 fun WsEndpoint.consume(): Endpoint = Endpoint(
@@ -107,6 +109,14 @@ private fun WsChannel.consume() = Channel(
     annotations = emptyList(),
     identifier = DefinitionIdentifier(identifier),
     reference = reference.consume(),
+)
+
+private fun WsRpc.consume() = Rpc(
+    comment = comment?.let { Comment(it) },
+    annotations = emptyList(),
+    identifier = DefinitionIdentifier(identifier),
+    requestParameters = requestParameters.map { it.consume() },
+    response = response.consume(),
 )
 
 private fun WsField.consume() = Field(
@@ -217,6 +227,13 @@ fun Definition.produce(): WsDefinition = when (this) {
         identifier = identifier.value,
         comment = comment?.value,
         reference = reference.produce(),
+    )
+
+    is Rpc -> WsRpc(
+        identifier = identifier.value,
+        comment = comment?.value,
+        requestParameters = requestParameters.produce(),
+        response = response.produce(),
     )
 }
 
@@ -349,6 +366,14 @@ data class WsChannel(
     override val identifier: String,
     override val comment: String?,
     val reference: WsReference,
+) : WsDefinition
+
+@JsExport
+data class WsRpc(
+    override val identifier: String,
+    override val comment: String?,
+    val requestParameters: Array<WsField>,
+    val response: WsReference,
 ) : WsDefinition
 
 @JsExport

--- a/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
+++ b/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
@@ -117,6 +117,7 @@ private fun WsRpc.consume() = Rpc(
     identifier = DefinitionIdentifier(identifier),
     requestParameters = requestParameters.map { it.consume() },
     response = response.consume(),
+    error = error?.consume(),
 )
 
 private fun WsField.consume() = Field(
@@ -234,6 +235,7 @@ fun Definition.produce(): WsDefinition = when (this) {
         comment = comment?.value,
         requestParameters = requestParameters.produce(),
         response = response.produce(),
+        error = error?.produce(),
     )
 }
 
@@ -374,6 +376,7 @@ data class WsRpc(
     override val comment: String?,
     val requestParameters: Array<WsField>,
     val response: WsReference,
+    val error: WsReference?,
 ) : WsDefinition
 
 @JsExport

--- a/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileRpcTest.kt
+++ b/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileRpcTest.kt
@@ -1,0 +1,13 @@
+package community.flock.wirespec.compiler.test
+
+object CompileRpcTest : Fixture {
+
+    override val source =
+        // language=ws
+        """
+        |type Todo { name: String }
+        |rpc CreateTodo(todo: Todo) -> Todo
+        """.trimMargin()
+
+    override val compiler = source.let(::compile)
+}

--- a/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileRpcTest.kt
+++ b/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileRpcTest.kt
@@ -6,7 +6,8 @@ object CompileRpcTest : Fixture {
         // language=ws
         """
         |type Todo { name: String }
-        |rpc CreateTodo(todo: Todo) -> Todo
+        |type Error { code: String }
+        |rpc CreateTodo(todo: Todo) -> Todo ! Error
         """.trimMargin()
 
     override val compiler = source.let(::compile)

--- a/src/compiler/test/src/jvmMain/kotlin/community/flock/wirespec/compiler/test/EmitterFixtureUpdater.kt
+++ b/src/compiler/test/src/jvmMain/kotlin/community/flock/wirespec/compiler/test/EmitterFixtureUpdater.kt
@@ -73,6 +73,7 @@ private fun IrEmitter.sharedOutputAsString(): String = emitShared()
 private fun compileFixtures(emitterFactory: () -> Emitter): Map<String, () -> String> = linkedMapOf(
     "compileFullEndpointTest" to { compile(CompileFullEndpointTest, emitterFactory) },
     "compileChannelTest" to { compile(CompileChannelTest, emitterFactory) },
+    "compileRpcTest" to { compile(CompileRpcTest, emitterFactory) },
     "compileEnumTest" to { compile(CompileEnumTest, emitterFactory) },
     "compileMinimalEndpointTest" to { compile(CompileMinimalEndpointTest, emitterFactory) },
     "compileRefinedTest" to { compile(CompileRefinedTest, emitterFactory) },

--- a/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3Emitter.kt
+++ b/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3Emitter.kt
@@ -39,6 +39,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Statements
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
@@ -95,6 +96,7 @@ object OpenAPIV3Emitter : Emitter {
                 is Union -> definition.emit()
                 is Endpoint -> error("Cannot emit endpoint")
                 is Channel -> error("Cannot emit channel")
+                is Rpc -> error("Cannot emit rpc")
             }
                 .also { logger.info("Emitting ${definition::class.simpleName} ${definition.identifier.value}") }
         }

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitter.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/emit/SpringKotlinEmitter.kt
@@ -10,6 +10,7 @@ import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Model
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.utils.Logger
 import community.flock.wirespec.emitters.kotlin.KotlinEmitter
 
@@ -44,7 +45,7 @@ class SpringKotlinEmitter(packageName: PackageName) : KotlinEmitter(packageName,
                 val name = definition.identifier.value
                 when (definition) {
                     is Model -> modelNames.add(name)
-                    is Endpoint, is Channel -> endpointNames.add(name)
+                    is Endpoint, is Channel, is Rpc -> endpointNames.add(name)
                 }
             }
         }

--- a/src/integration/wirespec/src/commonMain/kotlin/community/flock/wirespec/kotlin/Wirespec.kt
+++ b/src/integration/wirespec/src/commonMain/kotlin/community/flock/wirespec/kotlin/Wirespec.kt
@@ -10,6 +10,7 @@ object Wirespec {
     interface Endpoint
     interface Channel
     interface Rpc
+    data class Either<L, R>(val error: L?, val value: R?)
     interface Refined<T : Any> {
         val value: T
         fun validate(): Boolean

--- a/src/integration/wirespec/src/commonMain/kotlin/community/flock/wirespec/kotlin/Wirespec.kt
+++ b/src/integration/wirespec/src/commonMain/kotlin/community/flock/wirespec/kotlin/Wirespec.kt
@@ -9,6 +9,7 @@ object Wirespec {
     }
     interface Endpoint
     interface Channel
+    interface Rpc
     interface Refined<T : Any> {
         val value: T
         fun validate(): Boolean

--- a/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
+++ b/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
@@ -11,6 +11,7 @@ public interface Wirespec {
     interface Enum { String label(); }
     interface Endpoint {}
     interface Channel {}
+    interface Rpc {}
     interface Refined<T> { T value(); }
     interface Path {}
     interface Queries {}

--- a/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
+++ b/src/integration/wirespec/src/jvmMain/java/community/flock/wirespec/java/Wirespec.java
@@ -12,6 +12,7 @@ public interface Wirespec {
     interface Endpoint {}
     interface Channel {}
     interface Rpc {}
+    record Either<L, R>(L error, R value) {}
     interface Refined<T> { T value(); }
     interface Path {}
     interface Queries {}

--- a/src/tools/generator/src/commonMain/kotlin/community/flock/wirespec/generator/Generator.kt
+++ b/src/tools/generator/src/commonMain/kotlin/community/flock/wirespec/generator/Generator.kt
@@ -9,6 +9,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Rpc
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
 import kotlinx.serialization.json.JsonArray
@@ -102,4 +103,5 @@ private fun AST.generateObject(def: Definition, random: Random) = when (def) {
     is Union -> generateUnion(def, random)
     is Endpoint -> throw NotImplementedError("Endpoint cannot be generated")
     is Channel -> throw NotImplementedError("Channel cannot be generated")
+    is Rpc -> throw NotImplementedError("Rpc cannot be generated")
 }

--- a/types/wirespec/rpc.ws
+++ b/types/wirespec/rpc.ws
@@ -1,0 +1,4 @@
+type Todo { name: String }
+
+rpc CreateTodo(todo: Todo) -> Todo
+rpc DeleteTodo(id: String) -> Unit


### PR DESCRIPTION
Introduces a new top-level `rpc` construct, with an optional error type:

    rpc CreateTodo(todo: Todo) -> Todo
    rpc CreateTodo(todo: Todo) -> Todo ! Error

- Tokenizer: new `rpc` keyword and RpcDefinition token, plus the `!` (`Bang`) token
- AST: new Rpc definition (request parameters + response reference + optional `error` reference)
- Parser: RpcParser parses `rpc Name(params) -> Response` and the optional `! Error` suffix
- Validator: duplicate-rpc detection
- IR: converts an rpc to an interface with an `invoke` function;
  all six IR emitters (Kotlin, Java, Python, Rust, Scala, TypeScript)
  render it idiomatically
- Tests + per-language emitter fixtures for the new construct

Legacy string emitters are left as not-yet-implemented stubs.

## Error support (`! Error`)

The `-> <success> ! <error>` syntax declares an optional error payload for an rpc. The
error reference is parsed like any other type, so multiple variants can be composed with a
`union`.

The six IR emitters render the error as a dependency-free generic
`Wirespec.Either<Error, Success>` return type (e.g. `fun createTodo(todo: Todo): Wirespec.Either<Error, Todo>`;
Python uses `Wirespec.Either[Error, Todo]`). `Wirespec.Either<L, R>` is a new marker added to
the generated shared runtime and to the hand-written Kotlin/Java runtimes — no external
`Either`/`Result` library is used.

_Scope: this PR contains the compiler changes only. The Protobuf/gRPC emitter and the gRPC
example are tracked separately._

https://claude.ai/code/session_01Kddnhtp49orCaSeTka5vd8