### PR TITLE
Add Avro schema support to playground converter

### DIFF
--- a/src/site/playground/src/components/SpecificationSelector.tsx
+++ b/src/site/playground/src/components/SpecificationSelector.tsx
@@ -9,6 +9,7 @@ export function SpecificationSelector() {
   const convertOptions: CompileOption[] = [
     { value: "open_api_v2", label: "Open API v2" },
     { value: "open_api_v3", label: "Open API v3" },
+    { value: "avro", label: "Avro" },
   ];
 
   const navigate = useNavigate({ from: "/" });

--- a/src/site/playground/src/examples/avro.tsx
+++ b/src/site/playground/src/examples/avro.tsx
@@ -1,0 +1,22 @@
+export const avroExample = `{
+  "type": "record",
+  "namespace": "com.example",
+  "name": "Customer",
+  "fields": [
+    { "name": "first_name", "type": "string", "doc": "First Name of Customer" },
+    { "name": "last_name", "type": "string", "doc": "Last Name of Customer" },
+    { "name": "age", "type": "int", "doc": "Age at the time of registration" },
+    { "name": "height", "type": "float", "doc": "Height at the time of registration in cm" },
+    { "name": "weight", "type": "float", "doc": "Weight at the time of registration in kg" },
+    { "name": "automated_email", "type": "boolean", "default": true, "doc": "Field indicating if the user is enrolled in marketing emails" },
+    { "name": "address",  "doc": "Address", "type": {
+      "name": "Address",
+      "type": "record",
+      "fields": [
+        { "name": "street", "type": "string", "doc": "Street" },
+        { "name": "zipcode", "type": "string", "doc": "Zipcode" }
+      ]}
+    }
+  ]
+}
+`;

--- a/src/site/playground/src/routes/index.tsx
+++ b/src/site/playground/src/routes/index.tsx
@@ -17,11 +17,13 @@ import { swaggerExample } from "../examples/swagger";
 import {
   openApiV2ToWirespec,
   openApiV3ToWirespec,
+  avroToWirespec,
 } from "../transformations/OpenAPIToWirespec";
 import { openapiExample } from "../examples/openapi";
+import { avroExample } from "../examples/avro";
 
 type CompileSpecification = "wirespec";
-type ConvertSpecification = "open_api_v2" | "open_api_v3";
+type ConvertSpecification = "open_api_v2" | "open_api_v3" | "avro";
 
 export type Specification = CompileSpecification | ConvertSpecification;
 
@@ -108,7 +110,9 @@ function RouteComponent() {
     try {
       const json = JSON.parse(code);
 
-      if (json.swagger) {
+      if (specification === "avro") {
+        setWirespecOutput(avroToWirespec(code));
+      } else if (json.swagger) {
         setWirespecOutput(openApiV2ToWirespec(code));
       } else if (json.openapi) {
         setWirespecOutput(openApiV3ToWirespec(code));
@@ -151,6 +155,8 @@ function RouteComponent() {
         return setCode(swaggerExample);
       case "open_api_v3":
         return setCode(openapiExample);
+      case "avro":
+        return setCode(avroExample);
     }
   }, [specification]);
 


### PR DESCRIPTION
## Description

This PR adds Apache Avro schema support to the Wirespec playground, enabling users to convert Avro schemas to Wirespec format alongside existing OpenAPI v2/v3 converters.

### Changes

- **New Avro example** (`src/site/playground/src/examples/avro.tsx`): Added a comprehensive example Avro schema demonstrating a `Customer` record with nested `Address` type, including various field types (string, int, float, boolean) and documentation.

- **Updated route handler** (`src/site/playground/src/routes/index.tsx`):
  - Added `avro` to the `ConvertSpecification` type union
  - Imported `avroToWirespec` transformation function and `avroExample`
  - Added conditional logic to detect and handle Avro schemas in the conversion pipeline
  - Added case handler to load the Avro example when selected

- **Updated UI selector** (`src/site/playground/src/components/SpecificationSelector.tsx`): Added "Avro" option to the specification dropdown menu

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
- [x] I have followed the contribution guidelines
- [ ] I have written tests for my changes
- [x] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Notes

The actual `avroToWirespec` transformation function is imported from `../transformations/OpenAPIToWirespec` but not shown in this diff, indicating it was implemented separately. This PR focuses on integrating the Avro converter into the playground UI and routing logic.

https://claude.ai/code/session_01S99jonug5NZ716GG7A4Hv7