### PR TITLE
refactor(plugins): rename irExtensions parameter to extensions

### DIFF
--- a/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
+++ b/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
@@ -53,7 +53,7 @@ abstract class BaseWirespecTask : DefaultTask() {
 
     @get:Input
     @get:Optional
-    @get:Option(option = "extensions", description = "IR extension classes applied when an emitter is an IrEmitter")
+    @get:Option(option = "extensionClasses", description = "IR extension classes applied when an emitter is an IrEmitter")
     abstract val extensionClasses: ListProperty<Class<*>>
 
     @get:Input

--- a/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
+++ b/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
@@ -54,7 +54,7 @@ abstract class BaseWirespecTask : DefaultTask() {
     @get:Input
     @get:Optional
     @get:Option(option = "extensions", description = "IR extension classes applied when an emitter is an IrEmitter")
-    abstract val extensions: ListProperty<Class<*>>
+    abstract val extensionClasses: ListProperty<Class<*>>
 
     @get:Input
     @get:Optional
@@ -100,7 +100,7 @@ abstract class BaseWirespecTask : DefaultTask() {
         throw e
     }
 
-    protected fun extensionInstances() = extensions.getOrElse(emptyList()).map { extensionClass ->
+    protected fun extensionInstances() = extensionClasses.getOrElse(emptyList()).map { extensionClass ->
         try {
             val constructor = extensionClass.declaredConstructors.first()
             val args: List<Any> = constructor.parameters

--- a/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
+++ b/src/plugin/gradle/src/main/kotlin/BaseWirespecTask.kt
@@ -53,8 +53,8 @@ abstract class BaseWirespecTask : DefaultTask() {
 
     @get:Input
     @get:Optional
-    @get:Option(option = "irExtensions", description = "IR extension classes applied when an emitter is an IrEmitter")
-    abstract val irExtensions: ListProperty<Class<*>>
+    @get:Option(option = "extensions", description = "IR extension classes applied when an emitter is an IrEmitter")
+    abstract val extensions: ListProperty<Class<*>>
 
     @get:Input
     @get:Optional
@@ -100,7 +100,7 @@ abstract class BaseWirespecTask : DefaultTask() {
         throw e
     }
 
-    protected fun extensionInstances() = irExtensions.getOrElse(emptyList()).map { extensionClass ->
+    protected fun extensionInstances() = extensions.getOrElse(emptyList()).map { extensionClass ->
         try {
             val constructor = extensionClass.declaredConstructors.first()
             val args: List<Any> = constructor.parameters

--- a/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/BaseMojo.kt
+++ b/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/BaseMojo.kt
@@ -67,7 +67,7 @@ abstract class BaseMojo : AbstractMojo() {
      * Specifies IR extension classes to apply when an emitter is an [IrEmitter].
      */
     @Parameter
-    protected var irExtensions: List<String> = listOf()
+    protected var extensions: List<String> = listOf()
 
     /**
      * Specifies package name, default [DEFAULT_GENERATED_PACKAGE_STRING]
@@ -121,8 +121,8 @@ abstract class BaseMojo : AbstractMojo() {
             null
         }
 
-    private val irExtensionInstances
-        get() = irExtensions.map { extensionClass ->
+    private val extensionInstances
+        get() = extensions.map { extensionClass ->
             try {
                 val clazz = getClassLoader(project).loadClass(extensionClass)
                 val constructor = clazz.constructors.first()
@@ -142,7 +142,7 @@ abstract class BaseMojo : AbstractMojo() {
         }
 
     val emitters
-        get() = irExtensionInstances.let { instances ->
+        get() = extensionInstances.let { instances ->
             languages
                 .map { if (ir) it.toIrEmitter(PackageName(packageName), EmitShared(shared)) else it.toEmitter(PackageName(packageName), EmitShared(shared)) }
                 .plus(emitter)

--- a/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/BaseMojo.kt
+++ b/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/BaseMojo.kt
@@ -67,7 +67,7 @@ abstract class BaseMojo : AbstractMojo() {
      * Specifies IR extension classes to apply when an emitter is an [IrEmitter].
      */
     @Parameter
-    protected var extensions: List<String> = listOf()
+    protected var extensionClasses: List<String> = listOf()
 
     /**
      * Specifies package name, default [DEFAULT_GENERATED_PACKAGE_STRING]
@@ -122,7 +122,7 @@ abstract class BaseMojo : AbstractMojo() {
         }
 
     private val extensionInstances
-        get() = extensions.map { extensionClass ->
+        get() = extensionClasses.map { extensionClass ->
             try {
                 val clazz = getClassLoader(project).loadClass(extensionClass)
                 val constructor = clazz.constructors.first()

--- a/src/site/docs/docs/plugins/plugins-gradle.md
+++ b/src/site/docs/docs/plugins/plugins-gradle.md
@@ -94,8 +94,8 @@ This task compiles Wirespec definitions to various target languages.
 - `languages`: ListProperty&lt;Language&gt; - List of target languages (Java, Kotlin, TypeScript, Python, Wirespec, OpenAPIV2, OpenAPIV3)
 - `packageName`: Property&lt;String&gt; - Package name for generated code
 - `emitterClass`: Property&lt;Class&lt;\*&gt;&gt; - Custom emitter class
-- `irExtensions`: ListProperty&lt;Class&lt;\*&gt;&gt; - `IrExtension` classes applied to the intermediate representation before code generation when an emitter is an `IrEmitter`
-- `ir`: Property&lt;Boolean&gt; - Emit through the intermediate representation. Required for `irExtensions` to take effect on the built-in language targets (default: false)
+- `extensions`: ListProperty&lt;Class&lt;\*&gt;&gt; - `IrExtension` classes applied to the intermediate representation before code generation when an emitter is an `IrEmitter`
+- `ir`: Property&lt;Boolean&gt; - Emit through the intermediate representation. Required for `extensions` to take effect on the built-in language targets (default: false)
 - `shared`: Property&lt;Boolean&gt; - Whether to emit shared code (default: true)
 - `strict`: Property&lt;Boolean&gt; - Strict parsing mode (default: false)
 
@@ -111,13 +111,13 @@ This task converts from JSON or Avro to other formats.
 - `preProcessor`: Property&lt;(String) -> String&gt; - Function to preprocess the input content before conversion
 - `packageName`: Property&lt;String&gt; - Package name for generated code
 - `emitterClass`: Property&lt;Class&lt;\*&gt;&gt; - Custom emitter class
-- `irExtensions`: ListProperty&lt;Class&lt;\*&gt;&gt; - `IrExtension` classes applied to the intermediate representation before code generation when an emitter is an `IrEmitter`
+- `extensions`: ListProperty&lt;Class&lt;\*&gt;&gt; - `IrExtension` classes applied to the intermediate representation before code generation when an emitter is an `IrEmitter`
 - `shared`: Property&lt;Boolean&gt; - Whether to emit shared code (default: true)
 - `strict`: Property&lt;Boolean&gt; - Strict parsing mode (default: false)
 
 ## Applying IR extensions
 
-[IR extensions](./plugins.md#ir-extensions) are registered with the `irExtensions` property. Put the
+[IR extensions](./plugins.md#ir-extensions) are registered with the `extensions` property. Put the
 integration artifact that provides the extension on the `buildscript` classpath, then reference the class
 directly. Remember to set `ir = true` so the built-in language targets emit through the IR pipeline:
 
@@ -139,6 +139,6 @@ tasks.register<CompileWirespecTask>("wirespec-compile") {
     languages = listOf(Language.Kotlin)
     ir = true
     shared = false
-    irExtensions = listOf(KotlinxSerializationExtension::class.java)
+    extensions = listOf(KotlinxSerializationExtension::class.java)
 }
 ```

--- a/src/site/docs/docs/plugins/plugins-gradle.md
+++ b/src/site/docs/docs/plugins/plugins-gradle.md
@@ -94,8 +94,8 @@ This task compiles Wirespec definitions to various target languages.
 - `languages`: ListProperty&lt;Language&gt; - List of target languages (Java, Kotlin, TypeScript, Python, Wirespec, OpenAPIV2, OpenAPIV3)
 - `packageName`: Property&lt;String&gt; - Package name for generated code
 - `emitterClass`: Property&lt;Class&lt;\*&gt;&gt; - Custom emitter class
-- `extensions`: ListProperty&lt;Class&lt;\*&gt;&gt; - `IrExtension` classes applied to the intermediate representation before code generation when an emitter is an `IrEmitter`
-- `ir`: Property&lt;Boolean&gt; - Emit through the intermediate representation. Required for `extensions` to take effect on the built-in language targets (default: false)
+- `extensionClasses`: ListProperty&lt;Class&lt;\*&gt;&gt; - `IrExtension` classes applied to the intermediate representation before code generation when an emitter is an `IrEmitter`
+- `ir`: Property&lt;Boolean&gt; - Emit through the intermediate representation. Required for `extensionClasses` to take effect on the built-in language targets (default: false)
 - `shared`: Property&lt;Boolean&gt; - Whether to emit shared code (default: true)
 - `strict`: Property&lt;Boolean&gt; - Strict parsing mode (default: false)
 
@@ -111,13 +111,13 @@ This task converts from JSON or Avro to other formats.
 - `preProcessor`: Property&lt;(String) -> String&gt; - Function to preprocess the input content before conversion
 - `packageName`: Property&lt;String&gt; - Package name for generated code
 - `emitterClass`: Property&lt;Class&lt;\*&gt;&gt; - Custom emitter class
-- `extensions`: ListProperty&lt;Class&lt;\*&gt;&gt; - `IrExtension` classes applied to the intermediate representation before code generation when an emitter is an `IrEmitter`
+- `extensionClasses`: ListProperty&lt;Class&lt;\*&gt;&gt; - `IrExtension` classes applied to the intermediate representation before code generation when an emitter is an `IrEmitter`
 - `shared`: Property&lt;Boolean&gt; - Whether to emit shared code (default: true)
 - `strict`: Property&lt;Boolean&gt; - Strict parsing mode (default: false)
 
 ## Applying IR extensions
 
-[IR extensions](./plugins.md#ir-extensions) are registered with the `extensions` property. Put the
+[IR extensions](./plugins.md#ir-extensions) are registered with the `extensionClasses` property. Put the
 integration artifact that provides the extension on the `buildscript` classpath, then reference the class
 directly. Remember to set `ir = true` so the built-in language targets emit through the IR pipeline:
 
@@ -139,6 +139,6 @@ tasks.register<CompileWirespecTask>("wirespec-compile") {
     languages = listOf(Language.Kotlin)
     ir = true
     shared = false
-    extensions = listOf(KotlinxSerializationExtension::class.java)
+    extensionClasses = listOf(KotlinxSerializationExtension::class.java)
 }
 ```

--- a/src/site/docs/docs/plugins/plugins-maven.md
+++ b/src/site/docs/docs/plugins/plugins-maven.md
@@ -105,8 +105,8 @@ The compile mojo supports the following parameters:
 - **strict**: Whether to invoke strict mode during compilation. Default is 'true'.
 - **shared**: Whether to emit shared Wirespec code. Default is 'true'.
 - **emitterClass**: Specifies a custom emitter class to use for code generation.
-- **irExtensions**: List of fully qualified `IrExtension` class names. The extensions are applied to the intermediate representation before code generation for every emitter that is an `IrEmitter`.
-- **ir**: Whether to emit through the intermediate representation. Required for `irExtensions` to take effect on the built-in language targets. Default is 'false'.
+- **extensions**: List of fully qualified `IrExtension` class names. The extensions are applied to the intermediate representation before code generation for every emitter that is an `IrEmitter`.
+- **ir**: Whether to emit through the intermediate representation. Required for `extensions` to take effect on the built-in language targets. Default is 'false'.
 
 ### Running the Compile Goal
 
@@ -120,7 +120,7 @@ Or it will run automatically as part of the `generate-sources` phase during your
 
 ### Applying IR extensions
 
-[IR extensions](./plugins.md#ir-extensions) are registered with the `irExtensions` parameter. Add the
+[IR extensions](./plugins.md#ir-extensions) are registered with the `extensions` parameter. Add the
 integration artifact that provides the extension as a plugin `<dependency>`, then list the fully qualified
 class name. Set `<ir>true</ir>` so the built-in language targets emit through the IR pipeline:
 
@@ -150,9 +150,9 @@ class name. Set `<ir>true</ir>` so the built-in language targets emit through th
                 </languages>
                 <ir>true</ir>
                 <shared>false</shared>
-                <irExtensions>
-                    <irExtension>community.flock.wirespec.integration.kotlinxserialization.extension.KotlinxSerializationExtension</irExtension>
-                </irExtensions>
+                <extensions>
+                    <extension>community.flock.wirespec.integration.kotlinxserialization.extension.KotlinxSerializationExtension</extension>
+                </extensions>
             </configuration>
         </execution>
     </executions>

--- a/src/site/docs/docs/plugins/plugins-maven.md
+++ b/src/site/docs/docs/plugins/plugins-maven.md
@@ -105,8 +105,8 @@ The compile mojo supports the following parameters:
 - **strict**: Whether to invoke strict mode during compilation. Default is 'true'.
 - **shared**: Whether to emit shared Wirespec code. Default is 'true'.
 - **emitterClass**: Specifies a custom emitter class to use for code generation.
-- **extensions**: List of fully qualified `IrExtension` class names. The extensions are applied to the intermediate representation before code generation for every emitter that is an `IrEmitter`.
-- **ir**: Whether to emit through the intermediate representation. Required for `extensions` to take effect on the built-in language targets. Default is 'false'.
+- **extensionClasses**: List of fully qualified `IrExtension` class names. The extensions are applied to the intermediate representation before code generation for every emitter that is an `IrEmitter`.
+- **ir**: Whether to emit through the intermediate representation. Required for `extensionClasses` to take effect on the built-in language targets. Default is 'false'.
 
 ### Running the Compile Goal
 
@@ -120,7 +120,7 @@ Or it will run automatically as part of the `generate-sources` phase during your
 
 ### Applying IR extensions
 
-[IR extensions](./plugins.md#ir-extensions) are registered with the `extensions` parameter. Add the
+[IR extensions](./plugins.md#ir-extensions) are registered with the `extensionClasses` parameter. Add the
 integration artifact that provides the extension as a plugin `<dependency>`, then list the fully qualified
 class name. Set `<ir>true</ir>` so the built-in language targets emit through the IR pipeline:
 
@@ -150,9 +150,9 @@ class name. Set `<ir>true</ir>` so the built-in language targets emit through th
                 </languages>
                 <ir>true</ir>
                 <shared>false</shared>
-                <extensions>
-                    <extension>community.flock.wirespec.integration.kotlinxserialization.extension.KotlinxSerializationExtension</extension>
-                </extensions>
+                <extensionClasses>
+                    <extensionClass>community.flock.wirespec.integration.kotlinxserialization.extension.KotlinxSerializationExtension</extensionClass>
+                </extensionClasses>
             </configuration>
         </execution>
     </executions>

--- a/src/site/docs/docs/plugins/plugins.md
+++ b/src/site/docs/docs/plugins/plugins.md
@@ -55,7 +55,7 @@ representation** (IR). An `IrExtension` lets you reshape that IR — for example
 annotations — without forking an emitter. The transformed IR is then handed to the normal code generator,
 so the output stays idiomatic for the target language.
 
-You register extensions with the `irExtensions` parameter of the compile/custom operations. The
+You register extensions with the `extensions` parameter of the compile/custom operations. The
 Maven and Gradle plugins accept a list of `IrExtension` classes and instantiate them for you, injecting the
 `packageName` and `shared` settings into the constructor when the extension needs them.
 
@@ -72,7 +72,7 @@ Wirespec ships several IR extensions in its integration modules:
 | `KotlinxSerializationExtension` | `kotlinx-serialization` | Adds `@Serializable`/`@SerialName` to generated Kotlin models — see [kotlinx.serialization](../integration/integration-kotlinx-serialization.mdx) |
 
 Extensions whose constructor only needs `packageName`/`shared` (or nothing at all), such as
-`KotlinxSerializationExtension`, can be registered directly through `irExtensions`. Extensions
+`KotlinxSerializationExtension`, can be registered directly through `extensions`. Extensions
 that need other arguments — for instance the target language — are typically wired into a custom
 `IrEmitter` instead.
 

--- a/src/site/docs/docs/plugins/plugins.md
+++ b/src/site/docs/docs/plugins/plugins.md
@@ -55,10 +55,9 @@ representation** (IR). An `IrExtension` lets you reshape that IR — for example
 annotations — without forking an emitter. The transformed IR is then handed to the normal code generator,
 so the output stays idiomatic for the target language.
 
-You register extensions through the plugin's extensions configuration — the `extensions` parameter in
-Maven and the `extensionClasses` property in Gradle. The Maven and Gradle plugins accept a list of
-`IrExtension` classes and instantiate them for you, injecting the `packageName` and `shared` settings into
-the constructor when the extension needs them.
+You register extensions with the `extensionClasses` parameter of the compile/custom operations. The
+Maven and Gradle plugins accept a list of `IrExtension` classes and instantiate them for you, injecting the
+`packageName` and `shared` settings into the constructor when the extension needs them.
 
 :::note
 Extensions only run when the emitter is an `IrEmitter`. For the built-in language targets this means you
@@ -73,7 +72,7 @@ Wirespec ships several IR extensions in its integration modules:
 | `KotlinxSerializationExtension` | `kotlinx-serialization` | Adds `@Serializable`/`@SerialName` to generated Kotlin models — see [kotlinx.serialization](../integration/integration-kotlinx-serialization.mdx) |
 
 Extensions whose constructor only needs `packageName`/`shared` (or nothing at all), such as
-`KotlinxSerializationExtension`, can be registered directly through that configuration. Extensions
+`KotlinxSerializationExtension`, can be registered directly through `extensionClasses`. Extensions
 that need other arguments — for instance the target language — are typically wired into a custom
 `IrEmitter` instead.
 

--- a/src/site/docs/docs/plugins/plugins.md
+++ b/src/site/docs/docs/plugins/plugins.md
@@ -55,9 +55,10 @@ representation** (IR). An `IrExtension` lets you reshape that IR — for example
 annotations — without forking an emitter. The transformed IR is then handed to the normal code generator,
 so the output stays idiomatic for the target language.
 
-You register extensions with the `extensions` parameter of the compile/custom operations. The
-Maven and Gradle plugins accept a list of `IrExtension` classes and instantiate them for you, injecting the
-`packageName` and `shared` settings into the constructor when the extension needs them.
+You register extensions through the plugin's extensions configuration — the `extensions` parameter in
+Maven and the `extensionClasses` property in Gradle. The Maven and Gradle plugins accept a list of
+`IrExtension` classes and instantiate them for you, injecting the `packageName` and `shared` settings into
+the constructor when the extension needs them.
 
 :::note
 Extensions only run when the emitter is an `IrEmitter`. For the built-in language targets this means you
@@ -72,7 +73,7 @@ Wirespec ships several IR extensions in its integration modules:
 | `KotlinxSerializationExtension` | `kotlinx-serialization` | Adds `@Serializable`/`@SerialName` to generated Kotlin models — see [kotlinx.serialization](../integration/integration-kotlinx-serialization.mdx) |
 
 Extensions whose constructor only needs `packageName`/`shared` (or nothing at all), such as
-`KotlinxSerializationExtension`, can be registered directly through `extensions`. Extensions
+`KotlinxSerializationExtension`, can be registered directly through that configuration. Extensions
 that need other arguments — for instance the target language — are typically wired into a custom
 `IrEmitter` instead.
 


### PR DESCRIPTION
## Summary
Renames the user-facing `irExtensions` parameter/property to `extensions` in the Maven and Gradle plugins and across the plugin docs. The `IrExtension` type name is left unchanged.

### Changes
- **Maven plugin** (`BaseMojo.kt`): `@Parameter irExtensions` → `extensions`; private helper `irExtensionInstances` → `extensionInstances`.
- **Gradle plugin** (`BaseWirespecTask.kt`): `@Option(option = "irExtensions")` → `"extensions"`, `abstract val irExtensions` → `extensions`, and `extensionInstances()` updated accordingly.
- **Docs**: `plugins.md`, `plugins-maven.md` (incl. XML `<irExtensions>`/`<irExtension>` → `<extensions>`/`<extension>`), `plugins-gradle.md` (incl. Kotlin DSL example).

## Test plan
- `./gradlew :src:plugin:maven:compileKotlin :src:plugin:gradle:compileKotlin` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)