### PR TITLE
feat(maven): resolve classpath folder input from project + plugin artifacts

### DIFF
--- a/src/plugin/maven/build.gradle.kts
+++ b/src/plugin/maven/build.gradle.kts
@@ -25,6 +25,13 @@ dependencies {
     implementation(libs.kotlin.reflect)
     implementation(libs.bundles.maven.plugin)
     implementation(libs.kotlin.compiler.embeddable)
+
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 java {

--- a/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/BaseMojo.kt
+++ b/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/BaseMojo.kt
@@ -27,12 +27,13 @@ import community.flock.wirespec.plugin.maven.compiler.JavaCompiler
 import community.flock.wirespec.plugin.maven.compiler.KotlinCompiler
 import community.flock.wirespec.plugin.toEmitter
 import community.flock.wirespec.plugin.toIrEmitter
+import org.apache.maven.artifact.Artifact
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.project.MavenProject
 import java.io.File
-import java.net.JarURLConnection
 import java.net.URLClassLoader
+import java.util.jar.JarFile
 
 abstract class BaseMojo : AbstractMojo() {
 
@@ -109,6 +110,9 @@ abstract class BaseMojo : AbstractMojo() {
 
     @Parameter(defaultValue = "\${project}", readonly = true, required = true)
     protected lateinit var project: MavenProject
+
+    @Parameter(defaultValue = "\${plugin.artifacts}", readonly = true, required = true)
+    protected lateinit var pluginArtifacts: List<Artifact>
 
     protected val logger = object : Logger(ERROR) {
         override fun debug(string: String) = log.debug(string)
@@ -217,38 +221,54 @@ abstract class BaseMojo : AbstractMojo() {
             return nonEmptySetOf(readFromClasspath<Wirespec>())
         }
 
-        val classLoader = javaClass.classLoader
-        val folder = value.trimEnd('/')
-        val resources = classLoader.getResources(folder).toList()
-        if (resources.isEmpty()) error("Could not find folder: $value on the classpath.")
-
-        val sources = resources.flatMap { url ->
-            when (url.protocol) {
-                "file" -> File(url.toURI()).walkTopDown()
-                    .filter { it.isFile && it.name.endsWith(extension) }
-                    .map { Source<Wirespec>(Name(it.name.removeSuffix(extension)), it.readText(Charsets.UTF_8)) }
-                    .toList()
-
-                "jar" -> {
-                    val jarFile = (url.openConnection() as JarURLConnection).jarFile
-                    val prefix = "$folder/"
-                    jarFile.entries().asSequence()
-                        .filter { !it.isDirectory && it.name.startsWith(prefix) && it.name.endsWith(extension) }
-                        .map { entry ->
-                            val name = entry.name.substringAfterLast('/').removeSuffix(extension)
-                            val content = jarFile.getInputStream(entry).bufferedReader(Charsets.UTF_8).use { it.readText() }
-                            Source<Wirespec>(Name(name), content)
-                        }
-                        .toList()
-                }
-
-                else -> emptyList()
-            }
-        }
+        val classpathEntries = project.compileClasspathElements
+            .map { File(it as String) }
+            .plus(pluginArtifacts.mapNotNull { it.file })
+        val sources = readWirespecSourcesFromClasspathFolder(value, classpathEntries, extension)
 
         logger.info("Found ${sources.size} wirespec file(s) from classpath folder: $value")
         return sources.toNonEmptySetOrNull() ?: error("No wirespec files found in classpath folder: $value")
     }
 
     protected fun handleError(string: String): Nothing = throw RuntimeException(string)
+}
+
+internal fun readWirespecSourcesFromClasspathFolder(
+    value: String,
+    classpathEntries: List<File>,
+    extension: String = ".${FileExtension.Wirespec.value}",
+): List<Source<Wirespec>> {
+    val folder = value.trim('/')
+    val entries = classpathEntries
+        .map { it.absoluteFile }
+        .distinctBy { it.path }
+
+    fun read(resourceFolder: String) = entries.flatMap { entry ->
+        when {
+            entry.isDirectory -> entry.resolve(resourceFolder)
+                .takeIf { it.isDirectory }
+                ?.walkTopDown()
+                ?.filter { it.isFile && it.name.endsWith(extension) }
+                ?.map { Source<Wirespec>(Name(it.name.removeSuffix(extension)), it.readText(Charsets.UTF_8)) }
+                ?.toList()
+                .orEmpty()
+
+            entry.isFile && entry.extension.equals("jar", ignoreCase = true) -> JarFile(entry).use { jarFile ->
+                val prefix = "$resourceFolder/"
+                jarFile.entries().asSequence()
+                    .filter { !it.isDirectory && it.name.startsWith(prefix) && it.name.endsWith(extension) }
+                    .map { jarEntry ->
+                        val name = jarEntry.name.substringAfterLast('/').removeSuffix(extension)
+                        val content = jarFile.getInputStream(jarEntry).bufferedReader(Charsets.UTF_8).use { it.readText() }
+                        Source<Wirespec>(Name(name), content)
+                    }
+                    .toList()
+            }
+
+            else -> emptyList()
+        }
+    }.distinct()
+
+    val sources = read(folder)
+    return if (sources.isNotEmpty() || '/' in folder) sources else read(folder.replace('.', '/'))
 }

--- a/src/plugin/maven/src/test/kotlin/community/flock/wirespec/plugin/maven/mojo/ClasspathSourceReaderTest.kt
+++ b/src/plugin/maven/src/test/kotlin/community/flock/wirespec/plugin/maven/mojo/ClasspathSourceReaderTest.kt
@@ -1,0 +1,36 @@
+package community.flock.wirespec.plugin.maven.mojo
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import java.nio.file.Files
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+
+class ClasspathSourceReaderTest :
+    FunSpec({
+        test("reads wirespec files from a jar without directory entries") {
+            val jar = Files.createTempFile("wirespec-classpath", ".jar")
+            try {
+                JarOutputStream(Files.newOutputStream(jar)).use { output ->
+                    mapOf(
+                        "com/example/api/config/First.ws" to "endpoint First GET /first -> { 200 -> String }",
+                        "com/example/api/config/nested/Second.ws" to "endpoint Second GET /second -> { 200 -> String }",
+                        "com/example/api/other/Ignored.ws" to "endpoint Ignored GET /ignored -> { 200 -> String }",
+                    ).forEach { (name, content) ->
+                        output.putNextEntry(JarEntry(name))
+                        output.write(content.toByteArray())
+                        output.closeEntry()
+                    }
+                }
+
+                listOf("com/example/api/config", "com.example.api.config").forEach { folder ->
+                    readWirespecSourcesFromClasspathFolder(folder, listOf(jar.toFile()))
+                        .map { it.name.value }
+                        .sorted()
+                        .shouldContainExactly("First", "Second")
+                }
+            } finally {
+                Files.deleteIfExists(jar)
+            }
+        }
+    })


### PR DESCRIPTION
## Summary

Reworks how the Maven plugin resolves a `classpath:` **folder** input for the `compile` goal. Instead of relying on the plugin classloader's `getResources`, it scans the explicit classpath entries — the project's compile classpath elements plus the plugin's own artifacts — and reads every `.ws` file beneath the folder from both directory entries and jars.

## Changes

- **`BaseMojo.kt`**
  - Inject `${plugin.artifacts}` as `pluginArtifacts` so plugin-dependency jars are searchable alongside the project compile classpath.
  - Extract `readWirespecSourcesFromClasspathFolder(value, classpathEntries, extension)`:
    - Walks directory entries (`target/classes`, exploded resources) and reads `.ws` files recursively.
    - Reads `.ws` entries from jar files (handles jars that omit directory records).
    - De-duplicates classpath entries and resulting sources.
    - Accepts both slash- and dot-separated folder notation (`com/example/api` or `com.example.api`), falling back to the dotted → slashed form when the literal folder yields nothing.
- **`build.gradle.kts`** — add kotest test dependencies and `useJUnitPlatform()` for the test task.
- **`ClasspathSourceReaderTest.kt`** — verifies reading from a jar without directory entries, and that both folder notations resolve the nested `.ws` files while ignoring siblings outside the folder.

## Testing

- `:src:plugin:maven:test --tests *ClasspathSourceReaderTest*` → BUILD SUCCESSFUL
- `:src:plugin:maven:spotlessCheck` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)