### PR TITLE
Fix WirespecWebClient ClassCastException on Spring Framework 7 / Spring Boot 4

### DIFF
--- a/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/client/WirespecWebClient.java
+++ b/src/integration/spring/src/jvmMain/java/community/flock/wirespec/integration/spring/java/client/WirespecWebClient.java
@@ -2,9 +2,10 @@ package community.flock.wirespec.integration.spring.java.client;
 
 import community.flock.wirespec.java.Wirespec;
 import community.flock.wirespec.java.Wirespec.Serialization;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.util.CollectionUtils;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
@@ -12,6 +13,7 @@ import reactor.core.publisher.Mono;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -96,12 +98,12 @@ public class WirespecWebClient {
                         response.bodyToMono(byte[].class)
                                 .map(body -> new Wirespec.RawResponse(
                                         response.statusCode().value(),
-                                        CollectionUtils.toMultiValueMap(response.headers().asHttpHeaders()),
+                                        toRawHeaders(response.headers().asHttpHeaders()),
                                         Optional.of(body)
                                 ))
                                 .defaultIfEmpty(new Wirespec.RawResponse(
                                         response.statusCode().value(),
-                                        CollectionUtils.toMultiValueMap(response.headers().asHttpHeaders()),
+                                        toRawHeaders(response.headers().asHttpHeaders()),
                                         Optional.empty()
                                 ))
                 )
@@ -109,7 +111,7 @@ public class WirespecWebClient {
                     if (throwable instanceof WebClientResponseException e) {
                         return Mono.just(new Wirespec.RawResponse(
                                 e.getStatusCode().value(),
-                                CollectionUtils.toMultiValueMap(e.getHeaders()),
+                                toRawHeaders(e.getHeaders()),
                                 Optional.of(e.getResponseBodyAsByteArray())
                         ));
                     } else {
@@ -117,5 +119,20 @@ public class WirespecWebClient {
                     }
                 })
                 .toFuture();
+    }
+
+    /**
+     * Converts Spring {@link HttpHeaders} into the {@link Map} expected by
+     * {@link Wirespec.RawResponse}.
+     *
+     * <p>This deliberately avoids casting {@link HttpHeaders} to {@link Map}: in Spring Framework 6
+     * {@code HttpHeaders} implements {@code MultiValueMap} (and therefore {@code Map}), but in Spring
+     * Framework 7 it no longer does. Iterating via {@link HttpHeaders#forEach} works on both versions,
+     * so a jar compiled against Spring 6 keeps working at runtime on Spring 7.
+     */
+    private static Map<String, List<String>> toRawHeaders(HttpHeaders headers) {
+        LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        headers.forEach(map::put);
+        return map;
     }
 }

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
@@ -97,8 +97,7 @@ class WirespecWebClient(
      * Framework 7 it no longer does. Iterating via [HttpHeaders.forEach] works on both versions, so
      * a jar compiled against Spring 6 keeps working at runtime on Spring 7.
      */
-    private fun HttpHeaders.toRawHeaders(): Map<String, List<String>> =
-        LinkedMultiValueMap<String, String>().also { map ->
-            forEach { name, values -> map[name] = values }
-        }
+    private fun HttpHeaders.toRawHeaders(): Map<String, List<String>> = LinkedMultiValueMap<String, String>().also { map ->
+        forEach { name, values -> map[name] = values }
+    }
 }

--- a/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
+++ b/src/integration/spring/src/jvmMain/kotlin/community/flock/wirespec/integration/spring/kotlin/client/WirespecWebClient.kt
@@ -4,9 +4,10 @@ import community.flock.wirespec.integration.spring.shared.filterNotEmpty
 import community.flock.wirespec.kotlin.Wirespec
 import community.flock.wirespec.kotlin.Wirespec.Serialization
 import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.util.CollectionUtils.toMultiValueMap
+import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
@@ -60,7 +61,7 @@ class WirespecWebClient(
                 .map { body ->
                     Wirespec.RawResponse(
                         statusCode = response.statusCode().value(),
-                        headers = toMultiValueMap(response.headers().asHttpHeaders()),
+                        headers = response.headers().asHttpHeaders().toRawHeaders(),
                         body = body,
                     )
                 }
@@ -68,7 +69,7 @@ class WirespecWebClient(
                     Mono.just(
                         Wirespec.RawResponse(
                             statusCode = response.statusCode().value(),
-                            headers = toMultiValueMap(response.headers().asHttpHeaders()),
+                            headers = response.headers().asHttpHeaders().toRawHeaders(),
                             body = null,
                         ),
                     ),
@@ -79,7 +80,7 @@ class WirespecWebClient(
                 is WebClientResponseException ->
                     Wirespec.RawResponse(
                         statusCode = throwable.statusCode.value(),
-                        headers = toMultiValueMap(throwable.headers),
+                        headers = throwable.headers.toRawHeaders(),
                         body = throwable.responseBodyAsByteArray,
                     ).let { Mono.just(it) }
 
@@ -87,4 +88,17 @@ class WirespecWebClient(
             }
         }
         .awaitSingle()
+
+    /**
+     * Converts Spring [HttpHeaders] into the [Map] expected by [Wirespec.RawResponse].
+     *
+     * This deliberately avoids casting [HttpHeaders] to [Map]: in Spring Framework 6 [HttpHeaders]
+     * implements [org.springframework.util.MultiValueMap] (and therefore [Map]), but in Spring
+     * Framework 7 it no longer does. Iterating via [HttpHeaders.forEach] works on both versions, so
+     * a jar compiled against Spring 6 keeps working at runtime on Spring 7.
+     */
+    private fun HttpHeaders.toRawHeaders(): Map<String, List<String>> =
+        LinkedMultiValueMap<String, String>().also { map ->
+            forEach { name, values -> map[name] = values }
+        }
 }


### PR DESCRIPTION
## Summary

`WirespecWebClient` (both the Kotlin and Java reactive clients) threw a `ClassCastException` on **every** response when running on Spring Framework 7 / Spring Boot 4:

```
java.lang.ClassCastException: class org.springframework.http.ReadOnlyHttpHeaders
cannot be cast to class java.util.Map
```

## Root cause

The clients converted downstream response headers into the `Map<String, List<String>>` expected by `Wirespec.RawResponse` by passing Spring's `HttpHeaders` straight into `CollectionUtils.toMultiValueMap(...)`, which relies on `HttpHeaders` being a `Map`.

- In **Spring 6.x**, `HttpHeaders implements MultiValueMap<String, String>` (and therefore `Map`), so the upcast is valid and the artifact compiles cleanly.
- In **Spring 7.0** (Spring Boot 4), `HttpHeaders` was redesigned and **no longer implements `Map`/`MultiValueMap`**. The published jar — compiled against Spring 6 — therefore fails the cast at runtime on Spring 7.

## Fix

Stop assuming `HttpHeaders` is a `Map`. Convert headers by iterating via `HttpHeaders.forEach(BiConsumer)` into a `LinkedMultiValueMap`, replacing the three `toMultiValueMap(...)` call sites in each client.

### Backwards compatibility ✅

The change is binary compatible with both Spring 6 and Spring 7. `forEach(BiConsumer<? super String, ? super List<String>>)` exists with an **identical binary descriptor** `(Ljava/util/function/BiConsumer;)V` in both versions:

- **Spring 6** — inherited as the default method from `Map`
- **Spring 7** — declared directly on `HttpHeaders`

So a single jar compiled against Spring 6 (as this repo is, on `spring-webflux 6.1.13`) resolves the call correctly at runtime on Spring 7 as well. No `keySet()`/`headerNames()` (which differ between versions) is used.

## Changes

- `WirespecWebClient.kt` (Kotlin) — added a private `HttpHeaders.toRawHeaders()` helper and replaced all three `toMultiValueMap(...)` call sites.
- `WirespecWebClient.java` (Java) — added a private `static toRawHeaders(HttpHeaders)` helper and replaced all three `CollectionUtils.toMultiValueMap(...)` call sites.

## Verification

- `:src:integration:spring:compileKotlinJvm` and `compileJvmMainJava` compile cleanly against Spring 6.1.13.
- The existing client integration tests (`*it.client.*`), including `ResponseHeaderCaseInsensitivityTest`, which exercise the exact response-header mapping path, pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFtN52uDWW7dgxwQE5kEGb)_