### PR TITLE
fix(avro): support maps, nullable fields and recursive schemas

### DIFF
--- a/src/integration/avro/src/commonMain/kotlin/community/flock/wirespec/integration/avro/extension/AvroExtension.kt
+++ b/src/integration/avro/src/commonMain/kotlin/community/flock/wirespec/integration/avro/extension/AvroExtension.kt
@@ -234,38 +234,91 @@ private class KotlinAvroSource(packageName: PackageName) :
         else -> emptyList()
     }
 
+    /** The `<Type>Avro` object for [reference], named after the type itself, never its nullability. */
+    private fun avroObject(reference: Reference): String = reference.copy(isNullable = false).emit().avroClass()
+
     private fun schemaField(definition: Definition, module: Module, explicitType: Boolean): String {
         val declaration = if (explicitType) "val SCHEMA: org.apache.avro.Schema" else "val SCHEMA"
         return "$declaration = org.apache.avro.Schema.Parser().parse(\"${schema(definition, module)}\")"
     }
 
-    private fun toValue(field: Field): String = when (val reference = field.reference) {
-        is Reference.Iterable -> "data.${emit(field.identifier)}.map{${reference.reference.value.avroClass()}.to(it)}"
-        is Reference.Custom -> "${field.reference.emit().avroClass()}.to(data.${emit(field.identifier)})"
-        is Reference.Primitive -> when {
-            reference.type == Reference.Primitive.Type.Bytes -> "java.nio.ByteBuffer.wrap(data.${emit(field.identifier)}.toByteArray())"
-            else -> "data.${emit(field.identifier)}"
-        }
+    private fun toValue(field: Field): String {
+        val value = "data.${emit(field.identifier)}"
+        // A nullable field carries the null straight through to the record; the element
+        // conversions below only ever run on a present value.
+        val access = if (field.reference.isNullable) "$value?" else value
+        return when (val reference = field.reference) {
+            // Avro arrays and maps of primitives need no per-element conversion: the model
+            // already holds the very types the writer expects.
+            is Reference.Iterable -> when (reference.reference) {
+                is Reference.Custom -> "$access.map{${avroObject(reference.reference)}.to(it)}"
+                else -> value
+            }
+            is Reference.Dict -> when (reference.reference) {
+                is Reference.Custom -> "$access.mapValues{${avroObject(reference.reference)}.to(it.value)}"
+                else -> value
+            }
+            is Reference.Custom -> when {
+                field.reference.isNullable -> "$access.let{${avroObject(reference)}.to(it)}"
+                else -> "${avroObject(reference)}.to($value)"
+            }
+            is Reference.Primitive -> when {
+                // `bytes` is a ByteArray in the model and a ByteBuffer on the wire.
+                reference.type == Reference.Primitive.Type.Bytes && reference.isNullable ->
+                    "$access.let{java.nio.ByteBuffer.wrap(it)}"
+                reference.type == Reference.Primitive.Type.Bytes -> "java.nio.ByteBuffer.wrap($value)"
+                else -> value
+            }
 
-        else -> error("Cannot emit Avro: $reference")
+            else -> error("Cannot emit Avro: $reference")
+        }
     }
 
     private fun fromValue(module: Module): (index: Int, field: Field) -> String = { index, field ->
-        when (val reference = field.reference) {
-            is Reference.Iterable -> "(record.get($index) as java.util.List<org.apache.avro.generic.GenericData.Record>).map{${reference.reference.emit().avroClass()}.from(it)}"
-            is Reference.Custom -> when {
-                reference.isEnum(module) -> "${field.reference.emit().avroClass()}.from(record.get($index) as org.apache.avro.generic.GenericData.EnumSymbol)"
-                else -> "${field.reference.emit().avroClass()}.from(record.get($index) as org.apache.avro.generic.GenericData.Record)"
+        val reference = field.reference
+        val get = "record.get($index)"
+        // `?` after the cast keeps a null field null; the conversions then run under `?.`.
+        val orNull = if (reference.isNullable) "?" else ""
+        when (reference) {
+            is Reference.Iterable ->
+                "($get as kotlin.collections.List<*>$orNull)$orNull.map{${element(module, reference.reference, "it")}}"
+            is Reference.Dict ->
+                "($get as kotlin.collections.Map<*, *>$orNull)$orNull.entries$orNull.associate{it.key.toString() to ${element(module, reference.reference, "it.value")}}"
+            is Reference.Custom -> {
+                // An enum arrives as an EnumSymbol rather than a Record, so the cast that guards
+                // the null has to name the carrier the value actually has.
+                val carrier = if (reference.isEnum(module)) ENUM_SYMBOL else RECORD
+                when {
+                    reference.isNullable -> "($get as $carrier?)?.let{${avroObject(reference)}.from(it)}"
+                    else -> element(module, reference, get)
+                }
             }
 
             is Reference.Primitive -> when (reference.type) {
-                is Reference.Primitive.Type.Bytes -> "String((record.get($index) as java.nio.ByteBuffer).array())"
-                is Reference.Primitive.Type.String -> "record.get($index)${if (reference.isNullable) "?" else ""}.toString() as ${reference.emit()}"
-                else -> "record.get($index) as ${reference.emit()}"
+                is Reference.Primitive.Type.Bytes -> "($get as java.nio.ByteBuffer$orNull)$orNull.array()"
+                is Reference.Primitive.Type.String -> "$get$orNull.toString() as ${reference.emit()}"
+                else -> "$get as ${reference.emit()}"
             }
 
-            else -> "record.get($index): ${reference.emit()}"
+            else -> error("Cannot emit Avro: $reference")
         }
+    }
+
+    /**
+     * Reads a single Avro value held in [value] back into the model type [reference] — the element
+     * of an array or map, or a field read straight off the record. Avro hands strings back as
+     * `Utf8`, so anything string-shaped goes through `toString()` rather than a cast.
+     */
+    private fun element(module: Module, reference: Reference, value: String): String = when (reference) {
+        is Reference.Custom -> when {
+            reference.isEnum(module) -> "${avroObject(reference)}.from($value as $ENUM_SYMBOL)"
+            else -> "${avroObject(reference)}.from($value as $RECORD)"
+        }
+        is Reference.Primitive -> when (reference.type) {
+            is Reference.Primitive.Type.String -> "$value.toString()"
+            else -> "$value as ${reference.emit()}"
+        }
+        else -> error("Cannot emit Avro element: $reference")
     }
 }
 
@@ -280,22 +333,22 @@ private fun KotlinEmitter.schema(definition: Definition, module: Module): String
 
 private fun String.avroClass(): String = replace(".model.", ".avro.") + "Avro"
 
-private fun emitAvroSchema(packageName: PackageName, type: Definition, module: Module) = AvroJsonEmitter
-    .emit(module)
-    .map {
-        when (it) {
-            is AvroModel.RecordType -> it.copy(namespace = packageName.value)
-            else -> it
-        }
+/**
+ * The Avro schema for [definition] alone. Emitting per definition rather than picking one out of
+ * the whole module keeps every schema self-contained: nested records are written out in full the
+ * first time they appear, and the seeded name makes a type that refers back to itself — directly
+ * or through a nested record — resolve by name instead of trying to inline itself forever.
+ */
+private fun emitAvroSchema(packageName: PackageName, definition: Definition, module: Module) = with(AvroJsonEmitter) {
+    when (definition) {
+        is Type -> definition
+            .emit(module, mutableListOf(definition.identifier.value))
+            .copy(namespace = packageName.value)
+        is Enum -> definition.emit()
+        else -> null
     }
-    .find {
-        when (it) {
-            is AvroModel.RecordType -> it.name == type.identifier.value
-            is AvroModel.EnumType -> it.name == type.identifier.value
-            else -> false
-        }
-    }
-    ?.flatten()
+}
+    ?.flatten(mutableSetOf())
     ?.let { Json.encodeToString(it) }
     ?.escaped()
 
@@ -303,8 +356,18 @@ private fun Reference.isEnum(module: Module): Boolean = module.statements
     .filterIsInstance<Enum>()
     .any { it.identifier.value == this.value }
 
-private fun AvroModel.Type.flatten(): AvroModel.Type = when (this) {
-    is AvroModel.RecordType ->
+private val AVRO_PRIMITIVES = setOf("boolean", "int", "long", "float", "double", "bytes", "string", "null")
+
+/**
+ * Marks every name this schema does not define itself, so [schema] can splice in the emitting
+ * object's `SCHEMA` for it. [defined] collects the names defined along the way — a record or enum
+ * written out in full here, or a name already spliced in — and a repeat of one of those stays a
+ * bare Avro name, which is both how Avro deduplicates and the only way to write a recursive type.
+ */
+private fun AvroModel.Type.flatten(defined: MutableSet<String>): AvroModel.Type = when (this) {
+    is AvroModel.RecordType -> {
+        // Registered before the fields are walked, so a field referring back to this record finds it.
+        defined.add(name)
         this
             .copy(
                 fields = fields
@@ -312,22 +375,24 @@ private fun AvroModel.Type.flatten(): AvroModel.Type = when (this) {
                         field.copy(
                             type = AvroModel.TypeList(
                                 field.type
-                                    .map { it.flatten() },
+                                    .map { it.flatten(defined) },
                             ),
                         )
                     },
             )
+    }
 
-    is AvroModel.ArrayType -> this.copy(items = items.flatten())
-    is AvroModel.EnumType -> this
+    is AvroModel.ArrayType -> this.copy(items = items.flatten(defined))
+    is AvroModel.EnumType -> this.also { defined.add(name) }
     is AvroModel.LogicalType -> this
-    is AvroModel.SimpleType -> this.copy(
-        value = when (value) {
-            "boolean", "int", "long", "float", "double", "bytes", "string", "null" -> value
-            else -> "<<<<<$value>>>>>"
-        },
-    )
+    is AvroModel.SimpleType -> when {
+        value in AVRO_PRIMITIVES || value in defined -> this
+        else -> {
+            defined.add(value)
+            this.copy(value = "<<<<<$value>>>>>")
+        }
+    }
 
-    is AvroModel.MapType -> TODO()
-    is AvroModel.UnionType -> TODO()
+    is AvroModel.MapType -> this.copy(values = values.flatten(defined))
+    is AvroModel.UnionType -> this.copy(type = AvroModel.TypeList(type.map { it.flatten(defined) }))
 }

--- a/src/integration/avro/src/jvmTest/kotlin/community/flock/wirespec/integration/avro/extension/AvroExtensionTest.kt
+++ b/src/integration/avro/src/jvmTest/kotlin/community/flock/wirespec/integration/avro/extension/AvroExtensionTest.kt
@@ -63,6 +63,105 @@ class AvroExtensionTest {
         entries = setOf("ONE", "TWO", "THREE"),
     )
 
+    private fun field(name: String, reference: Reference) = Field(
+        identifier = FieldIdentifier(name = name),
+        annotations = emptyList(),
+        reference = reference,
+    )
+
+    private fun string(isNullable: Boolean = false) =
+        Reference.Primitive(type = Reference.Primitive.Type.String(null), isNullable = isNullable)
+
+    private val nested = Type(
+        comment = null,
+        annotations = emptyList(),
+        identifier = DefinitionIdentifier("Nested"),
+        shape = Type.Shape(listOf(field("name", string()))),
+        extends = emptyList(),
+    )
+
+    /** Maps, arrays of primitives and nullable records — none of which the flat [type] covers. */
+    private val collections = Type(
+        comment = null,
+        annotations = emptyList(),
+        identifier = DefinitionIdentifier("Collections"),
+        shape = Type.Shape(
+            listOf(
+                field("externalIds", Reference.Dict(reference = string(), isNullable = false)),
+                field("text", Reference.Dict(reference = Reference.Custom("Nested", false), isNullable = false)),
+                field("gtins", Reference.Iterable(reference = string(), isNullable = false)),
+                field("children", Reference.Iterable(reference = Reference.Custom("Nested", false), isNullable = true)),
+                field("update", Reference.Custom("Nested", isNullable = true)),
+            ),
+        ),
+        extends = emptyList(),
+    )
+
+    @Test
+    fun emitKotlinCollections() {
+        val ast = AST(nonEmptyListOf(Module(FileUri(""), nonEmptyListOf(collections, nested))))
+        val emitted = kotlinEmitter.emit(ast, noLogger).avro("packageName/avro/CollectionsAvro.kt").orEmpty()
+
+        // Maps and arrays of primitives already hold the types the writer wants and pass through
+        // untouched; the record-valued ones convert per entry. A nullable collection or record
+        // keeps its null rather than being dereferenced.
+        assertContains(emitted, "record.put(0, data.externalIds)")
+        assertContains(emitted, "record.put(1, data.text.mapValues{NestedAvro.to(it.value)})")
+        assertContains(emitted, "record.put(2, data.gtins)")
+        assertContains(emitted, "record.put(3, data.children?.map{NestedAvro.to(it)})")
+        assertContains(emitted, "record.put(4, data.update?.let{NestedAvro.to(it)})")
+
+        // Avro hands strings back as Utf8, and map keys with them, so both go through toString().
+        assertContains(emitted, "externalIds = (record.get(0) as kotlin.collections.Map<*, *>).entries.associate{it.key.toString() to it.value.toString()}")
+        assertContains(emitted, "text = (record.get(1) as kotlin.collections.Map<*, *>).entries.associate{it.key.toString() to NestedAvro.from(it.value as org.apache.avro.generic.GenericData.Record)}")
+        assertContains(emitted, "gtins = (record.get(2) as kotlin.collections.List<*>).map{it.toString()}")
+        assertContains(emitted, "children = (record.get(3) as kotlin.collections.List<*>?)?.map{NestedAvro.from(it as org.apache.avro.generic.GenericData.Record)}")
+        assertContains(emitted, "update = (record.get(4) as org.apache.avro.generic.GenericData.Record?)?.let{NestedAvro.from(it)}")
+
+        // The schema keeps the map structure rather than failing to flatten it.
+        assertContains(emitted, """{\"type\":\"map\",\"values\":\"string\"}""")
+    }
+
+    /** A taxonomy node holding its own parents — the shape that used to inline itself forever. */
+    private val recursive = Type(
+        comment = null,
+        annotations = emptyList(),
+        identifier = DefinitionIdentifier("Node"),
+        shape = Type.Shape(
+            listOf(
+                field("name", string()),
+                field("parents", Reference.Iterable(reference = Reference.Custom("Node", false), isNullable = false)),
+                field("nested", Reference.Custom("Nested", isNullable = false)),
+                field("alsoNested", Reference.Custom("Nested", isNullable = false)),
+            ),
+        ),
+        extends = emptyList(),
+    )
+
+    @Test
+    fun emitKotlinRecursiveSchema() {
+        val ast = AST(nonEmptyListOf(Module(FileUri(""), nonEmptyListOf(recursive, nested))))
+        val emitted = kotlinEmitter.emit(ast, noLogger).avro("packageName/avro/NodeAvro.kt").orEmpty()
+
+        // The self reference is a bare Avro name: the record is already defined by the time the
+        // field is read, so there is nothing left to inline.
+        assertContains(emitted, """{\"name\":\"parents\",\"type\":{\"type\":\"array\",\"items\":\"Node\"}}""")
+        // A nested record is written out in full once...
+        assertContains(emitted, """{\"name\":\"nested\",\"type\":{\"type\":\"record\",\"name\":\"Nested\"""")
+        // ...and referred to by name after that, since Avro forbids defining a name twice.
+        assertContains(emitted, """{\"name\":\"alsoNested\",\"type\":\"Nested\"}""")
+        // Nothing is spliced in from another object, so SCHEMA is a single parsed literal.
+        org.junit.jupiter.api.Assertions.assertFalse(
+            emitted.contains("NodeAvro.SCHEMA"),
+            "NodeAvro.SCHEMA must not reference itself:\n$emitted",
+        )
+    }
+
+    private fun assertContains(actual: String, expected: String) = org.junit.jupiter.api.Assertions.assertTrue(
+        actual.contains(expected),
+        "expected to find:\n  $expected\nin:\n$actual",
+    )
+
     @Test
     fun emitJavaType() {
         val ast = AST(nonEmptyListOf(Module(FileUri(""), nonEmptyListOf(type))))


### PR DESCRIPTION
## Summary

The Avro extension emitted code that did not compile — or schemas Avro refused to parse — for several shapes the Wirespec language allows. This fixes the emitter for those shapes and adds tests covering each one.

## What was broken

| Shape | Before |
|---|---|
| `Map<String, T>` | `TODO()` while flattening the schema; no `to`/`from` conversion at all |
| Nullable field | Dereferenced unconditionally — a null field threw instead of staying null |
| `List<primitive>` | Converted per element as though it held records |
| String-shaped values | Cast straight to `String`, but Avro hands them back as `Utf8` |
| `bytes` | Round-tripped through `String(...)` rather than the `ByteArray` the model holds |
| Recursive type | Spliced its own `SCHEMA` in and recursed forever (directly or via a nested record) |

## Approach

Each schema is now emitted **per definition** and self-contained, rather than picked out of the whole module. Names are tracked while flattening: a record or enum is written out in full the first time it appears and referred to by bare name after that — which is both how Avro deduplicates and the only way to express a recursive type.

`to`/`from` conversions were reworked to be driven by the reference shape: collections of primitives pass through untouched, record-valued ones convert per entry, and nullable slots keep their null under `?.` instead of being dereferenced.

## Test plan

- New `emitKotlinCollections` — maps, arrays of primitives, nullable collections and nullable records, asserting both the emitted conversions and the map schema
- New `emitKotlinRecursiveSchema` — a self-referencing node type, asserting the self reference is a bare name, a nested record appears in full once then by name, and `SCHEMA` never references itself
- `./gradlew :src:integration:avro:jvmTest` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)