### PR TITLE
fix(wirespec-emitter): emit re-parseable refined type bounds

### DIFF
--- a/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitter.kt
+++ b/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitter.kt
@@ -34,6 +34,6 @@ open class WirespecEmitter : LanguageEmitter(), WirespecEmitters {
 
     override fun Reference.Primitive.Type.Constraint.emit() = when(this){
         is Reference.Primitive.Type.Constraint.RegExp -> "(${value})"
-        is Reference.Primitive.Type.Constraint.Bound -> "(${min}, ${max})"
+        is Reference.Primitive.Type.Constraint.Bound -> "(${min ?: "_"}, ${max ?: "_"})"
     }
 }

--- a/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecRefinedTypeDefinitionEmitter.kt
+++ b/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecRefinedTypeDefinitionEmitter.kt
@@ -7,15 +7,24 @@ import community.flock.wirespec.compiler.core.parse.ast.Refined
 interface WirespecRefinedTypeDefinitionEmitter: RefinedTypeDefinitionEmitter, WirespecTypeDefinitionEmitter {
 
     override fun emit(refined: Refined) =
-        "type ${emit(refined.identifier)} = ${refined.reference.emit()}${refined.emitValidator()}\n"
+        "type ${emit(refined.identifier)} = ${refined.reference.copy(isNullable = false).emit()}${refined.emitValidator()}${if (refined.reference.isNullable) "?" else ""}\n"
 
     override fun Refined.emitValidator():String {
         return when (val type = reference.type) {
             is Reference.Primitive.Type.Integer -> type.constraint?.emit() ?: ""
-            is Reference.Primitive.Type.Number -> type.constraint?.emit() ?: ""
+            is Reference.Primitive.Type.Number -> type.constraint?.emitDecimal() ?: ""
             is Reference.Primitive.Type.String -> type.constraint?.emit() ?: ""
             Reference.Primitive.Type.Boolean -> ""
             Reference.Primitive.Type.Bytes -> ""
         }
+    }
+
+    private fun Reference.Primitive.Type.Constraint.Bound.emitDecimal(): String =
+        "(${min.toBoundDecimal()}, ${max.toBoundDecimal()})"
+
+    private fun String?.toBoundDecimal(): String = when {
+        this == null -> "_"
+        contains(".") -> this
+        else -> "$this.0"
     }
 }

--- a/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
+++ b/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
@@ -9,7 +9,12 @@ import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
+import community.flock.wirespec.compiler.test.compile
+import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Refined
 import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
 class WirespecEmitterTest {
@@ -94,23 +99,63 @@ class WirespecEmitterTest {
             |
             |type TestInt = Integer
             |
-            |type TestInt0 = Integer(null, null)
+            |type TestInt0 = Integer(_, _)
             |
-            |type TestInt1 = Integer(0, null)
+            |type TestInt1 = Integer(0, _)
             |
             |type TestInt2 = Integer(1, 3)
             |
             |type TestNum = Number
             |
-            |type TestNum0 = Number(null, null)
+            |type TestNum0 = Number(_, _)
             |
-            |type TestNum1 = Number(null, 0.5)
+            |type TestNum1 = Number(_, 0.5)
             |
             |type TestNum2 = Number(-0.2, 0.5)
             |
         """.trimMargin()
 
         CompileRefinedTest.compiler { WirespecEmitter() } shouldBeRight wirespec
+    }
+
+    @Test
+    fun compileNullableRefinedTest() {
+        // A nullable refined type must round-trip: the `?` goes after the bound, so it stays parseable.
+        val source = """
+            |type TestIntNullable = Integer(0, _)?
+            |type TestNumNullable = Number(-0.2, 0.5)?
+            |
+        """.trimMargin()
+
+        val wirespec = """
+            |type TestIntNullable = Integer(0, _)?
+            |
+            |type TestNumNullable = Number(-0.2, 0.5)?
+            |
+        """.trimMargin()
+
+        val compiler = compile(source)
+        compiler { WirespecEmitter() } shouldBeRight wirespec
+    }
+
+    @Test
+    fun compileNumberIntegerBoundsTest() {
+        // Integer-valued Number bounds cannot be parsed from Wirespec source (Number bounds must be
+        // decimals), but they can arrive via conversion (e.g. OpenAPI). The emitter must render them
+        // as decimals so the output stays parseable.
+        val refined = Refined(
+            comment = null,
+            annotations = emptyList(),
+            identifier = DefinitionIdentifier("TestNumIntBounds"),
+            reference = Reference.Primitive(
+                type = Reference.Primitive.Type.Number(
+                    constraint = Reference.Primitive.Type.Constraint.Bound("0", "1"),
+                ),
+                isNullable = false,
+            ),
+        )
+
+        WirespecEmitter().emit(refined) shouldBe "type TestNumIntBounds = Number(0.0, 1.0)\n"
     }
 
     @Test

--- a/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
+++ b/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
@@ -1,5 +1,8 @@
 package community.flock.wirespec.emitters.wirespec
 
+import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Refined
 import community.flock.wirespec.compiler.test.CompileChannelTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
@@ -10,9 +13,6 @@ import community.flock.wirespec.compiler.test.CompileRefinedTest
 import community.flock.wirespec.compiler.test.CompileTypeTest
 import community.flock.wirespec.compiler.test.CompileUnionTest
 import community.flock.wirespec.compiler.test.compile
-import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
-import community.flock.wirespec.compiler.core.parse.ast.Reference
-import community.flock.wirespec.compiler.core.parse.ast.Refined
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test


### PR DESCRIPTION
## Problem

The Wirespec emitter (which emits the `.ws` language itself) produced refined type bounds that Wirespec's own parser cannot parse back:

| Emitted (wrong) | Correct |
|---|---|
| `Integer32(0, null)` | `Integer32(0, _)` |
| `Number(0, 1)` | `Number(0.0, 1.0)` |
| `Integer32?(0, null)` | `Integer32(0, _)?` |

Root causes:
- **Open bounds** rendered as the literal string `null` (Kotlin interpolation of a null `String?`), but the parser expects `_`.
- **Number bounds** with integer-valued strings (which arrive via conversion, e.g. OpenAPI) were emitted without a decimal point; the parser's `Number` token requires a decimal (`-?[0-9]+\.[0-9]+`).
- **Nullable placement**: the `?` was appended by `Reference.emit()` *before* the bound was added, producing `Integer32?(0, _)`; the parser reads nullability *after* the constraint.

## Fix

- `WirespecEmitter`: open bounds now emit `_` instead of `null`.
- `WirespecRefinedTypeDefinitionEmitter`: `Number` bounds are formatted as decimals (`0` → `0.0`), and the nullable `?` now trails the bound (`Integer32(0, _)?`).

## Tests

- Updated the `compileRefinedTest` round-trip expectations to the corrected `_` form (they previously encoded the buggy `null` output, so the round-trip was not actually round-tripping).
- Added `compileNullableRefinedTest` — round-trips a nullable refined type, locking in `?`-after-bound.
- Added `compileNumberIntegerBoundsTest` — builds a `Refined` with integer-valued `Number` bounds directly (unparseable as source) and asserts decimal output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)