### PR TITLE
fix(integration/msw): align @flock/wirespec/msw with the IR contract (#657)

### DIFF
--- a/examples/npm-typescript/package.json
+++ b/examples/npm-typescript/package.json
@@ -12,7 +12,7 @@
     "compile": "tsc",
     "format": "npm run format:prettier",
     "format:prettier": "npx --yes prettier --write --ignore-unknown .",
-    "generate": "wirespec compile -i ./wirespec -o ./src/gen -l TypeScript --shared",
+    "generate": "wirespec compile -i ./wirespec -o ./src/gen -l TypeScript --shared --ir",
     "test": "vitest --run",
     "update": "npx --yes update-ruecksichtslos"
   },

--- a/examples/npm-typescript/src/client.test.ts
+++ b/examples/npm-typescript/src/client.test.ts
@@ -1,7 +1,7 @@
 import { HandleFetch, wirespecFetchIr } from "@flock/wirespec/fetch";
 import { wirespecSerialization } from "@flock/wirespec/serialization";
 import { expect, test, vi } from "vitest";
-import { client } from "./gen/client";
+import { client } from "./gen/Client";
 
 const arrayBufferOf = (text: string) =>
   Promise.resolve(new TextEncoder().encode(text).buffer);

--- a/examples/npm-typescript/src/client.test.ts
+++ b/examples/npm-typescript/src/client.test.ts
@@ -1,7 +1,10 @@
-import { HandleFetch, wirespecFetch } from "@flock/wirespec/fetch";
+import { HandleFetch, wirespecFetchIr } from "@flock/wirespec/fetch";
 import { wirespecSerialization } from "@flock/wirespec/serialization";
 import { expect, test, vi } from "vitest";
 import { client } from "./gen/client";
+
+const arrayBufferOf = (text: string) =>
+  Promise.resolve(new TextEncoder().encode(text).buffer);
 
 test("testGetTodoById", async () => {
   // @ts-ignore
@@ -12,14 +15,14 @@ test("testGetTodoById", async () => {
         ["Content-Type", "application/json"],
         ["Content-Length", "2"],
       ]),
-      text: () =>
-        Promise.resolve(`{"id": 123, "title": "test", "completed": false}`),
+      arrayBuffer: () =>
+        arrayBufferOf(`{"id": 123, "title": "test", "completed": false}`),
     }),
   );
-  const apiClient = client(wirespecSerialization, (req) =>
-    wirespecFetch(req, mockHandler),
-  );
-  const res = await apiClient.GetTodoById({ id: "123" });
+  const apiClient = client(wirespecSerialization, {
+    transport: (req) => wirespecFetchIr(req, mockHandler),
+  });
+  const res = await apiClient.getTodoById({ id: "123" });
 
   expect(res.status).toEqual(200);
   expect(res.headers).toEqual({});
@@ -40,17 +43,17 @@ test("testGetTodos", async () => {
         ["Content-Length", "2"],
         ["X-Total", "2"],
       ]),
-      text: () =>
-        Promise.resolve(`[{"id": 123, "title": "test", "completed": false}]`),
+      arrayBuffer: () =>
+        arrayBufferOf(`[{"id": 123, "title": "test", "completed": false}]`),
     }),
   );
-  const apiClient = client(wirespecSerialization, (req) =>
-    wirespecFetch(req, mockHandler),
-  );
-  const res = await apiClient.GetTodos({ done: undefined });
+  const apiClient = client(wirespecSerialization, {
+    transport: (req) => wirespecFetchIr(req, mockHandler),
+  });
+  const res = await apiClient.getTodos({ done: undefined });
 
   expect(res.status).toEqual(200);
-  expect(res.headers).toEqual({ "X-Total": "2" });
+  expect(res.headers).toEqual({ xTotal: "2" });
   expect(res.body).toEqual([
     {
       completed: false,

--- a/examples/npm-typescript/src/clientProxy.test.ts
+++ b/examples/npm-typescript/src/clientProxy.test.ts
@@ -4,6 +4,9 @@ import { expect, test } from "vitest";
 import { Wirespec } from "./gen/Wirespec";
 import { GetTodoById, GetTodos, GetUsers, PostTodo } from "./gen/endpoint";
 
+const encode = (value: unknown) =>
+  new TextEncoder().encode(JSON.stringify(value));
+
 const body = [
   {
     id: "1",
@@ -32,26 +35,26 @@ const body = [
 const mock = (
   method: Wirespec.Method,
   path: string[],
-  status: number,
-  headers: Record<string, string>,
-  body: any,
+  statusCode: number,
+  headers: Record<string, string[]>,
+  body: Uint8Array,
 ) => ({
   method,
   path,
-  status,
+  statusCode,
   headers,
   body,
 });
 
 const mocks = [
-  mock("GET", ["api", "todos"], 200, { "X-Total": "2" }, JSON.stringify(body)),
-  mock("GET", ["api", "todos", "1"], 200, {}, JSON.stringify(body[0])),
+  mock("GET", ["api", "todos"], 200, { "X-Total": ["2"] }, encode(body)),
+  mock("GET", ["api", "todos", "1"], 200, {}, encode(body[0])),
   mock(
     "POST",
     ["api", "todos"],
     200,
     {},
-    JSON.stringify({
+    encode({
       id: "3",
       name: "Do more",
       done: true,
@@ -113,7 +116,7 @@ const api = webClient(
 test("testGetTodos", async () => {
   const request: GetTodos.Request = GetTodos.request({});
   const response = await api.getTodos(request);
-  const expected = { status: 200, headers: { "X-Total": "2" }, body };
+  const expected = { status: 200, headers: { xTotal: "2" }, body };
 
   expect(response).toEqual(expected);
 });

--- a/examples/npm-typescript/src/clientSimple.test.ts
+++ b/examples/npm-typescript/src/clientSimple.test.ts
@@ -3,6 +3,9 @@ import { expect, test } from "vitest";
 import { Wirespec } from "./gen/Wirespec";
 import { GetTodoById, GetTodos, PostTodo } from "./gen/endpoint";
 
+const encode = (value: unknown) =>
+  new TextEncoder().encode(JSON.stringify(value));
+
 const body = [
   {
     id: "1",
@@ -38,31 +41,25 @@ const handleFetch =
     const mock = (
       method: Wirespec.Method,
       path: string[],
-      status: number,
-      headers: Record<string, string>,
-      body: any,
+      statusCode: number,
+      headers: Record<string, string[]>,
+      body: Uint8Array,
     ) => ({
       method,
       path,
-      status,
+      statusCode,
       headers,
       body,
     });
     const mocks = [
-      mock(
-        "GET",
-        ["api", "todos"],
-        200,
-        { "x-total": "2" },
-        JSON.stringify(body),
-      ),
-      mock("GET", ["api", "todos", "1"], 200, {}, JSON.stringify(body[0])),
+      mock("GET", ["api", "todos"], 200, { "X-Total": ["2"] }, encode(body)),
+      mock("GET", ["api", "todos", "1"], 200, {}, encode(body[0])),
       mock(
         "POST",
         ["api", "todos"],
         200,
         {},
-        JSON.stringify({
+        encode({
           id: "3",
           name: "Do more",
           done: true,
@@ -95,7 +92,7 @@ const api: Api = {
 test("testGetTodos", async () => {
   const request: GetTodos.Request = GetTodos.request({ done: undefined });
   const response = await api.getTodos(request);
-  const expected = { status: 200, headers: { "X-Total": "2" }, body };
+  const expected = { status: 200, headers: { xTotal: "2" }, body };
 
   expect(response).toEqual(expected);
 });

--- a/examples/npm-typescript/src/fetch.test.ts
+++ b/examples/npm-typescript/src/fetch.test.ts
@@ -1,32 +1,33 @@
-import { HandleFetch, wirespecFetch } from "@flock/wirespec/fetch";
+import { HandleFetch, wirespecFetchIr } from "@flock/wirespec/fetch";
 import { expect, test, vi } from "vitest";
 import { Wirespec } from "./gen/Wirespec";
 
 // @ts-ignore
 const mockHandler = vi.fn<HandleFetch>(() =>
   Promise.resolve({
+    status: 200,
     headers: new Map([
       ["Content-Type", "application/json"],
       ["Content-Length", "2"],
     ]),
-    text: () => Promise.resolve("{}"),
+    arrayBuffer: () => Promise.resolve(new TextEncoder().encode("{}").buffer),
   }),
 );
 
-test("wirespecFetch", async () => {
+test("wirespecFetchIr", async () => {
   const req: Wirespec.RawRequest = {
     method: "GET",
     path: ["test"],
     queries: {
-      test: "test",
+      test: ["test"],
     },
     headers: {
-      test: "TEST",
+      test: ["TEST"],
     },
-    body: "",
+    body: undefined,
   };
-  const res = await wirespecFetch(req, mockHandler);
+  const res = await wirespecFetchIr(req, mockHandler);
 
   expect(mockHandler).toHaveBeenCalledTimes(1);
-  expect(res.body).toEqual("{}");
+  expect(res.body).toEqual(new TextEncoder().encode("{}"));
 });

--- a/examples/npm-typescript/src/msw.test.ts
+++ b/examples/npm-typescript/src/msw.test.ts
@@ -57,7 +57,7 @@ test("baseUrl option matches requests under an absolute origin", async () => {
   const scoped = setupServer(
     wirespec(
       GetTodos.api,
-      async () => GetTodos.response200({ "X-Total": 0, body: [] }),
+      async () => GetTodos.response200({ xTotal: 0, body: [] }),
       { baseUrl: "https://api.example.com" },
     ),
   );

--- a/examples/npm-typescript/src/msw.ts
+++ b/examples/npm-typescript/src/msw.ts
@@ -23,7 +23,7 @@ export const todo: TodoDto = {
 
 export const handlers = [
   wirespec(GetTodos.api, async () =>
-    GetTodos.response200({ "X-Total": 1, body: [todo] }),
+    GetTodos.response200({ xTotal: 1, body: [todo] }),
   ),
 
   wirespec(GetTodoById.api, async (req) =>

--- a/examples/npm-typescript/src/server.test.ts
+++ b/examples/npm-typescript/src/server.test.ts
@@ -3,6 +3,9 @@ import { expect, test } from "vitest";
 import { Wirespec } from "./gen/Wirespec";
 import { GetTodoById, GetTodos, PostTodo } from "./gen/endpoint";
 
+const encode = (value: unknown) =>
+  new TextEncoder().encode(JSON.stringify(value));
+
 const body = [
   {
     id: "1",
@@ -42,7 +45,7 @@ const api: Api = {
     );
   },
   getTodos(_: GetTodos.Request): Promise<GetTodos.Response> {
-    return Promise.resolve(GetTodos.response200({ "X-Total": 2, body }));
+    return Promise.resolve(GetTodos.response200({ xTotal: 2, body }));
   },
   getTodoById(_: GetTodoById.Request): Promise<GetTodoById.Response> {
     return Promise.resolve(GetTodoById.response200({ body: body[0] }));
@@ -52,18 +55,19 @@ const api: Api = {
 test("testGetTodos", async () => {
   const rawRequest: Wirespec.RawRequest = {
     method: "GET",
-    path: ["todos"],
+    path: ["api", "todos"],
     queries: {},
     headers: {},
+    body: undefined,
   };
   const server = GetTodos.server(wirespecSerialization);
   const request = server.from(rawRequest);
   const response = await api.getTodos(request);
   const rawResponse = server.to(response);
-  const expected = {
-    status: 200,
-    headers: { "X-Total": "2" },
-    body: JSON.stringify(body),
+  const expected: Wirespec.RawResponse = {
+    statusCode: 200,
+    headers: { "X-Total": ["2"] },
+    body: encode(body),
   };
 
   expect(rawResponse).toEqual(expected);
@@ -72,35 +76,40 @@ test("testGetTodos", async () => {
 test("testGetTodoById", async () => {
   const rawRequest: Wirespec.RawRequest = {
     method: "GET",
-    path: ["todos", "1"],
+    path: ["api", "todos", "1"],
     queries: {},
     headers: {},
+    body: undefined,
   };
   const server = GetTodoById.server(wirespecSerialization);
   const request = server.from(rawRequest);
   const response = await api.getTodoById(request);
   const rawResponse = server.to(response);
-  const expected = { status: 200, headers: {}, body: JSON.stringify(body[0]) };
+  const expected: Wirespec.RawResponse = {
+    statusCode: 200,
+    headers: {},
+    body: encode(body[0]),
+  };
 
   expect(rawResponse).toEqual(expected);
 });
 
 test("testPostTodo", async () => {
   const rawRequest: Wirespec.RawRequest = {
-    method: "GET",
-    path: ["todos"],
+    method: "POST",
+    path: ["api", "todos"],
     queries: {},
     headers: {},
-    body: JSON.stringify({ name: "Do it later", done: false }),
+    body: encode({ name: "Do it later", done: false }),
   };
   const server = PostTodo.server(wirespecSerialization);
   const request = server.from(rawRequest);
   const response = await api.postTodo(request);
   const rawResponse = server.to(response);
-  const expected = {
-    status: 200,
+  const expected: Wirespec.RawResponse = {
+    statusCode: 200,
     headers: {},
-    body: JSON.stringify({ id: "3", name: "Do it later", done: false }),
+    body: encode({ id: "3", name: "Do it later", done: false }),
   };
 
   expect(rawResponse).toEqual(expected);

--- a/src/plugin/npm/src/jsMain/resources/wirespec-msw.d.ts
+++ b/src/plugin/npm/src/jsMain/resources/wirespec-msw.d.ts
@@ -8,15 +8,15 @@ type Method = 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH' |
 type RawRequest = {
     method: Method
     path: string[]
-    queries: Record<string, string>
-    headers: Record<string, string>
-    body?: string
+    queries: Record<string, string[]>
+    headers: Record<string, string[]>
+    body: Uint8Array | undefined
 }
 
 type RawResponse = {
-    status: number
-    headers: Record<string, string>
-    body?: string
+    statusCode: number
+    headers: Record<string, string[]>
+    body: Uint8Array | undefined
 }
 
 /**

--- a/src/plugin/npm/src/jsMain/resources/wirespec-msw.mjs
+++ b/src/plugin/npm/src/jsMain/resources/wirespec-msw.mjs
@@ -41,10 +41,35 @@ const buildPath = (templatePath, params) =>
         return Array.isArray(value) ? value[0] : value
     })
 
+// The generated `from()` reads queries/headers as `Record<string, string[]>` (it pulls
+// `values[0]` through `deserializeParam`), so collect every value per key into an array.
+const readParams = (entries) => {
+    const params = {}
+    for (const [key, value] of entries) {
+        if (params[key]) params[key].push(value)
+        else params[key] = [value]
+    }
+    return params
+}
+
+// The generated `from()` reads the body as a `Uint8Array` (`deserializeBody` does
+// `TextDecoder().decode(raw)`), so hand it the raw bytes rather than decoded text.
 const readBody = async (request) => {
     if (request.method === 'GET' || request.method === 'HEAD') return undefined
-    const text = await request.text()
-    return text.length > 0 ? text : undefined
+    const buffer = await request.arrayBuffer()
+    return buffer.byteLength > 0 ? new Uint8Array(buffer) : undefined
+}
+
+// The generated `to()` emits headers as `Record<string, string[]>`; flatten them into a
+// `Headers` (each value appended) so they form a valid HeadersInit for MSW's HttpResponse.
+const toHeaders = (rawHeaders) => {
+    const headers = new Headers()
+    for (const [key, values] of Object.entries(rawHeaders ?? {})) {
+        for (const value of Array.isArray(values) ? values : [values]) {
+            headers.append(key, String(value))
+        }
+    }
+    return headers
 }
 
 /**
@@ -68,16 +93,16 @@ export function wirespec(api, resolver, options = {}) {
         const rawRequest = {
             method: request.method,
             path: buildPath(api.path, params),
-            queries: Object.fromEntries(url.searchParams),
-            headers: Object.fromEntries(request.headers),
+            queries: readParams(url.searchParams),
+            headers: readParams(request.headers),
             body: await readBody(request),
         }
         const typedRequest = endpoint.from(rawRequest)
         const response = await resolver(typedRequest)
         const rawResponse = endpoint.to(response)
         return new HttpResponse(rawResponse.body ?? null, {
-            status: rawResponse.status,
-            headers: rawResponse.headers,
+            status: rawResponse.statusCode,
+            headers: toHeaders(rawResponse.headers),
         })
     })
 }


### PR DESCRIPTION
Fixes #657.

## Problem

The `@flock/wirespec/msw` helper (`wirespec(api, resolver, options)`) built/read a `RawRequest`/`RawResponse` in the **legacy** emitter shape, which the IR-emitted `server().from(...)`/`.to(...)` and the bundled `@flock/wirespec/serialization` do not agree with. The result: IR-generated mocks throw on request bodies, truncate multi-character query/header params to their first character, and default **every** response to `200` (so `404`/`409`/`412` mocks are impossible).

## Fix

Align `wirespec-msw.mjs` (and `wirespec-msw.d.ts`) to the IR contract:

| Area | Before | After |
|---|---|---|
| Request `body` | `string` (`request.text()`) | `Uint8Array` (`request.arrayBuffer()`) — `deserializeBody` decodes raw bytes |
| Request `queries`/`headers` | `Record<string,string>` | `Record<string,string[]>` (`deserializeParam` reads `values[0]`) |
| Response status | `rawResponse.status` (→ `undefined` → 200) | `rawResponse.statusCode` |
| Response headers | passed `Record<string,string[]>` straight to `HttpResponse` | flattened into a real `Headers` (valid `HeadersInit`) |

## Verification

The helper can't serve both the legacy and IR contracts at once (request body is `string` vs `Uint8Array`), so the `examples/npm-typescript` integration test is migrated to the IR emitter (`generate --ir`), and its `client`/`server`/`clientSimple`/`clientProxy`/`fetch`/`msw` tests are updated to the IR shapes (client tests use the existing `wirespecFetchIr` variant; IR response header params are camelCased, e.g. `xTotal`).

- `npx tsc` clean
- **34/34 vitest tests pass** — including a `404` mock returning `404`, a POST body deserializing without throwing, and the `X-Total` header flowing through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)