### PR TITLE
Add tabbed output view for multi-file code generation

### DIFF
--- a/src/site/playground/src/components/OutputView.tsx
+++ b/src/site/playground/src/components/OutputView.tsx
@@ -1,0 +1,63 @@
+import { useMemo, useState } from "react";
+import { Box, Tab, Tabs } from "@mui/material";
+import { WsEmitted } from "@flock/wirespec";
+import { PlayGround } from "./PlayGround";
+import { Language } from "../routes";
+
+interface OutputViewProps {
+  files: WsEmitted[];
+  allCode: string;
+  language: Language;
+}
+
+const ALL = "__all__";
+
+export function OutputView({ files, allCode, language }: OutputViewProps) {
+  const [selected, setSelected] = useState<string>(ALL);
+
+  // Resolve the currently selected file by name so the selection survives
+  // recompilation (which produces a fresh `files` array on every edit). When
+  // the selected file no longer exists, fall back to the combined view.
+  const activeFile = useMemo(
+    () =>
+      selected === ALL
+        ? undefined
+        : files.find((file) => file.typeName === selected),
+    [files, selected],
+  );
+
+  const tabValue = activeFile ? activeFile.typeName : ALL;
+  const code = activeFile ? activeFile.result : allCode;
+
+  return (
+    <Box>
+      {files.length > 1 && (
+        <Tabs
+          value={tabValue}
+          onChange={(_, value: string) => setSelected(value)}
+          variant="scrollable"
+          scrollButtons="auto"
+          sx={{
+            minHeight: 36,
+            borderBottom: "1px solid var(--border-primary)",
+            "& .MuiTab-root": {
+              color: "var(--color-primary)",
+              minHeight: 36,
+              textTransform: "none",
+            },
+          }}
+        >
+          <Tab value={ALL} label="All" />
+          {files.map((file) => (
+            <Tab
+              key={file.typeName}
+              value={file.typeName}
+              label={file.typeName}
+            />
+          ))}
+        </Tabs>
+      )}
+      <PlayGround code={code} language={language} />
+    </Box>
+  );
+}

--- a/src/site/playground/src/routes/index.tsx
+++ b/src/site/playground/src/routes/index.tsx
@@ -5,6 +5,7 @@ import { WsError, WsEmitted } from "@flock/wirespec";
 import { useMonaco } from "@monaco-editor/react";
 import { Box, Button } from "@mui/material";
 import { PlayGround } from "../components/PlayGround";
+import { OutputView } from "../components/OutputView";
 import { SpecificationSelector } from "../components/SpecificationSelector";
 import { EmitterSelector } from "../components/EmitterSelector";
 import { initializeMonaco } from "../utils/InitializeMonaco";
@@ -225,8 +226,9 @@ function RouteComponent() {
           borderTop="1px solid var(--border-primary)"
           borderLeft={{ sm: "1px solid var(--border-primary)" }}
         >
-          <PlayGround
-            code={wirespecResult}
+          <OutputView
+            files={wirespecOutput?.result || []}
+            allCode={wirespecResult}
             language={wirespecOutput?.language || "wirespec"}
           />
         </Box>


### PR DESCRIPTION
## Description

Refactored the playground output display to support viewing individual generated files in a tabbed interface. Previously, only the combined code output was shown. Now when multiple files are generated, users can switch between viewing individual files or the combined output via tabs.

### Changes

- **New component `OutputView`**: Manages tab selection and displays either a single file's output or the combined code. The component intelligently handles tab persistence across recompilation by resolving the selected file by name, falling back to the combined view if the file no longer exists.
- **Updated routes**: Replaced direct `PlayGround` component with `OutputView`, passing the array of generated files and combined code output.

The implementation uses React hooks (`useMemo`, `useState`) to efficiently track the active file selection and Material-UI `Tabs` for the tabbed interface. The tabs are only rendered when multiple files are present.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist

- [x] I have followed the contribution guidelines
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style

## Breaking Changes

None. This is a backward-compatible enhancement to the playground UI.

https://claude.ai/code/session_019EQbJaK4PKLtB6221UTu1C