### PR TITLE
Add Jackson IR extension for automatic annotation of generated models

### DIFF
--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
@@ -15,6 +15,7 @@ import community.flock.wirespec.ir.core.Parameter
 import community.flock.wirespec.ir.core.RawExpression
 import community.flock.wirespec.ir.core.Struct
 import community.flock.wirespec.ir.core.VariableReference
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.findElement
 import community.flock.wirespec.ir.core.function
 import community.flock.wirespec.ir.core.transform
@@ -124,7 +125,7 @@ internal fun <T : Element> T.flattenEndpointTypeRefs(endpointName: String): T = 
 
 internal fun <T : Element> T.addSelfReceiverToClientFields(): T {
     val struct = (this as? File)?.findElement<Struct>()
-    val fieldNames = struct?.fields?.filterIsInstance<Field>()?.map { it.name.value() }?.toSet() ?: emptySet()
+    val fieldNames = struct?.fieldList?.map { it.name.value() }?.toSet() ?: emptySet()
     if (fieldNames.isEmpty()) return this
 
     return transform {

--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
@@ -4,6 +4,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
 import community.flock.wirespec.ir.converter.convertConstraint
 import community.flock.wirespec.ir.core.Element
+import community.flock.wirespec.ir.core.Field
 import community.flock.wirespec.ir.core.FieldCall
 import community.flock.wirespec.ir.core.File
 import community.flock.wirespec.ir.core.FunctionCall
@@ -36,7 +37,7 @@ internal fun File.replaceReflectInNonGenericStructFields(): File = transform {
         if (struct.typeParameters.isNotEmpty()) return@matchingElements struct
         struct.copy(
             fields = struct.fields.map { field ->
-                field.copy(type = field.type.replaceReflectAsTypeAny())
+                if (field is Field) field.copy(type = field.type.replaceReflectAsTypeAny()) else field
             },
         )
     }
@@ -123,7 +124,7 @@ internal fun <T : Element> T.flattenEndpointTypeRefs(endpointName: String): T = 
 
 internal fun <T : Element> T.addSelfReceiverToClientFields(): T {
     val struct = (this as? File)?.findElement<Struct>()
-    val fieldNames = struct?.fields?.map { it.name.value() }?.toSet() ?: emptySet()
+    val fieldNames = struct?.fields?.filterIsInstance<Field>()?.map { it.name.value() }?.toSet() ?: emptySet()
     if (fieldNames.isEmpty()) return this
 
     return transform {

--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrTransformer.kt
@@ -125,7 +125,7 @@ internal fun <T : Element> T.flattenEndpointTypeRefs(endpointName: String): T = 
 
 internal fun <T : Element> T.addSelfReceiverToClientFields(): T {
     val struct = (this as? File)?.findElement<Struct>()
-    val fieldNames = struct?.fieldList?.map { it.name.value() }?.toSet() ?: emptySet()
+    val fieldNames = struct?.fieldList()?.map { it.name.value() }?.toSet() ?: emptySet()
     if (fieldNames.isEmpty()) return this
 
     return transform {

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
@@ -34,7 +34,6 @@ import community.flock.wirespec.ir.core.ConstructorStatement
 import community.flock.wirespec.ir.core.Element
 import community.flock.wirespec.ir.core.ArrayIndexCall
 import community.flock.wirespec.ir.core.Expression
-import community.flock.wirespec.ir.core.Field
 import community.flock.wirespec.ir.core.FieldCall
 import community.flock.wirespec.ir.core.File
 import community.flock.wirespec.ir.core.FunctionCall
@@ -50,6 +49,7 @@ import community.flock.wirespec.ir.core.Switch
 import community.flock.wirespec.ir.core.Transformer
 import community.flock.wirespec.ir.core.VariableReference
 import community.flock.wirespec.ir.core.collectCustomTypeNames
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.findElement
 import community.flock.wirespec.ir.core.import
 import community.flock.wirespec.ir.core.`interface`
@@ -270,7 +270,7 @@ open class RustIrEmitter(
             .let { file ->
                 LanguageFile(file.name, file.elements.flatMap { element ->
                     if (element !is Struct) return@flatMap listOf(element)
-                    val structFields = element.fields.filterIsInstance<Field>()
+                    val structFields = element.fieldList
                     val derive = when {
                         structFields.any { containsUnderiveable(it.type) } -> ""
                         structFields.any { containsWildcard(it.type) } -> "#[derive(Debug, Default)]"

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
@@ -270,7 +270,7 @@ open class RustIrEmitter(
             .let { file ->
                 LanguageFile(file.name, file.elements.flatMap { element ->
                     if (element !is Struct) return@flatMap listOf(element)
-                    val structFields = element.fieldList
+                    val structFields = element.fieldList()
                     val derive = when {
                         structFields.any { containsUnderiveable(it.type) } -> ""
                         structFields.any { containsWildcard(it.type) } -> "#[derive(Debug, Default)]"

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
@@ -34,6 +34,7 @@ import community.flock.wirespec.ir.core.ConstructorStatement
 import community.flock.wirespec.ir.core.Element
 import community.flock.wirespec.ir.core.ArrayIndexCall
 import community.flock.wirespec.ir.core.Expression
+import community.flock.wirespec.ir.core.Field
 import community.flock.wirespec.ir.core.FieldCall
 import community.flock.wirespec.ir.core.File
 import community.flock.wirespec.ir.core.FunctionCall
@@ -269,9 +270,10 @@ open class RustIrEmitter(
             .let { file ->
                 LanguageFile(file.name, file.elements.flatMap { element ->
                     if (element !is Struct) return@flatMap listOf(element)
+                    val structFields = element.fields.filterIsInstance<Field>()
                     val derive = when {
-                        element.fields.any { containsUnderiveable(it.type) } -> ""
-                        element.fields.any { containsWildcard(it.type) } -> "#[derive(Debug, Default)]"
+                        structFields.any { containsUnderiveable(it.type) } -> ""
+                        structFields.any { containsWildcard(it.type) } -> "#[derive(Debug, Default)]"
                         element.name.pascalCase() in setOf("RawRequest", "RawResponse") -> "#[derive(Debug, Clone, PartialEq)]"
                         else -> "#[derive(Debug, Clone, Default, PartialEq)]"
                     }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
@@ -134,28 +134,29 @@ data class Struct(
  * contain other elements (such as [RawElement] annotations injected before a field by an IR
  * extension); this helper filters those out when only the declared fields are needed.
  */
-val Struct.fieldList: List<Field> get() = fields.filterIsInstance<Field>()
+fun Struct.fieldList(): List<Field> = fields.filterIsInstance<Field>()
 
 /**
- * Each declared [Field] paired with the raw annotation codes that immediately precede it.
- * An IR extension may inject annotations as [RawElement]s in front of a [Field] (see the
- * Jackson integration); the Java and Kotlin generators render those as the field's
- * annotations. Elements that are neither a [Field] nor a [RawElement] are ignored.
+ * Pairs each declared [Field] with the annotation codes that immediately precede it.
+ *
+ * An IR extension annotates a field by inserting [RawElement]s directly in front of it (see
+ * the Jackson integration). This walks [fields] in order, buffering each raw annotation code
+ * it encounters and attaching the buffer to the next [Field]. Elements that are neither a
+ * [Field] nor a [RawElement] are ignored.
  */
-val Struct.annotatedFields: List<Pair<Field, List<String>>>
-    get() = buildList {
-        val pending = mutableListOf<String>()
-        fields.forEach { element ->
-            when (element) {
-                is RawElement -> pending += element.code
-                is Field -> {
-                    add(element to pending.toList())
-                    pending.clear()
-                }
-                else -> Unit
+fun Struct.annotatedFields(): List<Pair<Field, List<String>>> = buildList {
+    val pendingAnnotations = mutableListOf<String>()
+    fields.forEach { element ->
+        when (element) {
+            is RawElement -> pendingAnnotations += element.code
+            is Field -> {
+                add(element to pendingAnnotations.toList())
+                pendingAnnotations.clear()
             }
+            else -> Unit
         }
     }
+}
 
 data class Constructor(
     val parameters: List<Parameter>,

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
@@ -138,6 +138,7 @@ data class Field(
     val name: Name,
     val type: Type,
     val isOverride: Boolean = false,
+    val annotations: List<String> = emptyList(),
 )
 
 data class Function(

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
@@ -121,13 +121,20 @@ data class Import(
 
 data class Struct(
     override val name: Name,
-    val fields: List<Field>,
+    val fields: List<Element>,
     val constructors: List<Constructor> = emptyList(),
     val interfaces: List<Type.Custom> = emptyList(),
     override val elements: List<Element> = emptyList(),
     val typeParameters: List<TypeParameter> = emptyList(),
 ) : HasName,
     HasElements
+
+/**
+ * The [Field] entries of this struct's parameter list. A struct's [Struct.fields] may also
+ * contain other elements (such as [RawElement] annotations injected before a field by an IR
+ * extension); this helper filters those out when only the declared fields are needed.
+ */
+val Struct.fieldList: List<Field> get() = fields.filterIsInstance<Field>()
 
 data class Constructor(
     val parameters: List<Parameter>,
@@ -138,8 +145,7 @@ data class Field(
     val name: Name,
     val type: Type,
     val isOverride: Boolean = false,
-    val annotations: List<String> = emptyList(),
-)
+) : Element
 
 data class Function(
     override val name: Name,

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
@@ -136,6 +136,27 @@ data class Struct(
  */
 val Struct.fieldList: List<Field> get() = fields.filterIsInstance<Field>()
 
+/**
+ * Each declared [Field] paired with the raw annotation codes that immediately precede it.
+ * An IR extension may inject annotations as [RawElement]s in front of a [Field] (see the
+ * Jackson integration); the Java and Kotlin generators render those as the field's
+ * annotations. Elements that are neither a [Field] nor a [RawElement] are ignored.
+ */
+val Struct.annotatedFields: List<Pair<Field, List<String>>>
+    get() = buildList {
+        val pending = mutableListOf<String>()
+        fields.forEach { element ->
+            when (element) {
+                is RawElement -> pending += element.code
+                is Field -> {
+                    add(element to pending.toList())
+                    pending.clear()
+                }
+                else -> Unit
+            }
+        }
+    }
+
 data class Constructor(
     val parameters: List<Parameter>,
     val body: List<Statement>,

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Transform.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Transform.kt
@@ -93,7 +93,7 @@ fun Element.transformChildren(transformer: Transformer): Element = when (this) {
     is Package -> this
     is Import -> copy(type = transformer.transformType(type) as Type.Custom)
     is Struct -> copy(
-        fields = fields.map { transformer.transformField(it) },
+        fields = fields.map { if (it is Field) transformer.transformField(it) else transformer.transformElement(it) },
         constructors = constructors.map { transformer.transformConstructor(it) },
         interfaces = interfaces.map { transformer.transformType(it) as Type.Custom },
         elements = elements.map { transformer.transformElement(it) },
@@ -132,6 +132,7 @@ fun Element.transformChildren(transformer: Transformer): Element = when (this) {
         statics = statics.map { transformer.transformElement(it) },
         body = body.map { transformer.transformStatement(it) },
     )
+    is Field -> transformChildren(transformer)
     is RawElement -> this
 }
 

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
@@ -93,6 +93,7 @@ object JavaGenerator : Generator {
             "public class $fileName {\n$staticContent  public static void main(String[] args) {\n$content  }\n}\n"
         }
         is File -> elements.joinToString("") { it.emit(indent, isStatic, parents) }
+        // A field has no standalone rendering; it is emitted inline within its enclosing Struct parameter list via Struct.emit.
         is Field -> ""
         is RawElement -> code.indentCode(indent)
     }
@@ -191,7 +192,7 @@ object JavaGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element>): String {
-        val fields = fieldList
+        val fields = fieldList()
         val implStr = interfaces.map { it.emitGenerics() }.distinct().joinNonEmpty(", ", " implements ")
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "<", ">") { it.type.emitGenerics() }
         val isInsideStaticOrInterface = parents.any { it is Namespace || it is Interface }
@@ -204,7 +205,7 @@ object JavaGenerator : Generator {
         val customConstructors = constructors.joinToString("") { it.emit(name.pascalCase(), fields, 1, isRecord = true) }
         val nestedContent = elements.joinToString("") { it.emit(1, isStatic = true, parents = parents + this) }
 
-        val paramParts = annotatedFields.map { (field, annotations) ->
+        val paramParts = annotatedFields().map { (field, annotations) ->
             val annotationPrefix = annotations.joinToString("") { "$it " }
             "$annotationPrefix${field.type.emitGenerics()} ${field.name.value().sanitize()}".indentCode(1)
         }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
@@ -91,6 +91,7 @@ object JavaGenerator : Generator {
             "public class $fileName {\n$staticContent  public static void main(String[] args) {\n$content  }\n}\n"
         }
         is File -> elements.joinToString("") { it.emit(indent, isStatic, parents) }
+        is Field -> ""
         is RawElement -> code.indentCode(indent)
     }
 
@@ -188,6 +189,8 @@ object JavaGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element>): String {
+        val fieldElements = fields
+        val fields = fields.filterIsInstance<Field>()
         val implStr = interfaces.map { it.emitGenerics() }.distinct().joinNonEmpty(", ", " implements ")
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "<", ">") { it.type.emitGenerics() }
         val isInsideStaticOrInterface = parents.any { it is Namespace || it is Interface }
@@ -200,11 +203,21 @@ object JavaGenerator : Generator {
         val customConstructors = constructors.joinToString("") { it.emit(name.pascalCase(), fields, 1, isRecord = true) }
         val nestedContent = elements.joinToString("") { it.emit(1, isStatic = true, parents = parents + this) }
 
-        val paramsStr = if (fields.isEmpty()) {
-            " ()"
-        } else {
-            fields.joinToString(",\n", " (\n", "\n)") { "${it.type.emitGenerics()} ${it.name.value().sanitize()}".indentCode(1) }
+        val paramParts = buildList {
+            val pendingAnnotations = mutableListOf<String>()
+            fieldElements.forEach { element ->
+                when (element) {
+                    is RawElement -> pendingAnnotations.add(element.code)
+                    is Field -> {
+                        val annotationPrefix = pendingAnnotations.joinToString("") { "$it " }
+                        pendingAnnotations.clear()
+                        add("$annotationPrefix${element.type.emitGenerics()} ${element.name.value().sanitize()}".indentCode(1))
+                    }
+                    else -> Unit
+                }
+            }
         }
+        val paramsStr = if (paramParts.isEmpty()) " ()" else paramParts.joinToString(",\n", " (\n", "\n)")
 
         return "$typeModifier ${name.pascalCase()}$typeParamsStr$paramsStr$implStr {\n$customConstructors$nestedContent};\n\n".indentCode(indent)
     }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
@@ -55,6 +55,8 @@ import community.flock.wirespec.ir.core.TypeDescriptor
 import community.flock.wirespec.ir.core.TypeParameter
 import community.flock.wirespec.ir.core.Union
 import community.flock.wirespec.ir.core.VariableReference
+import community.flock.wirespec.ir.core.annotatedFields
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.Function as AstFunction
 
 object JavaGenerator : Generator {
@@ -189,8 +191,7 @@ object JavaGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element>): String {
-        val fieldElements = fields
-        val fields = fields.filterIsInstance<Field>()
+        val fields = fieldList
         val implStr = interfaces.map { it.emitGenerics() }.distinct().joinNonEmpty(", ", " implements ")
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "<", ">") { it.type.emitGenerics() }
         val isInsideStaticOrInterface = parents.any { it is Namespace || it is Interface }
@@ -203,19 +204,9 @@ object JavaGenerator : Generator {
         val customConstructors = constructors.joinToString("") { it.emit(name.pascalCase(), fields, 1, isRecord = true) }
         val nestedContent = elements.joinToString("") { it.emit(1, isStatic = true, parents = parents + this) }
 
-        val paramParts = buildList {
-            val pendingAnnotations = mutableListOf<String>()
-            fieldElements.forEach { element ->
-                when (element) {
-                    is RawElement -> pendingAnnotations.add(element.code)
-                    is Field -> {
-                        val annotationPrefix = pendingAnnotations.joinToString("") { "$it " }
-                        pendingAnnotations.clear()
-                        add("$annotationPrefix${element.type.emitGenerics()} ${element.name.value().sanitize()}".indentCode(1))
-                    }
-                    else -> Unit
-                }
-            }
+        val paramParts = annotatedFields.map { (field, annotations) ->
+            val annotationPrefix = annotations.joinToString("") { "$it " }
+            "$annotationPrefix${field.type.emitGenerics()} ${field.name.value().sanitize()}".indentCode(1)
         }
         val paramsStr = if (paramParts.isEmpty()) " ()" else paramParts.joinToString(",\n", " (\n", "\n)")
 

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
@@ -95,6 +95,7 @@ object KotlinGenerator : Generator {
             staticContent + "${modifier}fun main() {\n$content}\n\n".indentCode(indent)
         }
         is File -> elements.joinToString("") { it.emit(indent, isStatic, parents) }
+        // A field has no standalone rendering; it is emitted inline within its enclosing Struct parameter list via Struct.emit.
         is Field -> ""
         is RawElement -> "$code\n".indentCode(indent)
     }
@@ -172,7 +173,7 @@ object KotlinGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element>): String {
-        val fields = fieldList
+        val fields = fieldList()
         val pascal = name.pascalCase()
         val implStr = interfaces.map { it.emitGenerics() }.distinct().joinNonEmpty(", ", " : ")
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "<", ">") { it.emit() }
@@ -205,7 +206,7 @@ object KotlinGenerator : Generator {
             }
         }
 
-        val paramParts = annotatedFields.map { (field, annotations) ->
+        val paramParts = annotatedFields().map { (field, annotations) ->
             val annotationPrefix = annotations.joinToString("") { "$it " }
             val overridePrefix = "override ".takeIf { _ -> field.isOverride }.orEmpty()
             "$annotationPrefix${overridePrefix}val ${field.name.value().sanitize()}: ${field.type.emitGenerics()}".indentCode(indent + 1)

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
@@ -203,7 +203,8 @@ object KotlinGenerator : Generator {
 
         val paramsStr = fields.joinNonEmpty(",\n", "(\n", "\n${")".indentCode(indent)}") {
             val overridePrefix = "override ".takeIf { _ -> it.isOverride }.orEmpty()
-            "${overridePrefix}val ${it.name.value().sanitize()}: ${it.type.emitGenerics()}".indentCode(indent + 1)
+            val annotationsPrefix = it.annotations.joinToString("") { annotation -> "$annotation " }
+            "$annotationsPrefix${overridePrefix}val ${it.name.value().sanitize()}: ${it.type.emitGenerics()}".indentCode(indent + 1)
         }
         val hasBody = customConstructors.isNotEmpty() || nestedContent.isNotEmpty()
         return if (hasBody) {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
@@ -93,6 +93,7 @@ object KotlinGenerator : Generator {
             staticContent + "${modifier}fun main() {\n$content}\n\n".indentCode(indent)
         }
         is File -> elements.joinToString("") { it.emit(indent, isStatic, parents) }
+        is Field -> ""
         is RawElement -> "$code\n".indentCode(indent)
     }
 
@@ -169,6 +170,8 @@ object KotlinGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element>): String {
+        val fieldElements = fields
+        val fields = fields.filterIsInstance<Field>()
         val pascal = name.pascalCase()
         val implStr = interfaces.map { it.emitGenerics() }.distinct().joinNonEmpty(", ", " : ")
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "<", ">") { it.emit() }
@@ -201,11 +204,22 @@ object KotlinGenerator : Generator {
             }
         }
 
-        val paramsStr = fields.joinNonEmpty(",\n", "(\n", "\n${")".indentCode(indent)}") {
-            val overridePrefix = "override ".takeIf { _ -> it.isOverride }.orEmpty()
-            val annotationsPrefix = it.annotations.joinToString("") { annotation -> "$annotation " }
-            "$annotationsPrefix${overridePrefix}val ${it.name.value().sanitize()}: ${it.type.emitGenerics()}".indentCode(indent + 1)
+        val paramParts = buildList {
+            val pendingAnnotations = mutableListOf<String>()
+            fieldElements.forEach { element ->
+                when (element) {
+                    is RawElement -> pendingAnnotations.add(element.code)
+                    is Field -> {
+                        val annotationPrefix = pendingAnnotations.joinToString("") { "$it " }
+                        pendingAnnotations.clear()
+                        val overridePrefix = "override ".takeIf { _ -> element.isOverride }.orEmpty()
+                        add("$annotationPrefix${overridePrefix}val ${element.name.value().sanitize()}: ${element.type.emitGenerics()}".indentCode(indent + 1))
+                    }
+                    else -> Unit
+                }
+            }
         }
+        val paramsStr = paramParts.joinNonEmpty(",\n", "(\n", "\n${")".indentCode(indent)}") { it }
         val hasBody = customConstructors.isNotEmpty() || nestedContent.isNotEmpty()
         return if (hasBody) {
             "data class $pascal$typeParamsStr$paramsStr$implStr {\n$customConstructors$nestedContent$closingBrace\n\n".indentCode(indent)

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
@@ -55,6 +55,8 @@ import community.flock.wirespec.ir.core.TypeDescriptor
 import community.flock.wirespec.ir.core.TypeParameter
 import community.flock.wirespec.ir.core.Union
 import community.flock.wirespec.ir.core.VariableReference
+import community.flock.wirespec.ir.core.annotatedFields
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.Function as AstFunction
 
 object KotlinGenerator : Generator {
@@ -170,8 +172,7 @@ object KotlinGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element>): String {
-        val fieldElements = fields
-        val fields = fields.filterIsInstance<Field>()
+        val fields = fieldList
         val pascal = name.pascalCase()
         val implStr = interfaces.map { it.emitGenerics() }.distinct().joinNonEmpty(", ", " : ")
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "<", ">") { it.emit() }
@@ -204,20 +205,10 @@ object KotlinGenerator : Generator {
             }
         }
 
-        val paramParts = buildList {
-            val pendingAnnotations = mutableListOf<String>()
-            fieldElements.forEach { element ->
-                when (element) {
-                    is RawElement -> pendingAnnotations.add(element.code)
-                    is Field -> {
-                        val annotationPrefix = pendingAnnotations.joinToString("") { "$it " }
-                        pendingAnnotations.clear()
-                        val overridePrefix = "override ".takeIf { _ -> element.isOverride }.orEmpty()
-                        add("$annotationPrefix${overridePrefix}val ${element.name.value().sanitize()}: ${element.type.emitGenerics()}".indentCode(indent + 1))
-                    }
-                    else -> Unit
-                }
-            }
+        val paramParts = annotatedFields.map { (field, annotations) ->
+            val annotationPrefix = annotations.joinToString("") { "$it " }
+            val overridePrefix = "override ".takeIf { _ -> field.isOverride }.orEmpty()
+            "$annotationPrefix${overridePrefix}val ${field.name.value().sanitize()}: ${field.type.emitGenerics()}".indentCode(indent + 1)
         }
         val paramsStr = paramParts.joinNonEmpty(",\n", "(\n", "\n${")".indentCode(indent)}") { it }
         val hasBody = customConstructors.isNotEmpty() || nestedContent.isNotEmpty()

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
@@ -52,6 +52,7 @@ import community.flock.wirespec.ir.core.Type
 import community.flock.wirespec.ir.core.TypeDescriptor
 import community.flock.wirespec.ir.core.Union
 import community.flock.wirespec.ir.core.VariableReference
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.Function as AstFunction
 
 object PythonGenerator : Generator {
@@ -184,7 +185,7 @@ object PythonGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element> = emptyList(), qualifier: ((String) -> String)? = null): String {
-        val fields = fields.filterIsInstance<Field>()
+        val fields = fieldList
         val p = mutableListOf<String>()
         interfaces.forEach { p.add(it.emit()) }
         if (typeParameters.isNotEmpty()) {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
@@ -109,6 +109,7 @@ object PythonGenerator : Generator {
             "$staticContent$defBlock$guard"
         }
         is File -> elements.joinToString("") { it.emit(indent, parents, isStaticScope, qualifier) }
+        // A field has no standalone rendering; it is emitted inline within its enclosing Struct parameter list via Struct.emit.
         is Field -> ""
         is RawElement -> "$code\n".indentCode(indent)
     }
@@ -185,7 +186,7 @@ object PythonGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element> = emptyList(), qualifier: ((String) -> String)? = null): String {
-        val fields = fieldList
+        val fields = fieldList()
         val p = mutableListOf<String>()
         interfaces.forEach { p.add(it.emit()) }
         if (typeParameters.isNotEmpty()) {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
@@ -108,6 +108,7 @@ object PythonGenerator : Generator {
             "$staticContent$defBlock$guard"
         }
         is File -> elements.joinToString("") { it.emit(indent, parents, isStaticScope, qualifier) }
+        is Field -> ""
         is RawElement -> "$code\n".indentCode(indent)
     }
 
@@ -183,6 +184,7 @@ object PythonGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element> = emptyList(), qualifier: ((String) -> String)? = null): String {
+        val fields = fields.filterIsInstance<Field>()
         val p = mutableListOf<String>()
         interfaces.forEach { p.add(it.emit()) }
         if (typeParameters.isNotEmpty()) {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
@@ -90,6 +90,7 @@ object RustGenerator : Generator {
             }
         }
         is File -> elements.joinToString("") { it.emit(indent, parents, isStaticScope) }
+        // A field has no standalone rendering; it is emitted inline within its enclosing Struct parameter list via Struct.emit.
         is Field -> ""
         is RawElement -> "$code\n".indentCode(indent)
     }
@@ -191,7 +192,7 @@ object RustGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element> = emptyList()): String {
-        val fields = fieldList
+        val fields = fieldList()
         val rustName = name.pascalCase()
         val typeParamsStr = if (typeParameters.isEmpty()) "" else "<${typeParameters.joinToString(", ") { it.type.emit() }}>"
         val functions = elements.filterIsInstance<AstFunction>()

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
@@ -54,6 +54,7 @@ import community.flock.wirespec.ir.core.TypeDescriptor
 import community.flock.wirespec.ir.core.TypeParameter
 import community.flock.wirespec.ir.core.Union
 import community.flock.wirespec.ir.core.VariableReference
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.Function as AstFunction
 
 object RustGenerator : Generator {
@@ -190,7 +191,7 @@ object RustGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element> = emptyList()): String {
-        val fields = fields.filterIsInstance<Field>()
+        val fields = fieldList
         val rustName = name.pascalCase()
         val typeParamsStr = if (typeParameters.isEmpty()) "" else "<${typeParameters.joinToString(", ") { it.type.emit() }}>"
         val functions = elements.filterIsInstance<AstFunction>()

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
@@ -89,6 +89,7 @@ object RustGenerator : Generator {
             }
         }
         is File -> elements.joinToString("") { it.emit(indent, parents, isStaticScope) }
+        is Field -> ""
         is RawElement -> "$code\n".indentCode(indent)
     }
 
@@ -189,6 +190,7 @@ object RustGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element> = emptyList()): String {
+        val fields = fields.filterIsInstance<Field>()
         val rustName = name.pascalCase()
         val typeParamsStr = if (typeParameters.isEmpty()) "" else "<${typeParameters.joinToString(", ") { it.type.emit() }}>"
         val functions = elements.filterIsInstance<AstFunction>()

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
@@ -123,7 +123,7 @@ object ScalaGenerator : Generator {
         for (element in elements) {
             when (element) {
                 is Struct -> {
-                    result[element.name.pascalCase()] = element.fieldList.map { it.name.value() }.toSet()
+                    result[element.name.pascalCase()] = element.fieldList().map { it.name.value() }.toSet()
                     result.putAll(collectPrimaryFieldNames(element.elements))
                 }
                 is Namespace -> result.putAll(collectPrimaryFieldNames(element.elements))
@@ -173,6 +173,7 @@ object ScalaGenerator : Generator {
             "object $fileName {\n$staticContent  def main(args: Array[String]): Unit = {\n$content  }\n}\n\n".indentCode(indent)
         }
         is File -> elements.joinToString("") { it.emit(indent, isStatic, parents) }
+        // A field has no standalone rendering; it is emitted inline within its enclosing Struct parameter list via Struct.emit.
         is Field -> ""
         is RawElement -> "$code\n".indentCode(indent)
     }
@@ -249,7 +250,7 @@ object ScalaGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element>): String {
-        val fields = fieldList
+        val fields = fieldList()
         val pascal = name.pascalCase()
         val implStr = interfaces.map { it.emitTypeAnnotation() }.distinct().joinNonEmpty(" with ", " extends ")
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "[", "]") { it.type.emitGenerics() }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
@@ -122,7 +122,7 @@ object ScalaGenerator : Generator {
         for (element in elements) {
             when (element) {
                 is Struct -> {
-                    result[element.name.pascalCase()] = element.fields.map { it.name.value() }.toSet()
+                    result[element.name.pascalCase()] = element.fields.filterIsInstance<Field>().map { it.name.value() }.toSet()
                     result.putAll(collectPrimaryFieldNames(element.elements))
                 }
                 is Namespace -> result.putAll(collectPrimaryFieldNames(element.elements))
@@ -172,6 +172,7 @@ object ScalaGenerator : Generator {
             "object $fileName {\n$staticContent  def main(args: Array[String]): Unit = {\n$content  }\n}\n\n".indentCode(indent)
         }
         is File -> elements.joinToString("") { it.emit(indent, isStatic, parents) }
+        is Field -> ""
         is RawElement -> "$code\n".indentCode(indent)
     }
 
@@ -247,6 +248,7 @@ object ScalaGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element>): String {
+        val fields = fields.filterIsInstance<Field>()
         val pascal = name.pascalCase()
         val implStr = interfaces.map { it.emitTypeAnnotation() }.distinct().joinNonEmpty(" with ", " extends ")
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "[", "]") { it.type.emitGenerics() }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
@@ -55,6 +55,7 @@ import community.flock.wirespec.ir.core.TypeDescriptor
 import community.flock.wirespec.ir.core.TypeParameter
 import community.flock.wirespec.ir.core.Union
 import community.flock.wirespec.ir.core.VariableReference
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.Function as AstFunction
 
 object ScalaGenerator : Generator {
@@ -122,7 +123,7 @@ object ScalaGenerator : Generator {
         for (element in elements) {
             when (element) {
                 is Struct -> {
-                    result[element.name.pascalCase()] = element.fields.filterIsInstance<Field>().map { it.name.value() }.toSet()
+                    result[element.name.pascalCase()] = element.fieldList.map { it.name.value() }.toSet()
                     result.putAll(collectPrimaryFieldNames(element.elements))
                 }
                 is Namespace -> result.putAll(collectPrimaryFieldNames(element.elements))
@@ -248,7 +249,7 @@ object ScalaGenerator : Generator {
     }
 
     private fun Struct.emit(indent: Int, parents: List<Element>): String {
-        val fields = fields.filterIsInstance<Field>()
+        val fields = fieldList
         val pascal = name.pascalCase()
         val implStr = interfaces.map { it.emitTypeAnnotation() }.distinct().joinNonEmpty(" with ", " extends ")
         val typeParamsStr = typeParameters.joinNonEmpty(", ", "[", "]") { it.type.emitGenerics() }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
@@ -103,6 +103,7 @@ object TypeScriptGenerator : Generator {
             "$staticContent${";(async () => {\n$content${"})();".indentCode(indent)}\n".indentCode(indent)}"
         }
         is File -> elements.joinToString("") { it.emit(indent) }
+        is Field -> ""
         is RawElement -> code.lines().joinToString("\n") { if (it.isEmpty()) it else it.indentCode(indent) } + "\n"
     }
 
@@ -160,6 +161,7 @@ object TypeScriptGenerator : Generator {
     private fun Enum.emit(indent: Int): String = "export type ${name.pascalCase()} = ${entries.joinToString(" | ") { "\"${it.name.value()}\"" }}\n".indentCode(indent)
 
     private fun Struct.emit(indent: Int): String {
+        val fields = fields.filterIsInstance<Field>()
         val nestedStructs = elements.filterIsInstance<Struct>().associateBy { it.name.pascalCase() }
         val nonStructElements = elements.filter { it !is Struct }
         val fieldsContent = if (fields.isEmpty()) {
@@ -212,6 +214,7 @@ object TypeScriptGenerator : Generator {
     }
 
     private fun Struct.emitInline(): String {
+        val fields = fields.filterIsInstance<Field>()
         if (fields.isEmpty()) return "{}"
         val nestedStructs = elements.filterIsInstance<Struct>().associateBy { it.name.pascalCase() }
         return "{${fields.joinToString(", ") { field ->

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
@@ -104,6 +104,7 @@ object TypeScriptGenerator : Generator {
             "$staticContent${";(async () => {\n$content${"})();".indentCode(indent)}\n".indentCode(indent)}"
         }
         is File -> elements.joinToString("") { it.emit(indent) }
+        // A field has no standalone rendering; it is emitted inline within its enclosing Struct parameter list via Struct.emit.
         is Field -> ""
         is RawElement -> code.lines().joinToString("\n") { if (it.isEmpty()) it else it.indentCode(indent) } + "\n"
     }
@@ -162,7 +163,7 @@ object TypeScriptGenerator : Generator {
     private fun Enum.emit(indent: Int): String = "export type ${name.pascalCase()} = ${entries.joinToString(" | ") { "\"${it.name.value()}\"" }}\n".indentCode(indent)
 
     private fun Struct.emit(indent: Int): String {
-        val fields = fieldList
+        val fields = fieldList()
         val nestedStructs = elements.filterIsInstance<Struct>().associateBy { it.name.pascalCase() }
         val nonStructElements = elements.filter { it !is Struct }
         val fieldsContent = if (fields.isEmpty()) {
@@ -215,7 +216,7 @@ object TypeScriptGenerator : Generator {
     }
 
     private fun Struct.emitInline(): String {
-        val fields = fieldList
+        val fields = fieldList()
         if (fields.isEmpty()) return "{}"
         val nestedStructs = elements.filterIsInstance<Struct>().associateBy { it.name.pascalCase() }
         return "{${fields.joinToString(", ") { field ->

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/TypeScriptGenerator.kt
@@ -53,6 +53,7 @@ import community.flock.wirespec.ir.core.Type
 import community.flock.wirespec.ir.core.TypeDescriptor
 import community.flock.wirespec.ir.core.Union
 import community.flock.wirespec.ir.core.VariableReference
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.forEachElement
 import community.flock.wirespec.ir.core.Function as AstFunction
 
@@ -161,7 +162,7 @@ object TypeScriptGenerator : Generator {
     private fun Enum.emit(indent: Int): String = "export type ${name.pascalCase()} = ${entries.joinToString(" | ") { "\"${it.name.value()}\"" }}\n".indentCode(indent)
 
     private fun Struct.emit(indent: Int): String {
-        val fields = fields.filterIsInstance<Field>()
+        val fields = fieldList
         val nestedStructs = elements.filterIsInstance<Struct>().associateBy { it.name.pascalCase() }
         val nonStructElements = elements.filter { it !is Struct }
         val fieldsContent = if (fields.isEmpty()) {
@@ -214,7 +215,7 @@ object TypeScriptGenerator : Generator {
     }
 
     private fun Struct.emitInline(): String {
-        val fields = fields.filterIsInstance<Field>()
+        val fields = fieldList
         if (fields.isEmpty()) return "{}"
         val nestedStructs = elements.filterIsInstance<Struct>().associateBy { it.name.pascalCase() }
         return "{${fields.joinToString(", ") { field ->

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/transformer/SharedTransforms.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/transformer/SharedTransforms.kt
@@ -9,6 +9,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
 import community.flock.wirespec.ir.core.Constructor
 import community.flock.wirespec.ir.core.Element
+import community.flock.wirespec.ir.core.Field
 import community.flock.wirespec.ir.core.FieldCall
 import community.flock.wirespec.ir.core.Function
 import community.flock.wirespec.ir.core.Name
@@ -22,7 +23,7 @@ import community.flock.wirespec.ir.core.Enum as LanguageEnum
 import community.flock.wirespec.ir.core.Type as LanguageType
 
 fun Struct.markMembersAsOverride(): Struct = copy(
-    fields = fields.map { f -> f.copy(isOverride = true) },
+    fields = fields.map { f -> if (f is Field) f.copy(isOverride = true) else f },
     elements = elements.map { element ->
         if (element is Function) element.copy(isOverride = true) else element
     },

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
@@ -213,7 +213,7 @@ class IrConverterTest {
         val inlineStruct = inline.convert().findElement<Struct>()!!
 
         val emittedStructName = inlineStruct.name.pascalCase()
-        val embeddedField = parentStruct.fieldList.single()
+        val embeddedField = parentStruct.fieldList().single()
         val customRef = ((embeddedField.type as Type.Nullable).type as Type.Custom).name.value()
 
         assertEquals(emittedStructName, customRef)

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/IrConverterTest.kt
@@ -27,6 +27,7 @@ import community.flock.wirespec.ir.core.Struct
 import community.flock.wirespec.ir.core.Type
 import community.flock.wirespec.ir.core.VariableReference
 import community.flock.wirespec.ir.core.enum
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.file
 import community.flock.wirespec.ir.core.findElement
 import community.flock.wirespec.ir.core.struct
@@ -212,7 +213,7 @@ class IrConverterTest {
         val inlineStruct = inline.convert().findElement<Struct>()!!
 
         val emittedStructName = inlineStruct.name.pascalCase()
-        val embeddedField = parentStruct.fields.single()
+        val embeddedField = parentStruct.fieldList.single()
         val customRef = ((embeddedField.type as Type.Nullable).type as Type.Custom).name.value()
 
         assertEquals(emittedStructName, customRef)

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/core/TransformTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/core/TransformTest.kt
@@ -19,8 +19,8 @@ class TransformTest {
         val result = struct.renameType("Address", "Location")
 
         assertEquals(Name.of("Person"), result.name)
-        assertEquals(Type.String, result.fieldList[0].type)
-        assertEquals(Type.Custom("Location"), result.fieldList[1].type)
+        assertEquals(Type.String, result.fieldList()[0].type)
+        assertEquals(Type.Custom("Location"), result.fieldList()[1].type)
     }
 
     @Test
@@ -34,7 +34,7 @@ class TransformTest {
 
         val result = struct.renameType("Address", "Location")
 
-        assertEquals(Type.Array(Type.Custom("Location")), result.fieldList[0].type)
+        assertEquals(Type.Array(Type.Custom("Location")), result.fieldList()[0].type)
     }
 
     @Test
@@ -48,7 +48,7 @@ class TransformTest {
 
         val result = struct.renameType("Address", "Location")
 
-        assertEquals(Type.Nullable(Type.Custom("Location")), result.fieldList[0].type)
+        assertEquals(Type.Nullable(Type.Custom("Location")), result.fieldList()[0].type)
     }
 
     @Test
@@ -62,7 +62,7 @@ class TransformTest {
 
         val result = struct.renameType("Item", "Product")
 
-        assertEquals(Type.Dict(Type.String, Type.Custom("Product")), result.fieldList[0].type)
+        assertEquals(Type.Dict(Type.String, Type.Custom("Product")), result.fieldList()[0].type)
     }
 
     @Test
@@ -77,8 +77,8 @@ class TransformTest {
 
         val result = struct.renameField("firstName", "givenName")
 
-        assertEquals(Name.of("givenName"), result.fieldList[0].name)
-        assertEquals(Name.of("lastName"), result.fieldList[1].name)
+        assertEquals(Name.of("givenName"), result.fieldList()[0].name)
+        assertEquals(Name.of("lastName"), result.fieldList()[1].name)
     }
 
     @Test
@@ -95,8 +95,8 @@ class TransformTest {
             Type.Custom("List", listOf(array.elementType))
         }
 
-        assertEquals(Type.Custom("List", listOf(Type.Custom("Item"))), result.fieldList[0].type)
-        assertEquals(Type.Integer(), result.fieldList[1].type)
+        assertEquals(Type.Custom("List", listOf(Type.Custom("Item"))), result.fieldList()[0].type)
+        assertEquals(Type.Integer(), result.fieldList()[1].type)
     }
 
     @Test
@@ -134,9 +134,9 @@ class TransformTest {
             transform = { it.copy(type = Type.Nullable(it.type)) },
         )
 
-        assertEquals(Type.Nullable(Type.String), result.fieldList[0].type)
-        assertEquals(Type.Integer(), result.fieldList[1].type)
-        assertEquals(Type.Nullable(Type.String), result.fieldList[2].type)
+        assertEquals(Type.Nullable(Type.String), result.fieldList()[0].type)
+        assertEquals(Type.Integer(), result.fieldList()[1].type)
+        assertEquals(Type.Nullable(Type.String), result.fieldList()[2].type)
     }
 
     @Test
@@ -287,7 +287,7 @@ class TransformTest {
         val outer = result.elements[0] as Struct
         val inner = outer.elements[0] as Struct
 
-        assertEquals(Type.Custom("Data"), inner.fieldList[0].type)
+        assertEquals(Type.Custom("Data"), inner.fieldList()[0].type)
     }
 
     @Test
@@ -321,7 +321,7 @@ class TransformTest {
 
         assertEquals(
             Type.Custom("List", listOf(Type.Custom("Product"))),
-            result.fieldList[0].type,
+            result.fieldList()[0].type,
         )
     }
 
@@ -347,8 +347,8 @@ class TransformTest {
 
         val result = struct.transform(transformer)
 
-        assertEquals(Type.Nullable(Type.String), result.fieldList[0].type)
-        assertEquals(Type.Integer(), result.fieldList[1].type)
+        assertEquals(Type.Nullable(Type.String), result.fieldList()[0].type)
+        assertEquals(Type.Integer(), result.fieldList()[1].type)
     }
 
     @Test
@@ -373,8 +373,8 @@ class TransformTest {
 
         val result = struct.transform(transformer)
 
-        assertEquals(Type.Integer(Precision.P64), result.fieldList[0].type)
-        assertEquals(Type.Number(Precision.P32), result.fieldList[1].type)
+        assertEquals(Type.Integer(Precision.P64), result.fieldList()[0].type)
+        assertEquals(Type.Number(Precision.P32), result.fieldList()[1].type)
     }
 
     @Test
@@ -452,7 +452,7 @@ class TransformTest {
             renameType("Address", "Location")
         }
 
-        assertEquals(Type.Custom("Location"), result.fieldList[0].type)
+        assertEquals(Type.Custom("Location"), result.fieldList()[0].type)
     }
 
     @Test
@@ -469,8 +469,8 @@ class TransformTest {
             renameField("firstName", "givenName")
         }
 
-        assertEquals(Type.Custom("Location"), result.fieldList[0].type)
-        assertEquals(Name.of("givenName"), result.fieldList[0].name)
+        assertEquals(Type.Custom("Location"), result.fieldList()[0].type)
+        assertEquals(Name.of("givenName"), result.fieldList()[0].name)
     }
 
     @Test
@@ -512,7 +512,7 @@ class TransformTest {
             }
         }
 
-        assertEquals(Type.Integer(Precision.P64), result.fieldList[0].type)
+        assertEquals(Type.Integer(Precision.P64), result.fieldList()[0].type)
     }
 
     @Test
@@ -543,7 +543,7 @@ class TransformTest {
         }
 
         val struct = result.elements[0] as Struct
-        assertEquals(Type.Nullable(Type.String), struct.fieldList[0].type)
+        assertEquals(Type.Nullable(Type.String), struct.fieldList()[0].type)
         val fn = result.elements[1] as Function
         assertEquals(Type.Nullable(Type.String), fn.parameters[0].type)
     }

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/core/TransformTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/core/TransformTest.kt
@@ -19,8 +19,8 @@ class TransformTest {
         val result = struct.renameType("Address", "Location")
 
         assertEquals(Name.of("Person"), result.name)
-        assertEquals(Type.String, result.fields[0].type)
-        assertEquals(Type.Custom("Location"), result.fields[1].type)
+        assertEquals(Type.String, result.fieldList[0].type)
+        assertEquals(Type.Custom("Location"), result.fieldList[1].type)
     }
 
     @Test
@@ -34,7 +34,7 @@ class TransformTest {
 
         val result = struct.renameType("Address", "Location")
 
-        assertEquals(Type.Array(Type.Custom("Location")), result.fields[0].type)
+        assertEquals(Type.Array(Type.Custom("Location")), result.fieldList[0].type)
     }
 
     @Test
@@ -48,7 +48,7 @@ class TransformTest {
 
         val result = struct.renameType("Address", "Location")
 
-        assertEquals(Type.Nullable(Type.Custom("Location")), result.fields[0].type)
+        assertEquals(Type.Nullable(Type.Custom("Location")), result.fieldList[0].type)
     }
 
     @Test
@@ -62,7 +62,7 @@ class TransformTest {
 
         val result = struct.renameType("Item", "Product")
 
-        assertEquals(Type.Dict(Type.String, Type.Custom("Product")), result.fields[0].type)
+        assertEquals(Type.Dict(Type.String, Type.Custom("Product")), result.fieldList[0].type)
     }
 
     @Test
@@ -77,8 +77,8 @@ class TransformTest {
 
         val result = struct.renameField("firstName", "givenName")
 
-        assertEquals(Name.of("givenName"), result.fields[0].name)
-        assertEquals(Name.of("lastName"), result.fields[1].name)
+        assertEquals(Name.of("givenName"), result.fieldList[0].name)
+        assertEquals(Name.of("lastName"), result.fieldList[1].name)
     }
 
     @Test
@@ -95,8 +95,8 @@ class TransformTest {
             Type.Custom("List", listOf(array.elementType))
         }
 
-        assertEquals(Type.Custom("List", listOf(Type.Custom("Item"))), result.fields[0].type)
-        assertEquals(Type.Integer(), result.fields[1].type)
+        assertEquals(Type.Custom("List", listOf(Type.Custom("Item"))), result.fieldList[0].type)
+        assertEquals(Type.Integer(), result.fieldList[1].type)
     }
 
     @Test
@@ -134,9 +134,9 @@ class TransformTest {
             transform = { it.copy(type = Type.Nullable(it.type)) },
         )
 
-        assertEquals(Type.Nullable(Type.String), result.fields[0].type)
-        assertEquals(Type.Integer(), result.fields[1].type)
-        assertEquals(Type.Nullable(Type.String), result.fields[2].type)
+        assertEquals(Type.Nullable(Type.String), result.fieldList[0].type)
+        assertEquals(Type.Integer(), result.fieldList[1].type)
+        assertEquals(Type.Nullable(Type.String), result.fieldList[2].type)
     }
 
     @Test
@@ -287,7 +287,7 @@ class TransformTest {
         val outer = result.elements[0] as Struct
         val inner = outer.elements[0] as Struct
 
-        assertEquals(Type.Custom("Data"), inner.fields[0].type)
+        assertEquals(Type.Custom("Data"), inner.fieldList[0].type)
     }
 
     @Test
@@ -321,7 +321,7 @@ class TransformTest {
 
         assertEquals(
             Type.Custom("List", listOf(Type.Custom("Product"))),
-            result.fields[0].type,
+            result.fieldList[0].type,
         )
     }
 
@@ -347,8 +347,8 @@ class TransformTest {
 
         val result = struct.transform(transformer)
 
-        assertEquals(Type.Nullable(Type.String), result.fields[0].type)
-        assertEquals(Type.Integer(), result.fields[1].type)
+        assertEquals(Type.Nullable(Type.String), result.fieldList[0].type)
+        assertEquals(Type.Integer(), result.fieldList[1].type)
     }
 
     @Test
@@ -373,8 +373,8 @@ class TransformTest {
 
         val result = struct.transform(transformer)
 
-        assertEquals(Type.Integer(Precision.P64), result.fields[0].type)
-        assertEquals(Type.Number(Precision.P32), result.fields[1].type)
+        assertEquals(Type.Integer(Precision.P64), result.fieldList[0].type)
+        assertEquals(Type.Number(Precision.P32), result.fieldList[1].type)
     }
 
     @Test
@@ -452,7 +452,7 @@ class TransformTest {
             renameType("Address", "Location")
         }
 
-        assertEquals(Type.Custom("Location"), result.fields[0].type)
+        assertEquals(Type.Custom("Location"), result.fieldList[0].type)
     }
 
     @Test
@@ -469,8 +469,8 @@ class TransformTest {
             renameField("firstName", "givenName")
         }
 
-        assertEquals(Type.Custom("Location"), result.fields[0].type)
-        assertEquals(Name.of("givenName"), result.fields[0].name)
+        assertEquals(Type.Custom("Location"), result.fieldList[0].type)
+        assertEquals(Name.of("givenName"), result.fieldList[0].name)
     }
 
     @Test
@@ -512,7 +512,7 @@ class TransformTest {
             }
         }
 
-        assertEquals(Type.Integer(Precision.P64), result.fields[0].type)
+        assertEquals(Type.Integer(Precision.P64), result.fieldList[0].type)
     }
 
     @Test
@@ -543,7 +543,7 @@ class TransformTest {
         }
 
         val struct = result.elements[0] as Struct
-        assertEquals(Type.Nullable(Type.String), struct.fields[0].type)
+        assertEquals(Type.Nullable(Type.String), struct.fieldList[0].type)
         val fn = result.elements[1] as Function
         assertEquals(Type.Nullable(Type.String), fn.parameters[0].type)
     }

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/transformer/SanitizationTransformTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/transformer/SanitizationTransformTest.kt
@@ -48,8 +48,8 @@ class SanitizationTransformTest {
 
         val result = struct.sanitizeNames(javaLikeConfig)
 
-        assertEquals("firstName", result.fieldList[0].name.value())
-        assertEquals("lastName", result.fieldList[1].name.value())
+        assertEquals("firstName", result.fieldList()[0].name.value())
+        assertEquals("lastName", result.fieldList()[1].name.value())
     }
 
     @Test
@@ -63,7 +63,7 @@ class SanitizationTransformTest {
 
         val result = struct.sanitizeNames(javaLikeConfig)
 
-        assertEquals("_class", result.fieldList[0].name.value())
+        assertEquals("_class", result.fieldList()[0].name.value())
     }
 
     @Test

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/transformer/SanitizationTransformTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/transformer/SanitizationTransformTest.kt
@@ -9,6 +9,7 @@ import community.flock.wirespec.ir.core.ReturnStatement
 import community.flock.wirespec.ir.core.Struct
 import community.flock.wirespec.ir.core.Type
 import community.flock.wirespec.ir.core.VariableReference
+import community.flock.wirespec.ir.core.fieldList
 import community.flock.wirespec.ir.core.transformChildren
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -47,8 +48,8 @@ class SanitizationTransformTest {
 
         val result = struct.sanitizeNames(javaLikeConfig)
 
-        assertEquals("firstName", result.fields[0].name.value())
-        assertEquals("lastName", result.fields[1].name.value())
+        assertEquals("firstName", result.fieldList[0].name.value())
+        assertEquals("lastName", result.fieldList[1].name.value())
     }
 
     @Test
@@ -62,7 +63,7 @@ class SanitizationTransformTest {
 
         val result = struct.sanitizeNames(javaLikeConfig)
 
-        assertEquals("_class", result.fields[0].name.value())
+        assertEquals("_class", result.fieldList[0].name.value())
     }
 
     @Test

--- a/src/integration/jackson/src/jvmMain/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtension.kt
+++ b/src/integration/jackson/src/jvmMain/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtension.kt
@@ -1,0 +1,85 @@
+package community.flock.wirespec.integration.jackson.extension
+
+import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.ir.core.IR
+import community.flock.wirespec.ir.core.Name
+import community.flock.wirespec.ir.core.RawElement
+import community.flock.wirespec.ir.core.Struct
+import community.flock.wirespec.ir.core.Union
+import community.flock.wirespec.ir.extension.IrExtension
+import community.flock.wirespec.compiler.core.parse.ast.Type as TypeDefinition
+import community.flock.wirespec.ir.core.File as LanguageFile
+
+/**
+ * Adds Jackson annotations to every generated model declaration so the emitted
+ * classes (de)serialize correctly without registering a custom Jackson module:
+ *
+ * - record fields get `@JsonProperty("<wirespec name>")`, preserving the original
+ *   field name even when the emitter has to sanitize a reserved keyword.
+ * - unions get `@JsonTypeInfo` + `@JsonSubTypes`, mapping each member type to its
+ *   wirespec name so polymorphic values round-trip through a `type` discriminator.
+ *
+ * The annotations are emitted fully qualified against `com.fasterxml.jackson.annotation`
+ * (shared by Jackson 2 and 3), so generated code needs only the jackson-annotations
+ * runtime on its classpath — no imports are added and the IR stays language-neutral.
+ *
+ * Only the top-level model declarations of each [LanguageFile] are annotated;
+ * endpoint-internal structs live nested inside their endpoint `Namespace` and are
+ * left untouched. Register on a Kotlin
+ * [community.flock.wirespec.ir.emit.IrEmitter] built with `EmitShared(false)`, so
+ * the runtime classes come from the wirespec-jvm dependency rather than being
+ * re-emitted as source.
+ */
+class JacksonExtension : IrExtension {
+
+    override fun extend(ir: IR, ast: AST): IR {
+        val definitions = ast.modules.toList().flatMap { it.statements }
+        val recordNames = definitions
+            .filterIsInstance<TypeDefinition>()
+            .map { Name.of(it.identifier.value).pascalCase() }
+            .toSet()
+        return ir.map { element ->
+            if (element is LanguageFile) element.annotateJackson(recordNames) else element
+        }
+    }
+
+    private fun LanguageFile.annotateJackson(recordNames: Set<String>): LanguageFile = copy(
+        elements = elements.flatMap { element ->
+            when {
+                element is Struct && element.name.pascalCase() in recordNames ->
+                    listOf(element.annotateFields())
+                element is Union ->
+                    listOf(jsonTypeInfo, jsonSubTypes(element), element)
+                else ->
+                    listOf(element)
+            }
+        },
+    )
+
+    private fun Struct.annotateFields(): Struct = copy(
+        fields = fields.map { field ->
+            field.copy(annotations = field.annotations + jsonProperty(field.name.value()))
+        },
+    )
+
+    private companion object {
+        private const val ANNOTATION = "com.fasterxml.jackson.annotation"
+
+        fun jsonProperty(name: String) = "@$ANNOTATION.JsonProperty(\"$name\")"
+
+        val jsonTypeInfo = RawElement(
+            "@$ANNOTATION.JsonTypeInfo(" +
+                "use = $ANNOTATION.JsonTypeInfo.Id.NAME, " +
+                "include = $ANNOTATION.JsonTypeInfo.As.PROPERTY, " +
+                "property = \"type\")",
+        )
+
+        fun jsonSubTypes(union: Union): RawElement {
+            val types = union.members.joinToString(",\n") { member ->
+                val reference = member.name.referenceName()
+                "    $ANNOTATION.JsonSubTypes.Type(value = $reference::class, name = \"${member.name.pascalCase()}\")"
+            }
+            return RawElement("@$ANNOTATION.JsonSubTypes(\n$types,\n)")
+        }
+    }
+}

--- a/src/integration/jackson/src/jvmMain/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtension.kt
+++ b/src/integration/jackson/src/jvmMain/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtension.kt
@@ -1,6 +1,7 @@
 package community.flock.wirespec.integration.jackson.extension
 
 import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.ir.core.Field
 import community.flock.wirespec.ir.core.IR
 import community.flock.wirespec.ir.core.Name
 import community.flock.wirespec.ir.core.RawElement
@@ -16,40 +17,56 @@ import community.flock.wirespec.ir.core.File as LanguageFile
  *
  * - record fields get `@JsonProperty("<wirespec name>")`, preserving the original
  *   field name even when the emitter has to sanitize a reserved keyword.
- * - unions get `@JsonTypeInfo` + `@JsonSubTypes`, mapping each member type to its
- *   wirespec name so polymorphic values round-trip through a `type` discriminator.
+ * - unions get `@JsonTypeInfo(... property = "type")`, and each union member record
+ *   gets `@JsonTypeName("<wirespec name>")`, so polymorphic values round-trip through
+ *   a `type` discriminator. Subtypes are resolved from the sealed hierarchy that both
+ *   the Java (`permits`) and Kotlin (`sealed interface`) emitters generate.
  *
  * The annotations are emitted fully qualified against `com.fasterxml.jackson.annotation`
- * (shared by Jackson 2 and 3), so generated code needs only the jackson-annotations
- * runtime on its classpath — no imports are added and the IR stays language-neutral.
+ * (shared by Jackson 2 and 3) and use only syntax that is valid in **both** Java and
+ * Kotlin, so the same extension instance can be registered on either emitter. Field
+ * annotations are injected as [RawElement]s directly in front of the [Field] they
+ * annotate; the generators render any raw element that precedes a field as that field's
+ * annotation. No imports are added and the IR stays language-neutral.
  *
  * Only the top-level model declarations of each [LanguageFile] are annotated;
  * endpoint-internal structs live nested inside their endpoint `Namespace` and are
- * left untouched. Register on a Kotlin
- * [community.flock.wirespec.ir.emit.IrEmitter] built with `EmitShared(false)`, so
- * the runtime classes come from the wirespec-jvm dependency rather than being
- * re-emitted as source.
+ * left untouched. Register on a Java or Kotlin
+ * [community.flock.wirespec.ir.emit.IrEmitter] built with `EmitShared(false)`, so the
+ * runtime classes come from the wirespec-jvm dependency rather than being re-emitted as
+ * source.
  */
 class JacksonExtension : IrExtension {
 
     override fun extend(ir: IR, ast: AST): IR {
-        val definitions = ast.modules.toList().flatMap { it.statements }
-        val recordNames = definitions
+        val recordNames = ast.modules.toList()
+            .flatMap { it.statements }
             .filterIsInstance<TypeDefinition>()
             .map { Name.of(it.identifier.value).pascalCase() }
             .toSet()
+        val unionMemberNames = ir.filterIsInstance<LanguageFile>()
+            .flatMap { it.elements }
+            .filterIsInstance<Union>()
+            .flatMap { union -> union.members.map { it.name.pascalCase() } }
+            .toSet()
         return ir.map { element ->
-            if (element is LanguageFile) element.annotateJackson(recordNames) else element
+            if (element is LanguageFile) element.annotate(recordNames, unionMemberNames) else element
         }
     }
 
-    private fun LanguageFile.annotateJackson(recordNames: Set<String>): LanguageFile = copy(
+    private fun LanguageFile.annotate(recordNames: Set<String>, unionMemberNames: Set<String>): LanguageFile = copy(
         elements = elements.flatMap { element ->
             when {
-                element is Struct && element.name.pascalCase() in recordNames ->
-                    listOf(element.annotateFields())
                 element is Union ->
-                    listOf(jsonTypeInfo, jsonSubTypes(element), element)
+                    listOf(jsonTypeInfo, element)
+                element is Struct && element.name.pascalCase() in recordNames -> {
+                    val annotated = element.annotateFields()
+                    if (element.name.pascalCase() in unionMemberNames) {
+                        listOf(jsonTypeName(element.name.pascalCase()), annotated)
+                    } else {
+                        listOf(annotated)
+                    }
+                }
                 else ->
                     listOf(element)
             }
@@ -57,29 +74,23 @@ class JacksonExtension : IrExtension {
     )
 
     private fun Struct.annotateFields(): Struct = copy(
-        fields = fields.map { field ->
-            field.copy(annotations = field.annotations + jsonProperty(field.name.value()))
+        fields = fields.flatMap { field ->
+            if (field is Field) listOf(jsonProperty(field.name.value()), field) else listOf(field)
         },
     )
 
     private companion object {
         private const val ANNOTATION = "com.fasterxml.jackson.annotation"
 
-        fun jsonProperty(name: String) = "@$ANNOTATION.JsonProperty(\"$name\")"
+        fun jsonProperty(name: String) = RawElement("@$ANNOTATION.JsonProperty(\"$name\")")
 
         val jsonTypeInfo = RawElement(
             "@$ANNOTATION.JsonTypeInfo(" +
                 "use = $ANNOTATION.JsonTypeInfo.Id.NAME, " +
                 "include = $ANNOTATION.JsonTypeInfo.As.PROPERTY, " +
-                "property = \"type\")",
+                "property = \"type\")\n",
         )
 
-        fun jsonSubTypes(union: Union): RawElement {
-            val types = union.members.joinToString(",\n") { member ->
-                val reference = member.name.referenceName()
-                "    $ANNOTATION.JsonSubTypes.Type(value = $reference::class, name = \"${member.name.pascalCase()}\")"
-            }
-            return RawElement("@$ANNOTATION.JsonSubTypes(\n$types,\n)")
-        }
+        fun jsonTypeName(name: String) = RawElement("@$ANNOTATION.JsonTypeName(\"$name\")\n")
     }
 }

--- a/src/integration/jackson/src/jvmMain/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtension.kt
+++ b/src/integration/jackson/src/jvmMain/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtension.kt
@@ -56,26 +56,24 @@ class JacksonExtension : IrExtension {
 
     private fun LanguageFile.annotate(recordNames: Set<String>, unionMemberNames: Set<String>): LanguageFile = copy(
         elements = elements.flatMap { element ->
-            when {
-                element is Union ->
-                    listOf(jsonTypeInfo, element)
-                element is Struct && element.name.pascalCase() in recordNames -> {
-                    val annotated = element.annotateFields()
-                    if (element.name.pascalCase() in unionMemberNames) {
-                        listOf(jsonTypeName(element.name.pascalCase()), annotated)
-                    } else {
-                        listOf(annotated)
+            when (element) {
+                is Union -> listOf(jsonTypeInfo, element)
+                is Struct -> {
+                    val pascal = element.name.pascalCase()
+                    when {
+                        pascal !in recordNames -> listOf(element)
+                        pascal in unionMemberNames -> listOf(jsonTypeName(pascal), element.annotateFields())
+                        else -> listOf(element.annotateFields())
                     }
                 }
-                else ->
-                    listOf(element)
+                else -> listOf(element)
             }
         },
     )
 
     private fun Struct.annotateFields(): Struct = copy(
-        fields = fields.flatMap { field ->
-            if (field is Field) listOf(jsonProperty(field.name.value()), field) else listOf(field)
+        fields = fields.flatMap { element ->
+            if (element is Field) listOf(jsonProperty(element.name.value()), element) else listOf(element)
         },
     )
 

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtensionTest.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtensionTest.kt
@@ -1,0 +1,104 @@
+package community.flock.wirespec.integration.jackson.extension
+
+import arrow.core.nonEmptyListOf
+import community.flock.wirespec.compiler.core.FileUri
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.core.ParseContext
+import community.flock.wirespec.compiler.core.WirespecSpec
+import community.flock.wirespec.compiler.core.emit.EmitShared
+import community.flock.wirespec.compiler.core.emit.PackageName
+import community.flock.wirespec.compiler.core.parse
+import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.compiler.utils.NoLogger
+import community.flock.wirespec.compiler.utils.noLogger
+import community.flock.wirespec.emitters.kotlin.KotlinIrEmitter
+import community.flock.wirespec.ir.extension.applyExtensions
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+class JacksonExtensionTest {
+
+    private fun parse(source: String): AST = object : ParseContext, NoLogger {
+        override val spec = WirespecSpec
+    }.parse(nonEmptyListOf(ModuleContent(FileUri(""), source))).getOrNull() ?: error("Parsing failed.")
+
+    private fun jacksonEmitter(packageName: PackageName) = KotlinIrEmitter(packageName, EmitShared(false))
+        .applyExtensions(listOf(JacksonExtension()))
+
+    private val source =
+        """
+        |type Todo {
+        |  id: TodoId,
+        |  name: String
+        |}
+        |type TodoId = String(/^[0-9]+${'$'}/g)
+        |type UserAccount = UserAccountPassword | UserAccountToken
+        |type UserAccountPassword {
+        |  username: String,
+        |  password: String
+        |}
+        |type UserAccountToken {
+        |  token: String
+        |}
+        |enum Color { Red, Green, Blue }
+        """.trimMargin()
+
+    private fun emit() = jacksonEmitter(PackageName("community.flock.wirespec.generated"))
+        .emit(parse(source), noLogger)
+
+    @Test
+    fun `Should annotate record fields with JsonProperty`() {
+        val todo = emit().single { it.file.endsWith("Todo.kt") }.result
+
+        assertContains(todo, """@com.fasterxml.jackson.annotation.JsonProperty("id") val id: TodoId""")
+        assertContains(todo, """@com.fasterxml.jackson.annotation.JsonProperty("name") val name: String""")
+    }
+
+    @Test
+    fun `Should annotate unions with JsonTypeInfo and JsonSubTypes`() {
+        val union = emit().single { it.file.endsWith("UserAccount.kt") }.result
+
+        assertContains(union, "@com.fasterxml.jackson.annotation.JsonTypeInfo(")
+        assertContains(union, """property = "type")""")
+        assertContains(union, "@com.fasterxml.jackson.annotation.JsonSubTypes(")
+        assertContains(
+            union,
+            """com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = UserAccountPassword::class, name = "UserAccountPassword")""",
+        )
+        assertContains(
+            union,
+            """com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = UserAccountToken::class, name = "UserAccountToken")""",
+        )
+        // The annotations precede the declaration they belong to.
+        assertContains(union, "sealed interface UserAccount")
+    }
+
+    @Test
+    fun `Should annotate union member records with JsonProperty`() {
+        val member = emit().single { it.file.endsWith("UserAccountPassword.kt") }.result
+
+        assertContains(member, """@com.fasterxml.jackson.annotation.JsonProperty("username") val username: String""")
+        assertContains(member, """@com.fasterxml.jackson.annotation.JsonProperty("password") val password: String""")
+    }
+
+    @Test
+    fun `Should not annotate enums`() {
+        val color = emit().single { it.file.endsWith("Color.kt") }.result
+
+        assertFalse(
+            "com.fasterxml.jackson.annotation" in color,
+            "Enums should not receive Jackson annotations",
+        )
+    }
+
+    @Test
+    fun `Should not annotate the generated generator objects`() {
+        val generator = emit().single { it.file.endsWith("TodoGenerator.kt") }.result
+
+        assertFalse(
+            "com.fasterxml.jackson.annotation" in generator,
+            "Generator helper objects are not models and must not be annotated",
+        )
+    }
+}

--- a/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtensionTest.kt
+++ b/src/integration/jackson/src/jvmTest/kotlin/community/flock/wirespec/integration/jackson/extension/JacksonExtensionTest.kt
@@ -6,11 +6,13 @@ import community.flock.wirespec.compiler.core.ModuleContent
 import community.flock.wirespec.compiler.core.ParseContext
 import community.flock.wirespec.compiler.core.WirespecSpec
 import community.flock.wirespec.compiler.core.emit.EmitShared
+import community.flock.wirespec.compiler.core.emit.Emitter
 import community.flock.wirespec.compiler.core.emit.PackageName
 import community.flock.wirespec.compiler.core.parse
 import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.utils.NoLogger
 import community.flock.wirespec.compiler.utils.noLogger
+import community.flock.wirespec.emitters.java.JavaIrEmitter
 import community.flock.wirespec.emitters.kotlin.KotlinIrEmitter
 import community.flock.wirespec.ir.extension.applyExtensions
 import kotlin.test.Test
@@ -22,9 +24,6 @@ class JacksonExtensionTest {
     private fun parse(source: String): AST = object : ParseContext, NoLogger {
         override val spec = WirespecSpec
     }.parse(nonEmptyListOf(ModuleContent(FileUri(""), source))).getOrNull() ?: error("Parsing failed.")
-
-    private fun jacksonEmitter(packageName: PackageName) = KotlinIrEmitter(packageName, EmitShared(false))
-        .applyExtensions(listOf(JacksonExtension()))
 
     private val source =
         """
@@ -44,61 +43,70 @@ class JacksonExtensionTest {
         |enum Color { Red, Green, Blue }
         """.trimMargin()
 
-    private fun emit() = jacksonEmitter(PackageName("community.flock.wirespec.generated"))
+    private fun emit(emitter: Emitter) = emitter
+        .applyExtensions(listOf(JacksonExtension()))
         .emit(parse(source), noLogger)
 
-    @Test
-    fun `Should annotate record fields with JsonProperty`() {
-        val todo = emit().single { it.file.endsWith("Todo.kt") }.result
+    private fun kotlin() = emit(KotlinIrEmitter(PackageName("community.flock.wirespec.generated"), EmitShared(false)))
+    private fun java() = emit(JavaIrEmitter(PackageName("community.flock.wirespec.generated"), EmitShared(false)))
 
+    private fun List<community.flock.wirespec.compiler.core.emit.Emitted>.file(suffix: String) = single { it.file.endsWith(suffix) }.result
+
+    // ----- Kotlin -----
+
+    @Test
+    fun `Kotlin record fields get JsonProperty`() {
+        val todo = kotlin().file("Todo.kt")
         assertContains(todo, """@com.fasterxml.jackson.annotation.JsonProperty("id") val id: TodoId""")
         assertContains(todo, """@com.fasterxml.jackson.annotation.JsonProperty("name") val name: String""")
     }
 
     @Test
-    fun `Should annotate unions with JsonTypeInfo and JsonSubTypes`() {
-        val union = emit().single { it.file.endsWith("UserAccount.kt") }.result
-
+    fun `Kotlin unions get JsonTypeInfo`() {
+        val union = kotlin().file("UserAccount.kt")
         assertContains(union, "@com.fasterxml.jackson.annotation.JsonTypeInfo(")
         assertContains(union, """property = "type")""")
-        assertContains(union, "@com.fasterxml.jackson.annotation.JsonSubTypes(")
-        assertContains(
-            union,
-            """com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = UserAccountPassword::class, name = "UserAccountPassword")""",
-        )
-        assertContains(
-            union,
-            """com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = UserAccountToken::class, name = "UserAccountToken")""",
-        )
-        // The annotations precede the declaration they belong to.
         assertContains(union, "sealed interface UserAccount")
     }
 
     @Test
-    fun `Should annotate union member records with JsonProperty`() {
-        val member = emit().single { it.file.endsWith("UserAccountPassword.kt") }.result
-
+    fun `Kotlin union members get JsonTypeName and JsonProperty`() {
+        val member = kotlin().file("UserAccountPassword.kt")
+        assertContains(member, """@com.fasterxml.jackson.annotation.JsonTypeName("UserAccountPassword")""")
         assertContains(member, """@com.fasterxml.jackson.annotation.JsonProperty("username") val username: String""")
-        assertContains(member, """@com.fasterxml.jackson.annotation.JsonProperty("password") val password: String""")
     }
 
     @Test
-    fun `Should not annotate enums`() {
-        val color = emit().single { it.file.endsWith("Color.kt") }.result
+    fun `Kotlin enums are not annotated`() {
+        assertFalse("com.fasterxml.jackson.annotation" in kotlin().file("Color.kt"))
+    }
 
-        assertFalse(
-            "com.fasterxml.jackson.annotation" in color,
-            "Enums should not receive Jackson annotations",
-        )
+    // ----- Java -----
+
+    @Test
+    fun `Java record fields get JsonProperty`() {
+        val todo = java().file("Todo.java")
+        assertContains(todo, """@com.fasterxml.jackson.annotation.JsonProperty("id") TodoId id""")
+        assertContains(todo, """@com.fasterxml.jackson.annotation.JsonProperty("name") String name""")
     }
 
     @Test
-    fun `Should not annotate the generated generator objects`() {
-        val generator = emit().single { it.file.endsWith("TodoGenerator.kt") }.result
+    fun `Java unions get JsonTypeInfo`() {
+        val union = java().file("UserAccount.java")
+        assertContains(union, "@com.fasterxml.jackson.annotation.JsonTypeInfo(")
+        assertContains(union, """property = "type")""")
+        assertContains(union, "sealed interface UserAccount")
+    }
 
-        assertFalse(
-            "com.fasterxml.jackson.annotation" in generator,
-            "Generator helper objects are not models and must not be annotated",
-        )
+    @Test
+    fun `Java union members get JsonTypeName and JsonProperty`() {
+        val member = java().file("UserAccountPassword.java")
+        assertContains(member, """@com.fasterxml.jackson.annotation.JsonTypeName("UserAccountPassword")""")
+        assertContains(member, """@com.fasterxml.jackson.annotation.JsonProperty("username") String username""")
+    }
+
+    @Test
+    fun `Java enums are not annotated`() {
+        assertFalse("com.fasterxml.jackson.annotation" in java().file("Color.java"))
     }
 }

--- a/src/site/docs/docs/integration/integration-jackson.mdx
+++ b/src/site/docs/docs/integration/integration-jackson.mdx
@@ -98,12 +98,14 @@ annotations directly into the generated code. This integration ships an
 [IR extension](../plugins/plugins.md#ir-extensions) that adds the annotations during compilation, so
 polymorphic `union` types round-trip without any extra mapper configuration.
 
-The extension annotates the top-level model declarations of each generated Kotlin file:
+The extension annotates the top-level model declarations of each generated file:
 
 - record fields get `@JsonProperty("<wirespec name>")`, preserving the original field name even when the
   emitter has to sanitize a reserved keyword.
-- `union` types get `@JsonTypeInfo` and `@JsonSubTypes`, mapping each member to its wirespec name through a
-  `type` discriminator.
+- `union` types get `@JsonTypeInfo(... property = "type")`, and each union member gets
+  `@JsonTypeName("<wirespec name>")`, so polymorphic values round-trip through a `type` discriminator.
+  Subtypes are resolved from the sealed hierarchy that the Java (`permits`) and Kotlin (`sealed interface`)
+  emitters generate.
 
 For example, this definition:
 
@@ -115,7 +117,8 @@ type Todo {
 type UserAccount = UserAccountPassword | UserAccountToken
 ```
 
-is emitted as:
+is emitted as (Kotlin shown; the Java emitter produces the same annotations on records and the sealed
+interface):
 
 ```kotlin
 data class Todo(
@@ -124,24 +127,23 @@ data class Todo(
 )
 
 @com.fasterxml.jackson.annotation.JsonTypeInfo(use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME, include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY, property = "type")
-@com.fasterxml.jackson.annotation.JsonSubTypes(
-    com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = UserAccountPassword::class, name = "UserAccountPassword"),
-    com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = UserAccountToken::class, name = "UserAccountToken"),
-)
 sealed interface UserAccount
+
+@com.fasterxml.jackson.annotation.JsonTypeName("UserAccountPassword")
+data class UserAccountPassword(/* ... */)
 ```
 
 The annotations are emitted fully qualified against `com.fasterxml.jackson.annotation` (shared by Jackson 2
-and 3), so the generated code stays dependency-free apart from the jackson-annotations runtime — no imports
-are added.
+and 3) and use only syntax that is valid in **both Java and Kotlin**, so the generated code stays
+dependency-free apart from the jackson-annotations runtime — no imports are added.
 
 :::note
 Endpoint-internal structs (the `Path`, `Request`, `Response` types nested inside an endpoint) are left
 untouched; only the top-level models are annotated.
 :::
 
-The extension applies to the **Kotlin** target only, and runs as part of the IR pipeline. Enable the IR
-pipeline (`ir = true`) and disable shared-code emission (`shared = false`) so the Wirespec runtime classes
+The extension works for the **Java** and **Kotlin** targets and runs as part of the IR pipeline. Enable the
+IR pipeline (`ir = true`) and disable shared-code emission (`shared = false`) so the Wirespec runtime classes
 come from the `wirespec-jvm` dependency, then register `JacksonExtension` via `irExtensions`.
 
 <Tabs>
@@ -159,7 +161,8 @@ come from the `wirespec-jvm` dependency, then register `JacksonExtension` via `i
     tasks.register<CompileWirespecTask>("wirespec-compile") {
         input = layout.projectDirectory.dir("src/main/wirespec")
         output = layout.buildDirectory.dir("generated")
-        packageName = "community.flock.wirespec.generated.kotlin"
+        packageName = "community.flock.wirespec.generated"
+        // Works for both Java and Kotlin
         languages = listOf(Language.Kotlin)
         ir = true
         shared = false
@@ -182,7 +185,7 @@ come from the `wirespec-jvm` dependency, then register `JacksonExtension` via `i
         </dependencies>
         <executions>
             <execution>
-                <id>kotlin</id>
+                <id>generate</id>
                 <goals>
                     <goal>compile</goal>
                 </goals>
@@ -190,6 +193,7 @@ come from the `wirespec-jvm` dependency, then register `JacksonExtension` via `i
                     <input>${project.basedir}/src/main/wirespec</input>
                     <output>${project.build.directory}/generated-sources</output>
                     <languages>
+                        <!-- Works for both Java and Kotlin -->
                         <language>Kotlin</language>
                     </languages>
                     <ir>true</ir>

--- a/src/site/docs/docs/integration/integration-jackson.mdx
+++ b/src/site/docs/docs/integration/integration-jackson.mdx
@@ -91,6 +91,120 @@ imports accordingly.
   </TabItem>
 </Tabs>
 
+## Annotating generated models
+
+Instead of (or in addition to) registering the runtime module, you can let Wirespec write the Jackson
+annotations directly into the generated code. This integration ships an
+[IR extension](../plugins/plugins.md#ir-extensions) that adds the annotations during compilation, so
+polymorphic `union` types round-trip without any extra mapper configuration.
+
+The extension annotates the top-level model declarations of each generated Kotlin file:
+
+- record fields get `@JsonProperty("<wirespec name>")`, preserving the original field name even when the
+  emitter has to sanitize a reserved keyword.
+- `union` types get `@JsonTypeInfo` and `@JsonSubTypes`, mapping each member to its wirespec name through a
+  `type` discriminator.
+
+For example, this definition:
+
+```wirespec
+type Todo {
+  id: TodoId,
+  name: String
+}
+type UserAccount = UserAccountPassword | UserAccountToken
+```
+
+is emitted as:
+
+```kotlin
+data class Todo(
+  @com.fasterxml.jackson.annotation.JsonProperty("id") val id: TodoId,
+  @com.fasterxml.jackson.annotation.JsonProperty("name") val name: String,
+)
+
+@com.fasterxml.jackson.annotation.JsonTypeInfo(use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME, include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY, property = "type")
+@com.fasterxml.jackson.annotation.JsonSubTypes(
+    com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = UserAccountPassword::class, name = "UserAccountPassword"),
+    com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = UserAccountToken::class, name = "UserAccountToken"),
+)
+sealed interface UserAccount
+```
+
+The annotations are emitted fully qualified against `com.fasterxml.jackson.annotation` (shared by Jackson 2
+and 3), so the generated code stays dependency-free apart from the jackson-annotations runtime — no imports
+are added.
+
+:::note
+Endpoint-internal structs (the `Path`, `Request`, `Response` types nested inside an endpoint) are left
+untouched; only the top-level models are annotated.
+:::
+
+The extension applies to the **Kotlin** target only, and runs as part of the IR pipeline. Enable the IR
+pipeline (`ir = true`) and disable shared-code emission (`shared = false`) so the Wirespec runtime classes
+come from the `wirespec-jvm` dependency, then register `JacksonExtension` via `irExtensions`.
+
+<Tabs>
+  <TabItem value="gradle" label="Gradle">
+    ```gradle title="build.gradle.kts"
+    import community.flock.wirespec.integration.jackson.extension.JacksonExtension
+    import community.flock.wirespec.plugin.Language
+
+    buildscript {
+        dependencies {
+            classpath("community.flock.wirespec.integration:jackson:{{WIRESPEC_VERSION}}")
+        }
+    }
+
+    tasks.register<CompileWirespecTask>("wirespec-compile") {
+        input = layout.projectDirectory.dir("src/main/wirespec")
+        output = layout.buildDirectory.dir("generated")
+        packageName = "community.flock.wirespec.generated.kotlin"
+        languages = listOf(Language.Kotlin)
+        ir = true
+        shared = false
+        irExtensions = listOf(JacksonExtension::class.java)
+    }
+    ```
+  </TabItem>
+  <TabItem value="maven" label="Maven">
+    ```xml title="pom.xml"
+    <plugin>
+        <groupId>community.flock.wirespec.plugin.maven</groupId>
+        <artifactId>wirespec-maven-plugin</artifactId>
+        <version>{{WIRESPEC_VERSION}}</version>
+        <dependencies>
+            <dependency>
+                <groupId>community.flock.wirespec.integration</groupId>
+                <artifactId>jackson</artifactId>
+                <version>{{WIRESPEC_VERSION}}</version>
+            </dependency>
+        </dependencies>
+        <executions>
+            <execution>
+                <id>kotlin</id>
+                <goals>
+                    <goal>compile</goal>
+                </goals>
+                <configuration>
+                    <input>${project.basedir}/src/main/wirespec</input>
+                    <output>${project.build.directory}/generated-sources</output>
+                    <languages>
+                        <language>Kotlin</language>
+                    </languages>
+                    <ir>true</ir>
+                    <shared>false</shared>
+                    <irExtensions>
+                        <irExtension>community.flock.wirespec.integration.jackson.extension.JacksonExtension</irExtension>
+                    </irExtensions>
+                </configuration>
+            </execution>
+        </executions>
+    </plugin>
+    ```
+  </TabItem>
+</Tabs>
+
 ---
 
 :::note


### PR DESCRIPTION
## Description

This PR adds a new `JacksonExtension` IR extension that automatically annotates generated Java and Kotlin models with Jackson serialization annotations, enabling polymorphic types to round-trip without manual mapper configuration.

The extension:
- Adds `@JsonProperty("<wirespec name>")` to all record fields, preserving original field names even when sanitized for reserved keywords
- Adds `@JsonTypeInfo(... property = "type")` to union types and `@JsonTypeName("<wirespec name>")` to union members, enabling polymorphic deserialization via a `type` discriminator
- Uses fully qualified annotations (`com.fasterxml.jackson.annotation.*`) compatible with both Jackson 2 and 3
- Generates syntax valid in both Java and Kotlin, keeping generated code dependency-free (only jackson-annotations runtime is required)
- Only annotates top-level model declarations; endpoint-internal structs are left untouched

### Implementation Details

The extension works by:
1. Injecting `RawElement` annotation nodes directly before `Field` elements in struct parameter lists
2. Injecting `RawElement` annotation nodes before union type declarations
3. Leveraging the updated `Struct.fields` type (now `List<Element>` instead of `List<Field>`) to allow mixed field and annotation elements
4. Updating Java and Kotlin code generators to handle `RawElement` annotations that precede fields

The `Struct.fieldList` helper property provides backward compatibility for code that needs only the actual field declarations.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist

- [x] I have followed the contribution guidelines
- [x] I have written tests for my changes
- [x] I have updated the documentation if necessary
- [x] I have written code in a functional style (using Arrow where appropriate)

## Breaking Changes

The `Struct.fields` property type changed from `List<Field>` to `List<Element>` to support IR extensions that inject annotations. Code accessing struct fields should use the new `Struct.fieldList` helper property to filter out non-field elements. All existing code in the codebase has been updated to use this helper.

https://claude.ai/code/session_01AEWvdg9LmYam3uU4vCe2Ko