### PR TITLE
fix(ir): pascal-case custom type references to match definitions

### DIFF
--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/GeneratorConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/GeneratorConverter.kt
@@ -46,6 +46,14 @@ internal fun FieldIdentifier.toFieldName(): Name {
     return Name(parts)
 }
 
+// A cross-reference to another definition's `*Generator` object. Its name must
+// match that object's emitted namespace, which every generator renders by
+// pascal-casing the `toGeneratorName()` parts. Mirror that here so a synthetic
+// type like `Foo_bar` resolves to `FooBarGenerator`, not `Foo_barGenerator`.
+internal fun generatorReceiver(typeName: String): RawExpression = RawExpression(
+    Name(Name.of(typeName).parts.filter { part -> part.any(Char::isLetterOrDigit) } + "Generator").pascalCase(),
+)
+
 // List-append: use ListConcat so Java emits `Stream.concat(...)` instead of a
 // bogus `path + "segment"` (which Kotlin accepts but Java evaluates as
 // List.toString() + String).
@@ -268,7 +276,7 @@ private fun shapeConstructor(
         Name.of("generate") to Lambda(
             parameters = lambdaPathParam(depth),
             body = FunctionCall(
-                receiver = RawExpression("${downstreamGeneratorName}Generator"),
+                receiver = generatorReceiver(downstreamGeneratorName),
                 name = Name.of("generate"),
                 arguments = mapOf(
                     Name.of("generator") to VariableReference(Name.of("generator")),
@@ -500,7 +508,7 @@ fun UnionWirespec.convertToGenerator(): File {
                         case(Literal(variantName, Type.String)) {
                             returns(
                                 FunctionCall(
-                                    receiver = RawExpression("${variantName}Generator"),
+                                    receiver = generatorReceiver(variantName),
                                     name = Name.of("generate"),
                                     arguments = mapOf(
                                         Name.of("generator") to VariableReference(Name.of("generator")),

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
@@ -39,6 +39,8 @@ data class Name(val parts: List<String>) {
         }
     }
 
+    fun referenceName(): String = if (parts.size > 1) pascalCase() else value()
+
     override fun toString(): String = camelCase()
 
     companion object {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
@@ -283,7 +283,7 @@ object JavaGenerator : Generator {
         Type.Reflect -> "Type"
         is Type.Array -> "java.util.List"
         is Type.Dict -> "java.util.Map"
-        is Type.Custom -> name.value()
+        is Type.Custom -> name.referenceName()
         is Type.Nullable -> "java.util.Optional<${type.emitGenerics()}>"
         is Type.IntegerLiteral -> "Integer"
         is Type.StringLiteral -> "String"

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
@@ -288,7 +288,7 @@ object KotlinGenerator : Generator {
         Type.Reflect -> "KType"
         is Type.Array -> "List"
         is Type.Dict -> "Map"
-        is Type.Custom -> name.value()
+        is Type.Custom -> name.referenceName()
         is Type.Nullable -> "${type.emitGenerics()}?"
         is Type.IntegerLiteral -> "Int"
         is Type.StringLiteral -> "String"

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
@@ -262,7 +262,7 @@ object PythonGenerator : Generator {
         is Type.Array -> "list[${elementType.emit(qualifier)}]"
         is Type.Dict -> "dict[${keyType.emit(qualifier)}, ${valueType.emit(qualifier)}]"
         is Type.Custom -> {
-            val rawName = name.value()
+            val rawName = name.referenceName()
             val qualifiedName = qualifier?.invoke(rawName) ?: rawName
             if (generics.isEmpty()) {
                 qualifiedName

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
@@ -283,7 +283,7 @@ object RustGenerator : Generator {
         is Type.Array -> "Vec<${elementType.emit()}>"
         is Type.Dict -> "std::collections::HashMap<${keyType.emit()}, ${valueType.emit()}>"
         is Type.Custom -> {
-            val rawName = name.value()
+            val rawName = name.referenceName()
             if (generics.isEmpty()) {
                 rawName
             } else if (generics.any { it == Type.Wildcard || (it is Type.Custom && it.name.value() == "_") }) {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
@@ -374,7 +374,7 @@ object ScalaGenerator : Generator {
         Type.Reflect -> "scala.reflect.ClassTag[?]"
         is Type.Array -> "List"
         is Type.Dict -> "Map"
-        is Type.Custom -> name.value()
+        is Type.Custom -> name.referenceName()
         is Type.Nullable -> "Option[${type.emitGenerics()}]"
         is Type.IntegerLiteral -> "Int"
         is Type.StringLiteral -> "String"
@@ -403,7 +403,7 @@ object ScalaGenerator : Generator {
         is Type.Array -> "List[${elementType.emitTypeAnnotation()}]"
         is Type.Dict -> "Map[${keyType.emitTypeAnnotation()}, ${valueType.emitTypeAnnotation()}]"
         is Type.Custom -> {
-            val rawName = name.value()
+            val rawName = name.referenceName()
             if (generics.isEmpty()) {
                 if (rawName in objectNames) "$rawName.type" else rawName
             } else {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
@@ -460,7 +460,7 @@ object TypeScriptGenerator : Generator {
         }
         is Type.Dict -> "Record<${keyType.emit()}, ${valueType.emit()}>"
         is Type.Custom -> {
-            val rawName = name.value()
+            val rawName = name.referenceName()
             if (generics.isEmpty()) {
                 rawName
             } else {

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/UnderscoreTypeNameGeneratorTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/UnderscoreTypeNameGeneratorTest.kt
@@ -1,0 +1,114 @@
+package community.flock.wirespec.ir.converter
+
+import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.ir.core.Element
+import community.flock.wirespec.ir.generator.Generator
+import community.flock.wirespec.ir.generator.JavaGenerator
+import community.flock.wirespec.ir.generator.KotlinGenerator
+import community.flock.wirespec.ir.generator.PythonGenerator
+import community.flock.wirespec.ir.generator.RustGenerator
+import community.flock.wirespec.ir.generator.ScalaGenerator
+import community.flock.wirespec.ir.generator.TypeScriptGenerator
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import community.flock.wirespec.compiler.core.parse.ast.Type as TypeWirespec
+
+class UnderscoreTypeNameGeneratorTest {
+
+    // Wirespec's `typeIdentifier` token rule (`^\b[A-Z][a-zA-Z0-9_]*\b`) allows
+    // underscores, and OpenAPI HAL specs routinely produce them: a `_embedded`
+    // field on `ProposalNow` becomes a synthetic nested type named
+    // `ProposalNow_embedded`.
+    //
+    // Every emitter renders a type *definition* (struct/class) and its
+    // *Generator* object via `pascalCase()`, which drops the separator —
+    // yielding `ProposalNowEmbedded` / `ProposalNowEmbeddedGenerator`.
+    // So every *reference* must agree, or the generated code names something that
+    // was never declared. This regression guards that invariant across all
+    // language generators (each renders `Type.Custom` via `Name.referenceName()`,
+    // and the shared converter normalises the cross-`*Generator` receiver).
+    private val generators: List<Pair<String, Generator>> = listOf(
+        "Kotlin" to KotlinGenerator,
+        "Java" to JavaGenerator,
+        "Scala" to ScalaGenerator,
+        "Rust" to RustGenerator,
+        "Python" to PythonGenerator,
+        "TypeScript" to TypeScriptGenerator,
+    )
+
+    private fun typeDef(name: String, shape: List<Field>) = TypeWirespec(
+        comment = null,
+        annotations = emptyList(),
+        identifier = DefinitionIdentifier(name),
+        shape = TypeWirespec.Shape(shape),
+        extends = emptyList(),
+    )
+
+    @Test
+    fun underscoreBearingReferencesArePascalCasedInEveryGenerator() {
+        val parent = typeDef(
+            "ProposalNow",
+            listOf(
+                Field(
+                    emptyList(),
+                    FieldIdentifier("_embedded"),
+                    Reference.Custom("ProposalNow_embedded", true),
+                ),
+            ),
+        )
+        val nested = typeDef(
+            "ProposalNow_embedded",
+            listOf(
+                Field(
+                    emptyList(),
+                    FieldIdentifier("name"),
+                    Reference.Primitive(Reference.Primitive.Type.String(null), false),
+                ),
+            ),
+        )
+
+        for ((lang, generator) in generators) {
+            val parentCode = generator.generate(parent.convertToGenerator() as Element)
+            val nestedCode = generator.generate(nested.convertToGenerator() as Element)
+
+            // The pascal-cased name that matches the emitted definitions.
+            assertTrue(
+                parentCode.contains("ProposalNowEmbedded"),
+                "$lang: expected pascal-cased reference, got:\n$parentCode",
+            )
+            // The broken, underscore-preserving forms must never appear — neither
+            // the type reference nor the downstream `*Generator` receiver.
+            assertFalse(
+                parentCode.contains("ProposalNow_embedded"),
+                "$lang: underscore leaked into a reference:\n$parentCode",
+            )
+            assertFalse(
+                nestedCode.contains("ProposalNow_embedded"),
+                "$lang: underscore leaked into the nested generator:\n$nestedCode",
+            )
+        }
+    }
+
+    @Test
+    fun underscoreFieldNameItselfIsPreserved() {
+        // The fix must NOT over-sanitise: the JSON field name `_embedded` keeps
+        // its leading underscore (only the *type* name is normalised).
+        val parent = typeDef(
+            "ProposalNow",
+            listOf(
+                Field(
+                    emptyList(),
+                    FieldIdentifier("_embedded"),
+                    Reference.Custom("ProposalNow_embedded", true),
+                ),
+            ),
+        )
+        val kotlin = KotlinGenerator.generate(parent.convertToGenerator() as Element)
+        assertTrue(kotlin.contains("_embedded = generator.generate"), kotlin)
+        assertTrue(kotlin.contains("listOf(\"_embedded\")"), kotlin)
+    }
+}


### PR DESCRIPTION
## Problem

A bug was reported in the IR test-data **Generator** emitter (Kotlin shown), where generated code referenced types/generators that were never declared:

```kotlin
generate = { p1 -> ProposalNow_embeddedGenerator.generate(generator, p1) },
type = typeOf<ProposalNow_embedded>()
```

…but the actual declarations are `data class ProposalNowEmbedded` / `object ProposalNowEmbeddedGenerator`. The generated code doesn't compile.

## Root cause

Type **definitions** (struct/class/enum) and their `*Generator` objects are emitted via `Name.pascalCase()`, which drops separator parts. **References**, however, used `Name.value()` (raw join) and raw string concatenation. So any type name carrying a separator diverged.

Such names arise legitimately: Wirespec's `typeIdentifier` token rule (`^\b[A-Z][a-zA-Z0-9_]*\b`) allows underscores, and OpenAPI HAL specs produce them — a `_embedded` field on `ProposalNow` becomes a synthetic nested type `ProposalNow_embedded`. The `Ast.kt` doc comment already stated `Type.Custom` names *should* be pascal-cased "the same way struct names are"; the implementation had diverged from its own contract.

## Fix

- **`Name.referenceName()`** — pascal-case multi-part names (structured identifiers, matching definitions) while emitting single-part names verbatim, so raw/builtin escape-hatch types (`i32`, `&str`, `Wirespec.Model`, `_`) are never re-cased. This is why a blanket `pascalCase()` is unsafe.
- Render `Type.Custom` via `referenceName()` in **all six generators** (Java, Kotlin, Python, Rust, Scala, TypeScript).
- Normalise the cross-`*Generator` receiver in the shared `GeneratorConverter` so it matches the pascal-cased namespace definition.

Field names keep their wire form — `_embedded` stays `_embedded`; only **type** names are normalised.

## Tests

`UnderscoreTypeNameGeneratorTest` hardens the invariant across **all six language generators**:
- references never carry the underscore form (covers both the `Type.Custom` reference and the `*Generator` receiver);
- the `_embedded` field name keeps its underscore (no over-sanitization).

Verified the test catches the regression (reverting `referenceName()` to `value()` turns it red). No existing emitter fixtures shifted — none had underscore-bearing type names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)