### PR TITLE
fix(examples): migrate maven-wiremock to IR pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,6 +261,10 @@ jobs:
             type: maven
           - name: maven-spring-boot-4-integration
             type: maven
+          - name: maven-spring-kotlin
+            type: maven
+          - name: maven-wiremock
+            type: maven
           - name: maven-spring-native
             type: native
           - name: gradle-ktor

--- a/examples/maven-spring-avro/src/main/java/community/flock/wirespec/examples/maven/avro/AvroExampleService.java
+++ b/examples/maven-spring-avro/src/main/java/community/flock/wirespec/examples/maven/avro/AvroExampleService.java
@@ -33,7 +33,8 @@ public class AvroExampleService implements TestAvroRecord.Sender, TestAvroRecord
     }
 
     @Override
-    public void testAvroRecord(java.util.function.Function<com.eventloopsoftware.kafka.model.TestAvroRecord, Void> handler) {
+    public void testAvroRecord(
+            java.util.function.Function<com.eventloopsoftware.kafka.model.TestAvroRecord, Void> handler) {
         listen("group", handler::apply);
     }
 

--- a/examples/maven-wiremock/pom.xml
+++ b/examples/maven-wiremock/pom.xml
@@ -133,6 +133,7 @@
                             <languages>
                                 <language>Java</language>
                             </languages>
+                            <ir>true</ir>
                         </configuration>
                     </execution>
                 </executions>

--- a/examples/npm-typescript/README.md
+++ b/examples/npm-typescript/README.md
@@ -16,7 +16,7 @@ import { GetTodoById } from "./gen/endpoint";
 
 const server = setupServer(
   wirespec(GetTodoById.api, async (req) =>
-    GetTodoById.response200({ body: { id: req.path.id, /* ... */ } }),
+    GetTodoById.response200({ body: { id: req.path.id /* ... */ } }),
   ),
 );
 ```

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -52,9 +52,9 @@ balanced-match@^1.0.0:
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 brace-expansion@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
-  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -248,9 +248,9 @@ jackspeak@^3.1.2:
     "@pkgjs/parseargs" "^0.11.0"
 
 js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 
@@ -533,9 +533,9 @@ yargs-unparser@^2.0.0:
     is-plain-obj "^2.1.0"
 
 yargs@^17.7.2:
-  version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"

--- a/src/ide/vscode/package-lock.json
+++ b/src/ide/vscode/package-lock.json
@@ -30,10 +30,19 @@
       "version": "0.0.0-SNAPSHOT",
       "license": "Apache-2.0",
       "bin": {
-        "wirespec": "wirespec-bin.mjs"
+        "wirespec": "wirespec-bin.mjs",
+        "wirespec-lsp": "wirespec-lsp.mjs"
       },
       "devDependencies": {
         "typescript": "5.9.3"
+      },
+      "peerDependencies": {
+        "msw": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        }
       }
     },
     "../lsp": {

--- a/src/site/docs/package-lock.json
+++ b/src/site/docs/package-lock.json
@@ -36,10 +36,19 @@
       "version": "0.0.0-SNAPSHOT",
       "license": "Apache-2.0",
       "bin": {
-        "wirespec": "wirespec-bin.mjs"
+        "wirespec": "wirespec-bin.mjs",
+        "wirespec-lsp": "wirespec-lsp.mjs"
       },
       "devDependencies": {
         "typescript": "5.9.3"
+      },
+      "peerDependencies": {
+        "msw": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/src/site/playground/package-lock.json
+++ b/src/site/playground/package-lock.json
@@ -42,10 +42,19 @@
       "version": "0.0.0-SNAPSHOT",
       "license": "Apache-2.0",
       "bin": {
-        "wirespec": "wirespec-bin.mjs"
+        "wirespec": "wirespec-bin.mjs",
+        "wirespec-lsp": "wirespec-lsp.mjs"
       },
       "devDependencies": {
         "typescript": "5.9.3"
+      },
+      "peerDependencies": {
+        "msw": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
## Problem

`make clean all` fails in the `example` stage — the `maven-wiremock` example's tests throw:

```
java.lang.NoSuchMethodError:
'java.lang.Integer community.flock.wirespec.java.Wirespec$RawResponse.statusCode()'
```

## Root cause

The compiler has two Java runtime emitters that produce **structurally different** `Wirespec` runtimes:

- **Legacy** (`JavaShared.kt`): `record RawResponse(int statusCode, …)`
- **IR** (`JavaIrEmitter.emitShared()`): `RawResponse(Integer statusCode, …)`

The published `wiremock-jvm` integration jar is hand-written and compiled against the **IR** runtime (`Integer statusCode()`). But the `maven-wiremock` example's pom didn't set `<ir>true</ir>`, so the maven plugin defaulted to the **legacy** path and generated a `Wirespec.java` with primitive `int statusCode` into `target/classes`. That locally-compiled class shadows the jar's runtime, so the integration's `Integer statusCode()` call blows up at runtime.

## Fix

- Add `<ir>true</ir>` to the `wirespec-maven-plugin` config in `examples/maven-wiremock/pom.xml`, matching the already-migrated Spring/Avro examples.
- Regenerate the CI matrix in `.github/workflows/build.yml`, which was **missing** `maven-wiremock` (and `maven-spring-kotlin`) — the reason this regression escaped CI.

## Verification

`maven-wiremock` tests pass (3/3), and the full `make example format verify` pipeline is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)