### PR TITLE
feat(playground): tabbed output, package selector, file tabs

### DIFF
--- a/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
+++ b/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
@@ -15,6 +15,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Reference.Primitive.Type.Constraint
 import community.flock.wirespec.compiler.core.parse.ast.Reference.Primitive.Type.Precision.P32
 import community.flock.wirespec.compiler.core.parse.ast.Reference.Primitive.Type.Precision.P64
 import community.flock.wirespec.compiler.core.parse.ast.Refined
@@ -146,7 +147,7 @@ private fun WsReference.consume(): Reference = when (this) {
     )
 
     is WsPrimitive -> Reference.Primitive(
-        type = type.consume(),
+        type = consumeType(),
         isNullable = isNullable,
     )
 
@@ -161,14 +162,18 @@ private fun WsReference.consume(): Reference = when (this) {
     )
 }
 
-private fun WsPrimitiveType.consume() = when (this) {
-    WsPrimitiveType.String -> Reference.Primitive.Type.String(constraint = null)
-    WsPrimitiveType.Integer -> Reference.Primitive.Type.Integer(precision = P64, constraint = null)
-    WsPrimitiveType.Integer32 -> Reference.Primitive.Type.Integer(precision = P32, constraint = null)
-    WsPrimitiveType.Number -> Reference.Primitive.Type.Number(precision = P64, constraint = null)
-    WsPrimitiveType.Number32 -> Reference.Primitive.Type.Number(precision = P32, constraint = null)
-    WsPrimitiveType.Boolean -> Reference.Primitive.Type.Boolean
-    WsPrimitiveType.Bytes -> Reference.Primitive.Type.Bytes
+private fun WsPrimitive.consumeType(): Reference.Primitive.Type {
+    val regExp = (constraint as? WsRegExpConstraint)?.let { Constraint.RegExp(it.value) }
+    val bound = (constraint as? WsBoundConstraint)?.let { Constraint.Bound(it.min, it.max) }
+    return when (type) {
+        WsPrimitiveType.String -> Reference.Primitive.Type.String(constraint = regExp)
+        WsPrimitiveType.Integer -> Reference.Primitive.Type.Integer(precision = P64, constraint = bound)
+        WsPrimitiveType.Integer32 -> Reference.Primitive.Type.Integer(precision = P32, constraint = bound)
+        WsPrimitiveType.Number -> Reference.Primitive.Type.Number(precision = P64, constraint = bound)
+        WsPrimitiveType.Number32 -> Reference.Primitive.Type.Number(precision = P32, constraint = bound)
+        WsPrimitiveType.Boolean -> Reference.Primitive.Type.Boolean
+        WsPrimitiveType.Bytes -> Reference.Primitive.Type.Bytes
+    }
 }
 
 fun AST.produce(): WsAST = WsAST(modules.map { it.produce() }.toTypedArray())
@@ -245,7 +250,7 @@ private fun Reference.produce(): WsReference = when (this) {
     is Reference.Any -> WsAny(isNullable)
     is Reference.Unit -> WsUnit(isNullable)
     is Reference.Custom -> WsCustom(value, isNullable)
-    is Reference.Primitive -> WsPrimitive(type.produce(), isNullable)
+    is Reference.Primitive -> WsPrimitive(type.produce(), isNullable, type.produceConstraint())
     is Reference.Dict -> WsDict(reference.produce(), isNullable)
     is Reference.Iterable -> WsIterable(reference.produce(), isNullable)
 }
@@ -262,6 +267,14 @@ private fun Reference.Primitive.Type.produce() = when (this) {
     }
     is Reference.Primitive.Type.Boolean -> WsPrimitiveType.Boolean
     is Reference.Primitive.Type.Bytes -> WsPrimitiveType.Bytes
+}
+
+private fun Reference.Primitive.Type.produceConstraint(): WsConstraint? = when (this) {
+    is Reference.Primitive.Type.String -> constraint?.let { WsRegExpConstraint(it.value) }
+    is Reference.Primitive.Type.Integer -> constraint?.let { WsBoundConstraint(it.min, it.max) }
+    is Reference.Primitive.Type.Number -> constraint?.let { WsBoundConstraint(it.min, it.max) }
+    is Reference.Primitive.Type.Boolean -> null
+    is Reference.Primitive.Type.Bytes -> null
 }
 
 private fun Endpoint.Method.produce() = when (this) {
@@ -415,10 +428,20 @@ data class WsCustom(
 data class WsPrimitive(
     val type: WsPrimitiveType,
     override val isNullable: Boolean,
+    val constraint: WsConstraint? = null,
 ) : WsReference
 
 @JsExport
 enum class WsPrimitiveType { String, Integer, Integer32, Number, Number32, Boolean, Bytes }
+
+@JsExport
+sealed interface WsConstraint
+
+@JsExport
+data class WsRegExpConstraint(val value: String) : WsConstraint
+
+@JsExport
+data class WsBoundConstraint(val min: String?, val max: String?) : WsConstraint
 
 @JsExport
 data class WsRequest(val content: WsContent?)

--- a/src/plugin/npm/src/jsMain/kotlin/community/flock/wirespec/plugin/npm/Main.kt
+++ b/src/plugin/npm/src/jsMain/kotlin/community/flock/wirespec/plugin/npm/Main.kt
@@ -110,19 +110,19 @@ fun emit(wsAst: WsAST, emitter: Emitters, packageName: String, emitShared: Boole
             OpenAPIV2Emitter
                 .emitSwaggerObject(ast.modules.flatMap { it.statements }, noLogger)
                 .let(encode(OpenAPIV2ModelSerializer))
-                .let { Emitted("openapi", it) }
+                .let { Emitted("openapi.json", it) }
                 .let { nonEmptyListOf(it) }
         Emitters.OPENAPI_V3 ->
             OpenAPIV3Emitter
                 .emitOpenAPIObject(ast.modules.flatMap { it.statements }, null, noLogger)
                 .let(encode(OpenAPIV3ModelSerializer))
-                .let { Emitted("openapi", it) }
+                .let { Emitted("openapi.json", it) }
                 .let { nonEmptyListOf(it) }
         Emitters.AVRO ->
             ast.modules
                 .map { ast -> AvroJsonEmitter.emit(ast) }
                 .map { Json.encodeToString(it) }
-                .map { Emitted("avro", it) }
+                .map { Emitted("avro.json", it) }
     }
         .map { it.produce() }
         .toTypedArray()

--- a/src/site/playground/src/components/OutputView.tsx
+++ b/src/site/playground/src/components/OutputView.tsx
@@ -6,40 +6,47 @@ import { Language } from "../routes";
 
 interface OutputViewProps {
   files: WsEmitted[];
-  allCode: string;
   language: Language;
 }
 
-const ALL = "__all__";
+// Derive a short, readable tab label from an emitted file path
+// (e.g. "/model/TodoIdentifier.ts" -> "TodoIdentifier.ts").
+const fileLabel = (path: string) => path.split("/").pop() || path;
 
-export function OutputView({ files, allCode, language }: OutputViewProps) {
-  const [selected, setSelected] = useState<string>(ALL);
+export function OutputView({ files, language }: OutputViewProps) {
+  const [selected, setSelected] = useState<string>();
 
-  // Resolve the currently selected file by name so the selection survives
+  // Resolve the currently selected file by path so the selection survives
   // recompilation (which produces a fresh `files` array on every edit). When
-  // the selected file no longer exists, fall back to the combined view.
+  // the selected file no longer exists, fall back to the first file.
   const activeFile = useMemo(
-    () =>
-      selected === ALL
-        ? undefined
-        : files.find((file) => file.typeName === selected),
+    () => files.find((file) => file.file === selected) ?? files[0],
     [files, selected],
   );
 
-  const tabValue = activeFile ? activeFile.typeName : ALL;
-  const code = activeFile ? activeFile.result : allCode;
-
   return (
     <Box>
-      {files.length > 1 && (
+      {files.length > 0 && (
         <Tabs
-          value={tabValue}
+          value={activeFile?.file ?? false}
           onChange={(_, value: string) => setSelected(value)}
-          variant="scrollable"
-          scrollButtons="auto"
           sx={{
             minHeight: 36,
             borderBottom: "1px solid var(--border-primary)",
+            // Cap the strip height; when tabs overflow they wrap onto
+            // additional rows and the scroller scrolls vertically.
+            "& .MuiTabs-scroller": {
+              maxHeight: 36 * 3,
+              overflowX: "hidden !important",
+              overflowY: "auto !important",
+            },
+            "& .MuiTabs-flexContainer": {
+              flexWrap: "wrap",
+            },
+            // Hide the sliding indicator, which mispositions once tabs wrap.
+            "& .MuiTabs-indicator": {
+              display: "none",
+            },
             "& .MuiTab-root": {
               color: "var(--color-primary)",
               minHeight: 36,
@@ -47,17 +54,16 @@ export function OutputView({ files, allCode, language }: OutputViewProps) {
             },
           }}
         >
-          <Tab value={ALL} label="All" />
           {files.map((file) => (
             <Tab
-              key={file.typeName}
-              value={file.typeName}
-              label={file.typeName}
+              key={file.file}
+              value={file.file}
+              label={fileLabel(file.file)}
             />
           ))}
         </Tabs>
       )}
-      <PlayGround code={code} language={language} />
+      <PlayGround code={activeFile?.result ?? ""} language={language} />
     </Box>
   );
 }

--- a/src/site/playground/src/components/PackageSelector.tsx
+++ b/src/site/playground/src/components/PackageSelector.tsx
@@ -1,0 +1,41 @@
+import { FormControl, MenuItem, Select } from "@mui/material";
+
+interface PackageSelectorProps {
+  packages: string[];
+  value: string;
+  onChange: (pkg: string) => void;
+}
+
+// Render the package path as a dotted name (e.g.
+// "community/flock/wirespec/generated/model" -> "community.flock.wirespec.generated.model").
+// Files emitted at the root (e.g. "Wirespec.ts") have no package; label them "root".
+const packageLabel = (pkg: string) => (pkg ? pkg.replace(/\//g, ".") : "root");
+
+export function PackageSelector({
+  packages,
+  value,
+  onChange,
+}: PackageSelectorProps) {
+  return (
+    <FormControl sx={{ minWidth: 120 }} size="small">
+      <Select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {packages.map((pkg) => (
+          <MenuItem key={pkg} value={pkg}>
+            {packageLabel(pkg)}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
+// The package of an emitted file is its full directory path (every path
+// segment except the file name), so it captures the complete package:
+// "/model/Todo.ts" -> "model" and
+// "community/flock/.../model/Todo.kt" -> "community/flock/.../model".
+// Root-level files (e.g. "Wirespec.ts") have no package and map to "".
+export const packageOf = (path: string) =>
+  path.split("/").filter(Boolean).slice(0, -1).join("/");

--- a/src/site/playground/src/components/PlayGround.tsx
+++ b/src/site/playground/src/components/PlayGround.tsx
@@ -22,7 +22,7 @@ export function PlayGround({ code, setCode, language }: PlayGroundProps) {
         language={language}
         theme="vs-dark"
         height="100vh"
-        options={{ minimap: { enabled: false } }}
+        options={{ minimap: { enabled: false }, fontSize: 14 }}
         value={code}
         onChange={
           setCode

--- a/src/site/playground/src/routes/index.tsx
+++ b/src/site/playground/src/routes/index.tsx
@@ -1,13 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useSearch } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { WsError, WsEmitted } from "@flock/wirespec";
 import { useMonaco } from "@monaco-editor/react";
-import { Box, Button } from "@mui/material";
+import { Box, Button, Tab, Tabs } from "@mui/material";
 import { PlayGround } from "../components/PlayGround";
 import { OutputView } from "../components/OutputView";
 import { SpecificationSelector } from "../components/SpecificationSelector";
 import { EmitterSelector } from "../components/EmitterSelector";
+import { PackageSelector, packageOf } from "../components/PackageSelector";
 import { initializeMonaco } from "../utils/InitializeMonaco";
 import { MonacoError, setMonacoErrors } from "../utils/SetMonacoErrors";
 import { wirespecToTarget } from "../transformations/WirespecToTarget";
@@ -54,21 +55,6 @@ export type CompilationResult = {
   language: Language;
 };
 
-const createFileHeaderFor = (fileName: string, emitter: Emitter): string => {
-  switch (emitter) {
-    case "typescript":
-    case "kotlin":
-    case "open_api_v2":
-    case "open_api_v3":
-    case "avro":
-    case "wirespec":
-      return "";
-    case "java":
-    case "python":
-      return `\n/**\n/* ${fileName}\n**/\n`;
-  }
-};
-
 export const Route = createFileRoute("/")({
   component: RouteComponent,
   validateSearch: (search?: Record<string, unknown>): Search => {
@@ -85,10 +71,31 @@ function RouteComponent() {
   const { emitter, specification } = useSearch({ from: "/" });
   const [code, setCode] = useState("");
   const [wirespecOutput, setWirespecOutput] = useState<CompilationResult>();
-  const [wirespecResult, setWirespecResult] = useState("");
   const [wirespecErrors, setWirespecErrors] = useState<MonacoError[]>([]);
+  const [selectedPackage, setSelectedPackage] = useState<string>();
   const [mobileDisplay, setMobileDisplay] = useState<"input" | "output">(
     "input",
+  );
+
+  const files = wirespecOutput?.result ?? [];
+
+  // Distinct packages (the directory containing each file) across the emitted
+  // files, in first-seen order, used to populate the package selector.
+  const packages = useMemo(() => {
+    const seen = new Set<string>();
+    files.forEach((file) => seen.add(packageOf(file.file)));
+    return [...seen];
+  }, [files]);
+
+  // Default to the first package, and fall back to it when the chosen package
+  // is absent from the current output (e.g. after switching emitter/spec).
+  const activePackage =
+    selectedPackage && packages.includes(selectedPackage)
+      ? selectedPackage
+      : packages[0];
+
+  const filteredFiles = files.filter(
+    (file) => packageOf(file.file) === activePackage,
   );
 
   useEffect(() => {
@@ -148,22 +155,10 @@ function RouteComponent() {
   }, [specification]);
 
   useEffect(() => {
-    if (wirespecOutput) {
-      if (wirespecOutput.result.length) {
-        setWirespecResult(
-          wirespecOutput.result
-            .map(
-              (file) =>
-                `${createFileHeaderFor(file.typeName, emitter)}${file.result}`,
-            )
-            .join(""),
-        );
-      }
-      if (wirespecOutput.errors) {
-        setWirespecErrors(wirespecOutput.errors);
-      }
+    if (wirespecOutput?.errors) {
+      setWirespecErrors(wirespecOutput.errors);
     }
-  }, [wirespecOutput, emitter]);
+  }, [wirespecOutput]);
 
   return (
     <Box display="flex">
@@ -175,7 +170,7 @@ function RouteComponent() {
         }}
       >
         <Box
-          marginInline={{ xs: 1, sm: 8 }}
+          marginInline={{ xs: 1, sm: 2 }}
           display="flex"
           justifyContent="space-between"
         >
@@ -191,6 +186,25 @@ function RouteComponent() {
           </Box>
         </Box>
         <Box marginTop={1} borderTop="1px solid var(--border-primary)">
+          {/* Single file tab mirroring the output panel's file tabs, so both
+              editors stay vertically aligned. */}
+          <Tabs
+            value={0}
+            sx={{
+              minHeight: 36,
+              borderBottom: "1px solid var(--border-primary)",
+              "& .MuiTab-root": {
+                color: "var(--color-primary)",
+                minHeight: 36,
+                textTransform: "none",
+              },
+            }}
+          >
+            <Tab
+              value={0}
+              label={specification === "wirespec" ? "todo.ws" : "todo.json"}
+            />
+          </Tabs>
           <PlayGround
             code={code}
             setCode={setCode}
@@ -206,11 +220,20 @@ function RouteComponent() {
         }}
       >
         <Box
-          marginInline={{ xs: 1, sm: 8 }}
+          marginInline={{ xs: 1, sm: 2 }}
           display="flex"
           justifyContent="space-between"
         >
-          <EmitterSelector />
+          <Box display="flex" gap={1}>
+            <EmitterSelector />
+            {packages.length > 1 && (
+              <PackageSelector
+                packages={packages}
+                value={activePackage ?? ""}
+                onChange={setSelectedPackage}
+              />
+            )}
+          </Box>
           <Box display={{ sm: "none" }}>
             <Button
               sx={{ color: "var(--color-primary)" }}
@@ -227,8 +250,7 @@ function RouteComponent() {
           borderLeft={{ sm: "1px solid var(--border-primary)" }}
         >
           <OutputView
-            files={wirespecOutput?.result || []}
-            allCode={wirespecResult}
+            files={filteredFiles}
             language={wirespecOutput?.language || "wirespec"}
           />
         </Box>

--- a/src/site/playground/src/transformations/OpenAPIToWirespec.tsx
+++ b/src/site/playground/src/transformations/OpenAPIToWirespec.tsx
@@ -6,7 +6,7 @@ export const openApiV2ToWirespec: (openapi: string) => CompilationResult = (
 ) => {
   const ast = convert(x, Converters.OPENAPI_V2);
   return {
-    result: emit(ast, Emitters.WIRESPEC, ""),
+    result: emit(ast, Emitters.WIRESPEC, "", false),
     errors: [],
     language: "wirespec",
   };
@@ -17,7 +17,7 @@ export const openApiV3ToWirespec: (openapi: string) => CompilationResult = (
 ) => {
   const ast = convert(x, Converters.OPENAPI_V3);
   return {
-    result: emit(ast, Emitters.WIRESPEC, ""),
+    result: emit(ast, Emitters.WIRESPEC, "", false),
     errors: [],
     language: "wirespec",
   };
@@ -28,7 +28,7 @@ export const avroToWirespec: (avro: string) => CompilationResult = (
 ) => {
   const ast = convert(x, Converters.AVRO);
   return {
-    result: emit(ast, Emitters.WIRESPEC, ""),
+    result: emit(ast, Emitters.WIRESPEC, "", false),
     errors: [],
     language: "wirespec",
   };

--- a/src/site/playground/src/transformations/WirespecToTarget.tsx
+++ b/src/site/playground/src/transformations/WirespecToTarget.tsx
@@ -50,6 +50,7 @@ export const wirespecToTarget: (
       parseResult.result,
       internalEmitter,
       "community.flock.wirespec.generated",
+      false,
     );
     if (
       internalEmitter === Emitters.OPENAPI_V3 ||
@@ -57,7 +58,7 @@ export const wirespecToTarget: (
       internalEmitter === Emitters.AVRO
     ) {
       result = result.map((it) => ({
-        typeName: it.typeName,
+        file: it.file,
         result: prettyJson(it.result),
       }));
     }


### PR DESCRIPTION
## Summary

Playground UX improvements plus the JS-lib plumbing they rely on.

### Playground
- **Tabbed output view** with a **package selector** to navigate multi-file code generation. The selector is hidden when there's only one (or no) package — nothing to choose.
- **Input file tab** (`todo.ws` for Wirespec, `todo.json` for OpenAPI) so the input and output editors stay vertically aligned.
- **Output tab strip wraps** onto multiple rows and **scrolls vertically** once tabs overflow (capped at ~3 rows), instead of horizontal scrolling on a single row.
- **Explicit file extensions** for single-file outputs: `openapi.json` (V2 & V3) and `avro.json`, so the tab label shows the extension.
- Monaco editor **font size bumped to 14**.

### Compiler / JS lib
- Carry primitive **constraints (RegExp / Bound)** through the JS AST bridge via a new `WsConstraint` type, so refined types round-trip correctly.
- Thread the `emitShared` flag through the JS `emit()` calls.

## Test plan
- [ ] Rebuild `@flock/wirespec` JS package so the playground picks up the new file names / constraint bridge.
- [ ] Switch emitters (TypeScript/Kotlin/Java/Python) and confirm multi-file output tabs + package selector behave.
- [ ] Switch to OpenAPI v2/v3 and Avro and confirm single `openapi.json` / `avro.json` tab shows and the package selector is hidden.
- [ ] Confirm the output tab strip wraps and scrolls vertically with many files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)