### PR TITLE
Make response status/headers fixed members in generated code

### DIFF
--- a/src/compiler/emitters/java/fixtures/compileFullEndpointTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileFullEndpointTest.txt
@@ -45,12 +45,13 @@ public interface PutTodo extends Wirespec.Endpoint {
   public static record Response200Headers () implements Wirespec.Response.Headers {
   };
   public static record Response200 (
-    Integer status,
-    Response200Headers headers,
     TodoDto body
   ) implements Response2XX<TodoDto>, ResponseTodoDto {
-    public Response200(TodoDto body) {
-      this(200, new Response200Headers(), body);
+    public Integer status() {
+      return 200;
+    }
+    public Response200Headers headers() {
+      return new Response200Headers();
     }
   };
   public static record Response201Headers (
@@ -59,26 +60,30 @@ public interface PutTodo extends Wirespec.Endpoint {
   ) implements Wirespec.Response.Headers {
   };
   public static record Response201 (
-    Integer status,
-    Response201Headers headers,
+    Token token,
+    java.util.Optional<Token> refreshToken,
     TodoDto body
   ) implements Response2XX<TodoDto>, ResponseTodoDto {
-    public Response201(Token token, java.util.Optional<Token> refreshToken, TodoDto body) {
-      this(201, new Response201Headers(
+    public Integer status() {
+      return 201;
+    }
+    public Response201Headers headers() {
+      return new Response201Headers(
         token,
         refreshToken
-      ), body);
+      );
     }
   };
   public static record Response500Headers () implements Wirespec.Response.Headers {
   };
   public static record Response500 (
-    Integer status,
-    Response500Headers headers,
     Error body
   ) implements Response5XX<Error>, ResponseError {
-    public Response500(Error body) {
-      this(500, new Response500Headers(), body);
+    public Integer status() {
+      return 500;
+    }
+    public Response500Headers headers() {
+      return new Response500Headers();
     }
   };
   public static Wirespec.RawRequest toRawRequest(Wirespec.Serializer serialization, Request request) {

--- a/src/compiler/emitters/java/fixtures/compileMinimalEndpointTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileMinimalEndpointTest.txt
@@ -25,12 +25,13 @@ public interface GetTodos extends Wirespec.Endpoint {
   public static record Response200Headers () implements Wirespec.Response.Headers {
   };
   public static record Response200 (
-    Integer status,
-    Response200Headers headers,
     java.util.List<TodoDto> body
   ) implements Response2XX<java.util.List<TodoDto>>, ResponseListTodoDto {
-    public Response200(java.util.List<TodoDto> body) {
-      this(200, new Response200Headers(), body);
+    public Integer status() {
+      return 200;
+    }
+    public Response200Headers headers() {
+      return new Response200Headers();
     }
   };
   public static Wirespec.RawRequest toRawRequest(Wirespec.Serializer serialization, Request request) {

--- a/src/compiler/emitters/kotlin/fixtures/compileFullEndpointTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileFullEndpointTest.txt
@@ -39,33 +39,32 @@ object PutTodo : Wirespec.Endpoint {
   sealed interface ResponseError : Response<Error>
   object Response200Headers : Wirespec.Response.Headers
   data class Response200(
-      override val status: Int,
-      override val headers: Response200Headers,
       override val body: TodoDto
     ) : Response2XX<TodoDto>, ResponseTodoDto {
-      constructor(body: TodoDto) : this(200, Response200Headers, body)
+      override val status: Int = 200
+      override val headers: Response200Headers = Response200Headers
     }
   data class Response201Headers(
       val token: Token,
       val refreshToken: Token?
     ) : Wirespec.Response.Headers
   data class Response201(
-      override val status: Int,
-      override val headers: Response201Headers,
+      val token: Token,
+      val refreshToken: Token?,
       override val body: TodoDto
     ) : Response2XX<TodoDto>, ResponseTodoDto {
-      constructor(token: Token, refreshToken: Token?, body: TodoDto) : this(201, Response201Headers(
+      override val status: Int = 201
+      override val headers: Response201Headers = Response201Headers(
         token = token,
         refreshToken = refreshToken
-      ), body)
+      )
     }
   object Response500Headers : Wirespec.Response.Headers
   data class Response500(
-      override val status: Int,
-      override val headers: Response500Headers,
       override val body: Error
     ) : Response5XX<Error>, ResponseError {
-      constructor(body: Error) : this(500, Response500Headers, body)
+      override val status: Int = 500
+      override val headers: Response500Headers = Response500Headers
     }
   fun toRawRequest(serialization: Wirespec.Serializer, request: Request): Wirespec.RawRequest =
     Wirespec.RawRequest(

--- a/src/compiler/emitters/kotlin/fixtures/compileMinimalEndpointTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileMinimalEndpointTest.txt
@@ -17,11 +17,10 @@ object GetTodos : Wirespec.Endpoint {
   sealed interface ResponseListTodoDto : Response<List<TodoDto>>
   object Response200Headers : Wirespec.Response.Headers
   data class Response200(
-      override val status: Int,
-      override val headers: Response200Headers,
       override val body: List<TodoDto>
     ) : Response2XX<List<TodoDto>>, ResponseListTodoDto {
-      constructor(body: List<TodoDto>) : this(200, Response200Headers, body)
+      override val status: Int = 200
+      override val headers: Response200Headers = Response200Headers
     }
   fun toRawRequest(serialization: Wirespec.Serializer, request: Request): Wirespec.RawRequest =
     Wirespec.RawRequest(

--- a/src/compiler/emitters/rust/fixtures/compileFullEndpointTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileFullEndpointTest.txt
@@ -120,8 +120,8 @@ pub enum ResponseError {
 pub struct Response200Headers;
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Response200 {
-    pub status: i32,
-    pub headers: Response200Headers,
+    status: i32,
+    headers: Response200Headers,
     pub body: TodoDto,
 }
 impl Response200 {
@@ -140,8 +140,8 @@ pub struct Response201Headers {
 }
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Response201 {
-    pub status: i32,
-    pub headers: Response201Headers,
+    status: i32,
+    headers: Response201Headers,
     pub body: TodoDto,
 }
 impl Response201 {
@@ -157,8 +157,8 @@ impl Response201 {
 pub struct Response500Headers;
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Response500 {
-    pub status: i32,
-    pub headers: Response500Headers,
+    status: i32,
+    headers: Response500Headers,
     pub body: Error,
 }
 impl Response500 {

--- a/src/compiler/emitters/rust/fixtures/compileMinimalEndpointTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileMinimalEndpointTest.txt
@@ -55,8 +55,8 @@ pub enum ResponseListTodoDto {
 pub struct Response200Headers;
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Response200 {
-    pub status: i32,
-    pub headers: Response200Headers,
+    status: i32,
+    headers: Response200Headers,
     pub body: Vec<TodoDto>,
 }
 impl Response200 {

--- a/src/compiler/emitters/scala/fixtures/compileFullEndpointTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileFullEndpointTest.txt
@@ -39,33 +39,32 @@ object PutTodo extends Wirespec.Endpoint {
   sealed trait ResponseError extends Response[Error]
   object Response200Headers extends Wirespec.Response.Headers
   case class Response200(
-      override val status: Int,
-      override val headers: Response200Headers.type,
       override val body: TodoDto
     ) extends Response2XX[TodoDto] with ResponseTodoDto {
-      def this(body: TodoDto) = this(200, Response200Headers, body)
+      override val status: Int = 200
+      override val headers: Response200Headers.type = Response200Headers
     }
   case class Response201Headers(
       val token: Token,
       val refreshToken: Option[Token]
     ) extends Wirespec.Response.Headers
   case class Response201(
-      override val status: Int,
-      override val headers: Response201Headers,
+      val token: Token,
+      val refreshToken: Option[Token],
       override val body: TodoDto
     ) extends Response2XX[TodoDto] with ResponseTodoDto {
-      def this(token: Token, refreshToken: Option[Token], body: TodoDto) = this(201, Response201Headers(
+      override val status: Int = 201
+      override val headers: Response201Headers = Response201Headers(
         token = token,
         refreshToken = refreshToken
-      ), body)
+      )
     }
   object Response500Headers extends Wirespec.Response.Headers
   case class Response500(
-      override val status: Int,
-      override val headers: Response500Headers.type,
       override val body: Error
     ) extends Response5XX[Error] with ResponseError {
-      def this(body: Error) = this(500, Response500Headers, body)
+      override val status: Int = 500
+      override val headers: Response500Headers.type = Response500Headers
     }
   def toRawRequest(serialization: Wirespec.Serializer, request: Request): Wirespec.RawRequest =
     new Wirespec.RawRequest(

--- a/src/compiler/emitters/scala/fixtures/compileMinimalEndpointTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileMinimalEndpointTest.txt
@@ -17,11 +17,10 @@ object GetTodos extends Wirespec.Endpoint {
   sealed trait ResponseListTodoDto extends Response[List[TodoDto]]
   object Response200Headers extends Wirespec.Response.Headers
   case class Response200(
-      override val status: Int,
-      override val headers: Response200Headers.type,
       override val body: List[TodoDto]
     ) extends Response2XX[List[TodoDto]] with ResponseListTodoDto {
-      def this(body: List[TodoDto]) = this(200, Response200Headers, body)
+      override val status: Int = 200
+      override val headers: Response200Headers.type = Response200Headers
     }
   def toRawRequest(serialization: Wirespec.Serializer, request: Request.type): Wirespec.RawRequest =
     new Wirespec.RawRequest(

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -720,9 +720,29 @@ fun EndpointWirespec.convert(): File {
                 struct("Response$statusClassName") {
                     implements(type("Response${statusPrefix}XX", bodyType))
                     implements(type("Response$contentTypeName"))
-                    field("status", Type.IntegerLiteral(statusCode), isOverride = true)
-                    field("headers", type(headersName), isOverride = true)
-                    field("body", bodyType, isOverride = true)
+                    // status and headers are fixed/derived members: they carry an initializer so
+                    // emitters render them as non-settable members instead of constructor inputs.
+                    field(
+                        "status",
+                        Type.IntegerLiteral(statusCode),
+                        isOverride = true,
+                        initializer = Literal(statusCode, Type.Integer(Precision.P32)),
+                    )
+                    field(
+                        "headers",
+                        type(headersName),
+                        isOverride = true,
+                        initializer = construct(type(headersName)) {
+                            response.headers.forEach {
+                                arg(it.identifier.toName(), VariableReference(it.identifier.toName()))
+                            }
+                        },
+                    )
+                    if (response.content != null) {
+                        field("body", bodyType, isOverride = true)
+                    } else {
+                        field("body", bodyType, isOverride = true, initializer = construct(Type.Unit))
+                    }
                     constructo {
                         response.responseParameters().forEach { (name, type) -> arg(name, type) }
                         assign("status", Literal(statusCode, Type.Integer(Precision.P32)))

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Ast.kt
@@ -167,6 +167,12 @@ data class Field(
     val name: Name,
     val type: Type,
     val isOverride: Boolean = false,
+    /**
+     * When set, this field is a fixed/derived member rather than a constructor input: emitters
+     * render it with this initializer expression (e.g. `Response` status/headers) and exclude it
+     * from the constructable surface, so its value cannot be overridden by callers.
+     */
+    val initializer: Expression? = null,
 ) : Element
 
 data class Function(

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Dsl.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Dsl.kt
@@ -312,12 +312,12 @@ class StructBuilder(private val name: Name) : ContainerBuilder {
         typeParameters.add(TypeParameter(type, extends.toList()))
     }
 
-    fun field(name: String, type: Type, isOverride: Boolean = false) {
-        fields.add(Field(Name.of(name), type, isOverride))
+    fun field(name: String, type: Type, isOverride: Boolean = false, initializer: Expression? = null) {
+        fields.add(Field(Name.of(name), type, isOverride, initializer))
     }
 
-    fun field(name: Name, type: Type, isOverride: Boolean = false) {
-        fields.add(Field(name, type, isOverride))
+    fun field(name: Name, type: Type, isOverride: Boolean = false, initializer: Expression? = null) {
+        fields.add(Field(name, type, isOverride, initializer))
     }
 
     fun construct(type: Type, block: ConstructorBuilder.() -> Unit = {}): ConstructorStatement {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Transform.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/core/Transform.kt
@@ -136,7 +136,10 @@ fun Element.transformChildren(transformer: Transformer): Element = when (this) {
     is RawElement -> this
 }
 
-fun Field.transformChildren(transformer: Transformer): Field = copy(type = transformer.transformType(type))
+fun Field.transformChildren(transformer: Transformer): Field = copy(
+    type = transformer.transformType(type),
+    initializer = initializer?.let { transformer.transformExpression(it) },
+)
 
 fun Parameter.transformChildren(transformer: Transformer): Parameter = copy(type = transformer.transformType(type))
 

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/JavaGenerator.kt
@@ -205,6 +205,29 @@ object JavaGenerator : Generator {
         val customConstructors = constructors.joinToString("") { it.emit(name.pascalCase(), fields, 1, isRecord = true) }
         val nestedContent = elements.joinToString("") { it.emit(1, isStatic = true, parents = parents + this) }
 
+        // Fields carrying an initializer are fixed/derived members rather than record components:
+        // they are rendered as accessor methods returning a constant value, so they cannot be set
+        // through the canonical constructor. The constructor parameters become the record's
+        // components (the only construction surface).
+        val memberFields = fields.filter { it.initializer != null }
+        if (memberFields.isNotEmpty()) {
+            val componentParts = (constructors.singleOrNull()?.parameters ?: emptyList()).map { param ->
+                "${param.type.emitGenerics()} ${param.name.camelCase().sanitize()}".indentCode(1)
+            }
+            val componentsStr = if (componentParts.isEmpty()) " ()" else componentParts.joinToString(",\n", " (\n", "\n)")
+            val memberMethods = memberFields.joinToString("") { field ->
+                val init = field.initializer!!
+                val valueStr = when {
+                    init is ConstructorStatement && init.type == Type.Unit -> "null"
+                    init is ConstructorStatement -> "new ${init.type.emitConstructorType()}${init.formatArgs()}"
+                    else -> init.emit()
+                }
+                val methodBody = "return $valueStr;\n".indentCode(1)
+                "public ${field.type.emitGenerics()} ${field.name.value().sanitize()}() {\n$methodBody}\n".indentCode(1)
+            }
+            return "$typeModifier ${name.pascalCase()}$typeParamsStr$componentsStr$implStr {\n$memberMethods$nestedContent};\n\n".indentCode(indent)
+        }
+
         val paramParts = annotatedFields().map { (field, annotations) ->
             val annotationPrefix = annotations.joinToString("") { "$it " }
             "$annotationPrefix${field.type.emitGenerics()} ${field.name.value().sanitize()}".indentCode(1)

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/KotlinGenerator.kt
@@ -206,6 +206,25 @@ object KotlinGenerator : Generator {
             }
         }
 
+        // Fields carrying an initializer are fixed/derived members rather than constructor inputs.
+        // The constructor parameters become the (only) public construction surface; matching
+        // declared fields contribute their `override` modifier.
+        val memberFields = fields.filter { it.initializer != null }
+        val ctorWithParams = constructors.singleOrNull()?.takeIf { it.parameters.isNotEmpty() }
+        if (memberFields.isNotEmpty() && ctorWithParams != null) {
+            val fieldsByName = fields.associateBy { it.name.value() }
+            val memberParamParts = ctorWithParams.parameters.map { param ->
+                val overridePrefix = "override ".takeIf { _ -> fieldsByName[param.name.value()]?.isOverride == true }.orEmpty()
+                "${overridePrefix}val ${param.name.camelCase().sanitize()}: ${param.type.emitGenerics()}".indentCode(indent + 1)
+            }
+            val memberParamsStr = memberParamParts.joinNonEmpty(",\n", "(\n", "\n${")".indentCode(indent)}") { it }
+            val memberLines = memberFields.joinToString("") { field ->
+                val overridePrefix = "override ".takeIf { _ -> field.isOverride }.orEmpty()
+                "${overridePrefix}val ${field.name.value().sanitize()}: ${field.type.emitGenerics()} = ${field.initializer!!.emit()}\n".indentCode(indent + 1)
+            }
+            return "data class $pascal$typeParamsStr$memberParamsStr$implStr {\n$memberLines$nestedContent$closingBrace\n\n".indentCode(indent)
+        }
+
         val paramParts = annotatedFields().map { (field, annotations) ->
             val annotationPrefix = annotations.joinToString("") { "$it " }
             val overridePrefix = "override ".takeIf { _ -> field.isOverride }.orEmpty()

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/RustGenerator.kt
@@ -213,7 +213,12 @@ object RustGenerator : Generator {
 
         val fieldsStr = fields.joinToString("\n") {
             val fieldName = it.name.snakeCase().sanitize()
-            "pub $fieldName: ${it.type.emit()},".indentCode(1)
+            // Fields carrying an initializer (e.g. response status/headers) are fixed and must not
+            // be settable by consumers: keep them module-private so external struct-literal
+            // construction is rejected while the generated `new` and conversion helpers (defined in
+            // the same/descendant module) can still read and assign them.
+            val visibility = if (it.initializer != null) "" else "pub "
+            "$visibility$fieldName: ${it.type.emit()},".indentCode(1)
         }
         val structDef = "pub struct $rustName$typeParamsStr {\n$fieldsStr\n}\n\n".indentCode(indent)
 

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/ScalaGenerator.kt
@@ -290,6 +290,24 @@ object ScalaGenerator : Generator {
             }
         }
 
+        // Fields carrying an initializer are fixed/derived members rather than constructor inputs.
+        // The constructor parameters become the (only) public construction surface; matching
+        // declared fields contribute their `override` modifier.
+        val memberFields = fields.filter { it.initializer != null }
+        val ctorWithParams = constructors.singleOrNull()?.takeIf { it.parameters.isNotEmpty() }
+        if (memberFields.isNotEmpty() && ctorWithParams != null) {
+            val fieldsByName = fields.associateBy { it.name.value() }
+            val memberParamsStr = ctorWithParams.parameters.joinToString(",\n", "(\n", "\n${")".indentCode(indent)}") { param ->
+                val overridePrefix = "override ".takeIf { _ -> fieldsByName[param.name.value()]?.isOverride == true }.orEmpty()
+                "${overridePrefix}val ${param.name.camelCase().sanitize()}: ${param.type.emitTypeAnnotation()}".indentCode(indent + 1)
+            }
+            val memberLines = memberFields.joinToString("") { field ->
+                val overridePrefix = "override ".takeIf { _ -> field.isOverride }.orEmpty()
+                "${overridePrefix}val ${field.name.value().sanitize()}: ${field.type.emitTypeAnnotation()} = ${field.initializer!!.emit()}\n".indentCode(indent + 1)
+            }
+            return "case class $pascal$typeParamsStr$memberParamsStr$implStr {\n$memberLines$nestedContent$closingBrace\n\n".indentCode(indent)
+        }
+
         val paramsStr = if (fields.isEmpty()) {
             ""
         } else {


### PR DESCRIPTION
## Description

This change refactors how HTTP response `status` and `headers` fields are generated across all language emitters (Java, Kotlin, Scala, Rust). Instead of being constructor parameters that can be set by callers, they are now fixed/derived members with initializers that return constant values.

### Key Changes

**IR Layer** (`IrConverter.kt`):
- Response `status` and `headers` fields now include initializers in the IR
- `status` initializer is a literal with the HTTP status code
- `headers` initializer constructs the headers object with response-specific values
- Updated `Field` data class to support optional `initializer` expressions

**Language Emitters**:
- **Java** (`JavaGenerator.kt`): Fields with initializers render as accessor methods returning constant values, not record components
- **Kotlin** (`KotlinGenerator.kt`): Fields with initializers become property declarations with assignments, excluded from constructor parameters
- **Scala** (`ScalaGenerator.kt`): Similar to Kotlin—properties with initializers, not constructor inputs
- **Rust** (`RustGenerator.kt`): Fields with initializers are marked private (no `pub`) to prevent external struct-literal construction

**DSL Updates** (`Dsl.kt`):
- `field()` builder now accepts optional `initializer` parameter
- `Transform.kt` updated to handle initializer transformation

### Benefits

1. **Immutability**: Callers cannot override response status or headers—they are always correct
2. **Simpler API**: Response constructors only require the body (and any custom header values), not boilerplate status/headers
3. **Type Safety**: Compile-time guarantee that responses have the correct status code
4. **Consistency**: All language emitters follow the same pattern

### Generated Code Example

**Before** (Java):
```java
public Response200(Integer status, Response200Headers headers, TodoDto body) { ... }
```

**After** (Java):
```java
public Integer status() { return 200; }
public Response200Headers headers() { return new Response200Headers(); }
```

Fixture files updated for Java, Kotlin, Scala, and Rust to reflect the new generated structure.

## Type of Change
- [x] Refactoring
- [x] Feature

## Checklist
- [x] I have followed the contribution guidelines
- [x] Fixture tests updated to reflect new generated code
- [x] IR and all language emitters (Java, Kotlin, Scala, Rust) updated consistently
- [x] DSL and transform layer updated to support field initializers

## Breaking Changes

Generated response classes now have a different constructor signature. Callers must update code that constructs response objects:

**Before:**
```java
new Response200(200, new Response200Headers(), body)
```

**After:**
```java
new Response200(body)  // status and headers are fixed
```

This is a breaking change for code that directly instantiates response classes, but the new API is simpler and safer.

https://claude.ai/code/session_01DRAX1fKZA5xaJzSxadKR4Y