### PR TITLE
test(verify): add verify tests for emitted test-data Generators

### DIFF
--- a/src/compiler/emitters/python/fixtures/compileComplexModelTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileComplexModelTest.txt
@@ -9,7 +9,7 @@ from ..wirespec import T, Wirespec, _raise
 class Email(Wirespec.Refined[str]):
     value: str
     def validate(self) -> bool:
-        return bool(re.match(r"/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/g", self.value))
+        return bool(re.match(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$", self.value))
     def __str__(self) -> str:
         return self.value
 
@@ -24,7 +24,7 @@ from ..wirespec import T, Wirespec, _raise
 class PhoneNumber(Wirespec.Refined[str]):
     value: str
     def validate(self) -> bool:
-        return bool(re.match(r"/^\+[1-9]\d{1,14}$/g", self.value))
+        return bool(re.match(r"^\+[1-9]\d{1,14}$", self.value))
     def __str__(self) -> str:
         return self.value
 
@@ -39,7 +39,7 @@ from ..wirespec import T, Wirespec, _raise
 class Tag(Wirespec.Refined[str]):
     value: str
     def validate(self) -> bool:
-        return bool(re.match(r"/^[a-z][a-z0-9-]{0,19}$/g", self.value))
+        return bool(re.match(r"^[a-z][a-z0-9-]{0,19}$", self.value))
     def __str__(self) -> str:
         return self.value
 
@@ -72,7 +72,7 @@ class ContactInfo(Wirespec.Shape):
     email: Email
     phone: Optional[PhoneNumber]
     def validate(self) -> list[str]:
-        return (['email'] if not self.email.validate() else []) + (['phone'] if not self.phone.validate() else []) if self.phone is not None else []
+        return (['email'] if not self.email.validate() else []) + ((['phone'] if not self.phone.validate() else []) if self.phone is not None else [])
 
 from __future__ import annotations
 import re

--- a/src/compiler/emitters/python/fixtures/compileFullEndpointTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileFullEndpointTest.txt
@@ -158,17 +158,17 @@ class Response500(Response5XX[Error], ResponseError):
 class PutTodo(Wirespec.Endpoint):
     @staticmethod
     def toRawRequest(serialization: Wirespec.Serializer, request: Request) -> Wirespec.RawRequest:
-        return Wirespec.RawRequest(method=request.method.value, path=['todos', serialization.serializePath(request.path.id, str)], queries={'done': serialization.serializeParam(request.queries.done, bool), 'name': serialization.serializeParam(request.queries.name, str) if request.queries.name is not None else []}, headers={'token': serialization.serializeParam(request.headers.token, Token), 'Refresh-Token': serialization.serializeParam(request.headers.refreshToken, Token) if request.headers.refreshToken is not None else []}, body=serialization.serializeBody(request.body, PotentialTodoDto))
+        return Wirespec.RawRequest(method=request.method.value, path=['todos', serialization.serializePath(request.path.id, str)], queries={'done': serialization.serializeParam(request.queries.done, bool), 'name': (serialization.serializeParam(request.queries.name, str) if request.queries.name is not None else [])}, headers={'token': serialization.serializeParam(request.headers.token, Token), 'Refresh-Token': (serialization.serializeParam(request.headers.refreshToken, Token) if request.headers.refreshToken is not None else [])}, body=serialization.serializeBody(request.body, PotentialTodoDto))
     @staticmethod
     def fromRawRequest(serialization: Wirespec.Deserializer, request: Wirespec.RawRequest) -> Request:
-        return Request(id=serialization.deserializePath(request.path[1], str), done=serialization.deserializeParam(request.queries['done'], bool) if request.queries['done'] is not None else _raise('Param done cannot be null'), name=serialization.deserializeParam(request.queries['name'], str) if request.queries['name'] is not None else None, token=serialization.deserializeParam(next((v for k, v in request.headers.items() if k.lower() == 'token'.lower()), None), Token) if next((v for k, v in request.headers.items() if k.lower() == 'token'.lower()), None) is not None else _raise('Param token cannot be null'), refreshToken=serialization.deserializeParam(next((v for k, v in request.headers.items() if k.lower() == 'Refresh-Token'.lower()), None), Token) if next((v for k, v in request.headers.items() if k.lower() == 'Refresh-Token'.lower()), None) is not None else None, body=serialization.deserializeBody(request.body, PotentialTodoDto) if request.body is not None else _raise('body is null'))
+        return Request(id=serialization.deserializePath(request.path[1], str), done=(serialization.deserializeParam(request.queries['done'], bool) if request.queries['done'] is not None else _raise('Param done cannot be null')), name=(serialization.deserializeParam(request.queries['name'], str) if request.queries['name'] is not None else None), token=(serialization.deserializeParam(next((v for k, v in request.headers.items() if k.lower() == 'token'.lower()), None), Token) if next((v for k, v in request.headers.items() if k.lower() == 'token'.lower()), None) is not None else _raise('Param token cannot be null')), refreshToken=(serialization.deserializeParam(next((v for k, v in request.headers.items() if k.lower() == 'Refresh-Token'.lower()), None), Token) if next((v for k, v in request.headers.items() if k.lower() == 'Refresh-Token'.lower()), None) is not None else None), body=(serialization.deserializeBody(request.body, PotentialTodoDto) if request.body is not None else _raise('body is null')))
     @staticmethod
     def toRawResponse(serialization: Wirespec.Serializer, response: Response[Any]) -> Wirespec.RawResponse:
         match response:
             case Response200() as r:
                 return Wirespec.RawResponse(statusCode=r.status, headers={}, body=serialization.serializeBody(r.body, TodoDto))
             case Response201() as r:
-                return Wirespec.RawResponse(statusCode=r.status, headers={'token': serialization.serializeParam(r.headers.token, Token), 'refreshToken': serialization.serializeParam(r.headers.refreshToken, Token) if r.headers.refreshToken is not None else []}, body=serialization.serializeBody(r.body, TodoDto))
+                return Wirespec.RawResponse(statusCode=r.status, headers={'token': serialization.serializeParam(r.headers.token, Token), 'refreshToken': (serialization.serializeParam(r.headers.refreshToken, Token) if r.headers.refreshToken is not None else [])}, body=serialization.serializeBody(r.body, TodoDto))
             case Response500() as r:
                 return Wirespec.RawResponse(statusCode=r.status, headers={}, body=serialization.serializeBody(r.body, Error))
             case _:
@@ -177,11 +177,11 @@ class PutTodo(Wirespec.Endpoint):
     def fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> Response[Any]:
         match response.statusCode:
             case 200:
-                return Response200(body=serialization.deserializeBody(response.body, TodoDto) if response.body is not None else _raise('body is null'))
+                return Response200(body=(serialization.deserializeBody(response.body, TodoDto) if response.body is not None else _raise('body is null')))
             case 201:
-                return Response201(token=serialization.deserializeParam(next((v for k, v in response.headers.items() if k.lower() == 'token'.lower()), None), Token) if next((v for k, v in response.headers.items() if k.lower() == 'token'.lower()), None) is not None else _raise('Param token cannot be null'), refreshToken=serialization.deserializeParam(next((v for k, v in response.headers.items() if k.lower() == 'refreshToken'.lower()), None), Token) if next((v for k, v in response.headers.items() if k.lower() == 'refreshToken'.lower()), None) is not None else None, body=serialization.deserializeBody(response.body, TodoDto) if response.body is not None else _raise('body is null'))
+                return Response201(token=(serialization.deserializeParam(next((v for k, v in response.headers.items() if k.lower() == 'token'.lower()), None), Token) if next((v for k, v in response.headers.items() if k.lower() == 'token'.lower()), None) is not None else _raise('Param token cannot be null')), refreshToken=(serialization.deserializeParam(next((v for k, v in response.headers.items() if k.lower() == 'refreshToken'.lower()), None), Token) if next((v for k, v in response.headers.items() if k.lower() == 'refreshToken'.lower()), None) is not None else None), body=(serialization.deserializeBody(response.body, TodoDto) if response.body is not None else _raise('body is null')))
             case 500:
-                return Response500(body=serialization.deserializeBody(response.body, Error) if response.body is not None else _raise('body is null'))
+                return Response500(body=(serialization.deserializeBody(response.body, Error) if response.body is not None else _raise('body is null')))
             case _:
                 raise Exception(('Cannot match response with status: ' + str(response.statusCode)))
     class Handler(Wirespec.Handler, ABC):

--- a/src/compiler/emitters/python/fixtures/compileMinimalEndpointTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileMinimalEndpointTest.txt
@@ -80,7 +80,7 @@ class GetTodos(Wirespec.Endpoint):
     def fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> Response[Any]:
         match response.statusCode:
             case 200:
-                return Response200(body=serialization.deserializeBody(response.body, list[TodoDto]) if response.body is not None else _raise('body is null'))
+                return Response200(body=(serialization.deserializeBody(response.body, list[TodoDto]) if response.body is not None else _raise('body is null')))
             case _:
                 raise Exception(('Cannot match response with status: ' + str(response.statusCode)))
     class Handler(Wirespec.Handler, ABC):

--- a/src/compiler/emitters/python/fixtures/compileNestedTypeTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileNestedTypeTest.txt
@@ -9,7 +9,7 @@ from ..wirespec import T, Wirespec, _raise
 class DutchPostalCode(Wirespec.Refined[str]):
     value: str
     def validate(self) -> bool:
-        return bool(re.match(r"/^([0-9]{4}[A-Z]{2})$/g", self.value))
+        return bool(re.match(r"^([0-9]{4}[A-Z]{2})$", self.value))
     def __str__(self) -> str:
         return self.value
 

--- a/src/compiler/emitters/python/fixtures/compileRefinedTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileRefinedTest.txt
@@ -9,7 +9,7 @@ from ..wirespec import T, Wirespec, _raise
 class TodoId(Wirespec.Refined[str]):
     value: str
     def validate(self) -> bool:
-        return bool(re.match(r"/^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/g", self.value))
+        return bool(re.match(r"^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$", self.value))
     def __str__(self) -> str:
         return self.value
 

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
@@ -421,17 +421,17 @@ object PythonGenerator : Generator {
             val exprStr = expression.emit()
             val bodyStr = body.emitWithInlinedIt(exprStr)
             val altStr = alternative?.emit() ?: "None"
-            "$bodyStr if $exprStr is not None else $altStr"
+            "($bodyStr if $exprStr is not None else $altStr)"
         }
         is NullableMap -> {
             val exprStr = expression.emit()
             val bodyStr = body.emitWithInlinedIt(exprStr)
             val altStr = alternative.emit()
-            "$bodyStr if $exprStr is not None else $altStr"
+            "($bodyStr if $exprStr is not None else $altStr)"
         }
         is NullableOf -> expression.emit()
         is NullableGet -> expression.emit()
-        is Constraint.RegexMatch -> "bool(re.match(r\"${rawValue}\", ${value.emit()}))"
+        is Constraint.RegexMatch -> "bool(re.match(r\"${pattern}\", ${value.emit()}))"
         is Constraint.BoundCheck -> {
             val checks = listOfNotNull(
                 min?.let { "$it <= ${value.emit()}" },

--- a/src/verify/src/main/kotlin/community/flock/wirespec/verify/VerifyGenerator.kt
+++ b/src/verify/src/main/kotlin/community/flock/wirespec/verify/VerifyGenerator.kt
@@ -7,6 +7,9 @@ import community.flock.wirespec.emitters.scala.ScalaIrEmitter
 import community.flock.wirespec.emitters.typescript.TypeScriptIrEmitter
 import community.flock.wirespec.ir.core.ContainerBuilder
 
+private const val WIRESPEC = "Wirespec"
+private const val GENERATOR_PACKAGE = "community.flock.wirespec.generated.generator"
+
 /**
  * Imports for a test file that exercises the emitted test-data Generators.
  * Pulls in the shared Wirespec runtime plus a `<name>Generator` per given definition name.
@@ -14,24 +17,24 @@ import community.flock.wirespec.ir.core.ContainerBuilder
 internal fun ContainerBuilder.generatorImports(lang: Language, definitionNames: List<String>) {
     when (lang.emitter) {
         is JavaIrEmitter -> {
-            import("community.flock.wirespec.java", "Wirespec")
-            definitionNames.forEach { import("community.flock.wirespec.generated.generator", "${it}Generator") }
+            import("community.flock.wirespec.java", WIRESPEC)
+            definitionNames.forEach { import(GENERATOR_PACKAGE, "${it}Generator") }
         }
         is KotlinIrEmitter -> {
-            import("community.flock.wirespec.kotlin", "Wirespec")
-            definitionNames.forEach { import("community.flock.wirespec.generated.generator", "${it}Generator") }
+            import("community.flock.wirespec.kotlin", WIRESPEC)
+            definitionNames.forEach { import(GENERATOR_PACKAGE, "${it}Generator") }
         }
         is ScalaIrEmitter -> {
-            import("community.flock.wirespec.scala", "Wirespec")
-            definitionNames.forEach { import("community.flock.wirespec.generated.generator", "${it}Generator") }
+            import("community.flock.wirespec.scala", WIRESPEC)
+            definitionNames.forEach { import(GENERATOR_PACKAGE, "${it}Generator") }
         }
         is TypeScriptIrEmitter -> {
-            import("./Wirespec", "Wirespec")
+            import("./Wirespec", WIRESPEC)
             definitionNames.forEach { import("./generator/${it}Generator", "${it}Generator") }
         }
         is PythonIrEmitter -> {
-            import("community.flock.wirespec.generated.wirespec", "Wirespec")
-            definitionNames.forEach { import("community.flock.wirespec.generated.generator.${it}Generator", "${it}Generator") }
+            import("community.flock.wirespec.generated.wirespec", WIRESPEC)
+            definitionNames.forEach { import("$GENERATOR_PACKAGE.${it}Generator", "${it}Generator") }
         }
         else -> error("Generators are not verified for: ${lang.emitter::class.simpleName}")
     }

--- a/src/verify/src/main/kotlin/community/flock/wirespec/verify/VerifyGenerator.kt
+++ b/src/verify/src/main/kotlin/community/flock/wirespec/verify/VerifyGenerator.kt
@@ -1,0 +1,169 @@
+package community.flock.wirespec.verify
+
+import community.flock.wirespec.emitters.java.JavaIrEmitter
+import community.flock.wirespec.emitters.kotlin.KotlinIrEmitter
+import community.flock.wirespec.emitters.python.PythonIrEmitter
+import community.flock.wirespec.emitters.scala.ScalaIrEmitter
+import community.flock.wirespec.emitters.typescript.TypeScriptIrEmitter
+import community.flock.wirespec.ir.core.ContainerBuilder
+
+/**
+ * Imports for a test file that exercises the emitted test-data Generators.
+ * Pulls in the shared Wirespec runtime plus a `<name>Generator` per given definition name.
+ */
+internal fun ContainerBuilder.generatorImports(lang: Language, definitionNames: List<String>) {
+    when (lang.emitter) {
+        is JavaIrEmitter -> {
+            import("community.flock.wirespec.java", "Wirespec")
+            definitionNames.forEach { import("community.flock.wirespec.generated.generator", "${it}Generator") }
+        }
+        is KotlinIrEmitter -> {
+            import("community.flock.wirespec.kotlin", "Wirespec")
+            definitionNames.forEach { import("community.flock.wirespec.generated.generator", "${it}Generator") }
+        }
+        is ScalaIrEmitter -> {
+            import("community.flock.wirespec.scala", "Wirespec")
+            definitionNames.forEach { import("community.flock.wirespec.generated.generator", "${it}Generator") }
+        }
+        is TypeScriptIrEmitter -> {
+            import("./Wirespec", "Wirespec")
+            definitionNames.forEach { import("./generator/${it}Generator", "${it}Generator") }
+        }
+        is PythonIrEmitter -> {
+            import("community.flock.wirespec.generated.wirespec", "Wirespec")
+            definitionNames.forEach { import("community.flock.wirespec.generated.generator.${it}Generator", "${it}Generator") }
+        }
+        else -> error("Generators are not verified for: ${lang.emitter::class.simpleName}")
+    }
+}
+
+/**
+ * A deterministic `Wirespec.Generator` implementation per language, bound to a `generator`
+ * variable. Primitive fields get fixed values so tests can assert on the generated data:
+ * strings are "string" ("1234AB" when a regex constraint is present, matching the
+ * DutchPostalCode fixture), integers 42, numbers 4.2, booleans true. Composite fields
+ * (shape, array, nullable, dict) recurse via the field's own generate callback.
+ */
+internal fun generatorCode(lang: Language): String = when (lang.emitter) {
+    is JavaIrEmitter -> """
+        |static Wirespec.Generator generator = new Wirespec.Generator() {
+        |    @SuppressWarnings("unchecked")
+        |    @Override
+        |    public <T> T generate(java.util.List<String> path, Wirespec.GeneratorField<T> field) {
+        |        if (field instanceof Wirespec.GeneratorFieldString f) return (T) (f.regex().isPresent() ? "1234AB" : "string");
+        |        if (field instanceof Wirespec.GeneratorFieldInteger64 f) return (T) Long.valueOf(42L);
+        |        if (field instanceof Wirespec.GeneratorFieldInteger32 f) return (T) Integer.valueOf(42);
+        |        if (field instanceof Wirespec.GeneratorFieldNumber64 f) return (T) Double.valueOf(4.2);
+        |        if (field instanceof Wirespec.GeneratorFieldNumber32 f) return (T) Float.valueOf(4.2f);
+        |        if (field instanceof Wirespec.GeneratorFieldBoolean f) return (T) Boolean.TRUE;
+        |        if (field instanceof Wirespec.GeneratorFieldBytes f) return (T) new byte[0];
+        |        if (field instanceof Wirespec.GeneratorFieldEnum f) return (T) f.values().get(0);
+        |        if (field instanceof Wirespec.GeneratorFieldUnion f) return (T) f.variants().get(0);
+        |        if (field instanceof Wirespec.GeneratorFieldArray<?> f) return (T) java.util.List.of(f.generate().apply(append(path, "0")));
+        |        if (field instanceof Wirespec.GeneratorFieldNullable<?> f) return (T) java.util.Optional.of(f.generate().apply(path));
+        |        if (field instanceof Wirespec.GeneratorFieldShape<?> f) return (T) f.generate().apply(path);
+        |        if (field instanceof Wirespec.GeneratorFieldDict<?> f) return (T) java.util.Map.of("key", f.generate().apply(append(path, "key")));
+        |        throw new IllegalStateException("Unknown generator field: " + field);
+        |    }
+        |    private java.util.List<String> append(java.util.List<String> path, String segment) {
+        |        return java.util.stream.Stream.concat(path.stream(), java.util.stream.Stream.of(segment)).toList();
+        |    }
+        |};
+    """.trimMargin()
+
+    is KotlinIrEmitter -> """
+        |@Suppress("UNCHECKED_CAST")
+        |val generator = object : Wirespec.Generator {
+        |    override fun <T> generate(path: List<String>, field: Wirespec.GeneratorField<T>): T = when (field) {
+        |        is Wirespec.GeneratorFieldString -> if (field.regex != null) "1234AB" else "string"
+        |        is Wirespec.GeneratorFieldInteger64 -> 42L
+        |        is Wirespec.GeneratorFieldInteger32 -> 42
+        |        is Wirespec.GeneratorFieldNumber64 -> 4.2
+        |        is Wirespec.GeneratorFieldNumber32 -> 4.2f
+        |        is Wirespec.GeneratorFieldBoolean -> true
+        |        is Wirespec.GeneratorFieldBytes -> ByteArray(0)
+        |        is Wirespec.GeneratorFieldEnum -> field.values.first()
+        |        is Wirespec.GeneratorFieldUnion -> field.variants.first()
+        |        is Wirespec.GeneratorFieldArray<*> -> listOf(field.generate(path + "0"))
+        |        is Wirespec.GeneratorFieldNullable<*> -> field.generate(path)
+        |        is Wirespec.GeneratorFieldShape<*> -> field.generate(path)
+        |        is Wirespec.GeneratorFieldDict<*> -> mapOf("key" to field.generate(path + "key"))
+        |    } as T
+        |}
+    """.trimMargin()
+
+    is TypeScriptIrEmitter -> """
+        |const generator: Wirespec.Generator = {
+        |    generate: <T>(path: string[], field: Wirespec.GeneratorField<T>): T => {
+        |        const f = field as any;
+        |        switch (f.kind) {
+        |            case "string": return (f.regex !== undefined ? "1234AB" : "string") as unknown as T;
+        |            case "integer64": return 42 as unknown as T;
+        |            case "integer32": return 42 as unknown as T;
+        |            case "number64": return 4.2 as unknown as T;
+        |            case "number32": return 4.2 as unknown as T;
+        |            case "boolean": return true as unknown as T;
+        |            case "bytes": return new ArrayBuffer(0) as unknown as T;
+        |            case "enum": return f.values[0] as unknown as T;
+        |            case "union": return f.variants[0] as unknown as T;
+        |            case "array": return [f.generate([...path, "0"])] as unknown as T;
+        |            case "nullable": return f.generate(path) as unknown as T;
+        |            case "shape": return f.generate(path) as unknown as T;
+        |            case "dict": return { key: f.generate([...path, "key"]) } as unknown as T;
+        |        }
+        |        throw new Error("Unknown generator field: " + f.kind);
+        |    }
+        |};
+    """.trimMargin()
+
+    is PythonIrEmitter -> """
+        |class TestGenerator(Wirespec.Generator):
+        |    def generate(self, path, field):
+        |        if isinstance(field, Wirespec.GeneratorFieldString):
+        |            return "1234AB" if field.regex is not None else "string"
+        |        if isinstance(field, (Wirespec.GeneratorFieldInteger64, Wirespec.GeneratorFieldInteger32)):
+        |            return 42
+        |        if isinstance(field, (Wirespec.GeneratorFieldNumber64, Wirespec.GeneratorFieldNumber32)):
+        |            return 4.2
+        |        if isinstance(field, Wirespec.GeneratorFieldBoolean):
+        |            return True
+        |        if isinstance(field, Wirespec.GeneratorFieldBytes):
+        |            return b""
+        |        if isinstance(field, Wirespec.GeneratorFieldEnum):
+        |            return field.values[0]
+        |        if isinstance(field, Wirespec.GeneratorFieldUnion):
+        |            return field.variants[0]
+        |        if isinstance(field, Wirespec.GeneratorFieldArray):
+        |            return [field.generate(path + ["0"])]
+        |        if isinstance(field, Wirespec.GeneratorFieldNullable):
+        |            return field.generate(path)
+        |        if isinstance(field, Wirespec.GeneratorFieldShape):
+        |            return field.generate(path)
+        |        if isinstance(field, Wirespec.GeneratorFieldDict):
+        |            return {"key": field.generate(path + ["key"])}
+        |        raise Exception("Unknown generator field")
+        |generator = TestGenerator()
+    """.trimMargin()
+
+    is ScalaIrEmitter -> """
+        |val generator: Wirespec.Generator = new Wirespec.Generator {
+        |    def generate[T](path: List[String], field: Wirespec.GeneratorField[T]): T = (field match {
+        |        case f: Wirespec.GeneratorFieldString => if (f.regex.isDefined) "1234AB" else "string"
+        |        case f: Wirespec.GeneratorFieldInteger64 => 42L
+        |        case f: Wirespec.GeneratorFieldInteger32 => 42
+        |        case f: Wirespec.GeneratorFieldNumber64 => 4.2d
+        |        case f: Wirespec.GeneratorFieldNumber32 => 4.2f
+        |        case f: Wirespec.GeneratorFieldBoolean => true
+        |        case f: Wirespec.GeneratorFieldBytes => Array.empty[Byte]
+        |        case f: Wirespec.GeneratorFieldEnum => f.values.head
+        |        case f: Wirespec.GeneratorFieldUnion => f.variants.head
+        |        case f: Wirespec.GeneratorFieldArray[?] => List(f.generate(path :+ "0"))
+        |        case f: Wirespec.GeneratorFieldNullable[?] => Option(f.generate(path))
+        |        case f: Wirespec.GeneratorFieldShape[?] => f.generate(path)
+        |        case f: Wirespec.GeneratorFieldDict[?] => Map("key" -> f.generate(path :+ "key"))
+        |    }).asInstanceOf[T]
+        |}
+    """.trimMargin()
+
+    else -> error("Unknown emitter: ${lang.emitter::class.simpleName}")
+}

--- a/src/verify/src/main/kotlin/community/flock/wirespec/verify/VerifyUtil.kt
+++ b/src/verify/src/main/kotlin/community/flock/wirespec/verify/VerifyUtil.kt
@@ -166,7 +166,7 @@ class Language(
         val runCommand: String = when (emitter) {
             is JavaIrEmitter -> "java -ea -cp /tmp/out $fileName"
             is KotlinIrEmitter -> "java -ea -cp /tmp/run.jar ${fileName}Kt"
-            is PythonIrEmitter -> "cd /app/gen && python -O ${fileName}.py"
+            is PythonIrEmitter -> "cd /app/gen && python ${fileName}.py"
             is RustIrEmitter -> {
                 // Build use statements from the test file's imports
                 val imports = resolved.elements.filterIsInstance<Import>()

--- a/src/verify/src/test/kotlin/community/flock/wirespec/verify/VerifyGeneratorTest.kt
+++ b/src/verify/src/test/kotlin/community/flock/wirespec/verify/VerifyGeneratorTest.kt
@@ -1,0 +1,77 @@
+package community.flock.wirespec.verify
+
+import community.flock.wirespec.compiler.test.CompileNestedTypeTest
+import community.flock.wirespec.emitters.rust.RustIrEmitter
+import community.flock.wirespec.emitters.typescript.TypeScriptIrEmitter
+import community.flock.wirespec.ir.core.ArrayIndexCall
+import community.flock.wirespec.ir.core.BinaryOp
+import community.flock.wirespec.ir.core.FieldCall
+import community.flock.wirespec.ir.core.Literal
+import community.flock.wirespec.ir.core.Name
+import community.flock.wirespec.ir.core.Precision
+import community.flock.wirespec.ir.core.RawExpression
+import community.flock.wirespec.ir.core.Type
+import community.flock.wirespec.ir.core.VariableReference
+import community.flock.wirespec.ir.core.file
+import io.kotest.core.spec.style.FunSpec
+
+class VerifyGeneratorTest : FunSpec({
+
+    // Rust is excluded: the Rust emitter's generator output is not wired into the generated
+    // module tree (lib.rs lacks `pub mod generator`) and does not compile yet.
+    languages.values.filterNot { it.emitter is RustIrEmitter }.forEach { lang ->
+        test("generated test data - $lang") {
+            val isTypeScript = lang.emitter is TypeScriptIrEmitter
+
+            val testFile = file("GeneratorDataTest") {
+                generatorImports(lang, listOf("Person"))
+
+                main(statics = { raw(generatorCode(lang)) }) {
+                    assign("person", functionCall("generate", receiver = RawExpression("PersonGenerator")) {
+                        arg("generator", VariableReference("generator"))
+                        arg("path", emptyList(string))
+                    })
+                    assign("address", FieldCall(VariableReference("person"), Name.of("address")))
+
+                    assertThat(
+                        BinaryOp(
+                            FieldCall(VariableReference("person"), Name.of("name")),
+                            BinaryOp.Operator.EQUALS,
+                            Literal("string", Type.String),
+                        ),
+                        "Person name should be the deterministic string",
+                    )
+                    assertThat(
+                        BinaryOp(
+                            FieldCall(VariableReference("address"), Name.of("houseNumber")),
+                            BinaryOp.Operator.EQUALS,
+                            Literal(42L, Type.Integer(Precision.P64)),
+                        ),
+                        "House number should be the deterministic integer",
+                    )
+                    // TypeScript inlines refined types to their primitive, so there is no .value wrapper
+                    val postalCode = FieldCall(VariableReference("address"), Name.of("postalCode"))
+                    val postalValue = if (isTypeScript) postalCode else FieldCall(postalCode, Name.of("value"))
+                    assertThat(
+                        BinaryOp(postalValue, BinaryOp.Operator.EQUALS, Literal("1234AB", Type.String)),
+                        "Postal code should satisfy the refined regex",
+                    )
+                    assertThat(
+                        BinaryOp(
+                            ArrayIndexCall(
+                                FieldCall(VariableReference("person"), Name.of("tags")),
+                                Literal(0, Type.Integer()),
+                            ),
+                            BinaryOp.Operator.EQUALS,
+                            Literal("string", Type.String),
+                        ),
+                        "Tags should contain the deterministic string",
+                    )
+                }
+            }
+
+            lang.start(name = "generator-test", fixture = CompileNestedTypeTest)
+            lang.run(testFile)
+        }
+    }
+})


### PR DESCRIPTION
Add VerifyGeneratorTest which compiles the nested-type fixture and runs a
deterministic Wirespec.Generator implementation against the emitted
PersonGenerator in Java, Kotlin, Python, TypeScript and Scala, asserting the
generated data (plain string, regex-refined string, integer, nested shape,
array element). Rust is excluded for now: its generator output is not wired
into the generated module tree and does not compile yet.

Run Python verify programs without -O: the flag stripped all assert
statements, so Python assertions never ran. Enabling them exposed two
Python emitter bugs, fixed here:

- refined regex validation embedded the raw /.../g literal in re.match,
  so no refined value ever validated; use the delimiter-stripped pattern
- nullable conditional expressions were emitted without parentheses,
  so `a + b if x is not None else []` dropped earlier validation errors
  whenever the nullable field was absent

Python fixtures regenerated accordingly.

https://claude.ai/code/session_01KKeN4SRoJV9ErVUQvmtKiV