### PR TITLE
feat(compiler): add Any as a first-class type in the Wirespec language

### DIFF
--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
@@ -42,6 +42,7 @@ import community.flock.wirespec.compiler.core.tokenize.TypeDefinition
 import community.flock.wirespec.compiler.core.tokenize.TypeIdentifier
 import community.flock.wirespec.compiler.core.tokenize.Underscore
 import community.flock.wirespec.compiler.core.tokenize.WhiteSpaceExceptNewLine
+import community.flock.wirespec.compiler.core.tokenize.WsAny
 import community.flock.wirespec.compiler.core.tokenize.WsBoolean
 import community.flock.wirespec.compiler.core.tokenize.WsBytes
 import community.flock.wirespec.compiler.core.tokenize.WsInteger
@@ -103,6 +104,7 @@ object WirespecSpec : LanguageSpec {
 
 data object WirespecType : TypeIdentifier {
     override val specificTypes = mapOf(
+        "Any" to WsAny,
         "Boolean" to WsBoolean,
         "Bytes" to WsBytes,
         "Integer" to WsInteger(P64),

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
@@ -41,6 +41,7 @@ import community.flock.wirespec.compiler.core.tokenize.TypeIdentifier
 import community.flock.wirespec.compiler.core.tokenize.Underscore
 import community.flock.wirespec.compiler.core.tokenize.WirespecIdentifier
 import community.flock.wirespec.compiler.core.tokenize.WirespecType
+import community.flock.wirespec.compiler.core.tokenize.WsAny
 import community.flock.wirespec.compiler.core.tokenize.WsBoolean
 import community.flock.wirespec.compiler.core.tokenize.WsBytes
 import community.flock.wirespec.compiler.core.tokenize.WsInteger
@@ -104,6 +105,12 @@ object TypeParser {
 
             is WsUnit -> {
                 Reference.Unit(
+                    isNullable = isNullable().bind(),
+                )
+            }
+
+            is WsAny -> {
+                Reference.Any(
                     isNullable = isNullable().bind(),
                 )
             }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
@@ -72,6 +72,7 @@ interface TypeIdentifier : WirespecType {
 }
 
 data object WsUnit : SpecificType
+data object WsAny : SpecificType
 data object WsString : PrimitiveType
 data object WsBoolean : PrimitiveType
 data object WsBytes : PrimitiveType

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseTypeTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseTypeTest.kt
@@ -62,6 +62,34 @@ class ParseTypeTest {
     }
 
     @Test
+    fun testAnyTypeParser() {
+        val source =
+            // language=ws
+            """
+            |type Foo {
+            |    bar: Any,
+            |    baz: Any?,
+            |    qux: Any[]
+            |}
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(1)
+            .first()
+            .shouldBeInstanceOf<Type>()
+            .also { it.identifier.value shouldBe "Foo" }
+            .shape.value
+            .shouldHaveSize(3)
+            .run {
+                get(0).reference.shouldBeInstanceOf<Reference.Any>().isNullable.shouldBeFalse()
+                get(1).reference.shouldBeInstanceOf<Reference.Any>().isNullable shouldBe true
+                get(2).reference.shouldBeInstanceOf<Reference.Iterable>()
+                    .reference.shouldBeInstanceOf<Reference.Any>().isNullable.shouldBeFalse()
+            }
+    }
+
+    @Test
     fun testRefinedParserString() {
         val source =
             // language=ws

--- a/src/compiler/emitters/java/fixtures/compileAnyTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileAnyTest.txt
@@ -1,0 +1,27 @@
+package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
+public record Message (
+  Object payload,
+  java.util.Optional<Object> metadata,
+  java.util.List<Object> attachments,
+  java.util.Map<String, Object> extensions
+) implements Wirespec.Shape {
+  @Override
+  public java.util.List<String> validate() {
+    return java.util.List.<String>of();
+  }
+};
+
+package community.flock.wirespec.generated.generator;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.Message;
+public interface MessageGenerator {
+  public static Message generate(Wirespec.Generator generator, java.util.List<String> path) {
+    return new Message(
+      null,
+      generator.generate(java.util.stream.Stream.of(path, java.util.List.of("metadata")).flatMap(java.util.Collection::stream).toList(), new Wirespec.GeneratorFieldNullable<>((p0) -> null)),
+      generator.generate(java.util.stream.Stream.of(path, java.util.List.of("attachments")).flatMap(java.util.Collection::stream).toList(), new Wirespec.GeneratorFieldArray<>((p0) -> null)),
+      generator.generate(java.util.stream.Stream.of(path, java.util.List.of("extensions")).flatMap(java.util.Collection::stream).toList(), new Wirespec.GeneratorFieldDict<>((p0) -> null))
+    );
+  }
+}

--- a/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitterTest.kt
+++ b/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitterTest.kt
@@ -8,6 +8,7 @@ import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
@@ -84,6 +85,11 @@ class JavaIrEmitterTest {
     @Test
     fun compileTypeTest() {
         CompileTypeTest.compiler { JavaIrEmitter() } shouldBeRight EmitterFixtures.compileTypeTest
+    }
+
+    @Test
+    fun compileAnyTest() {
+        CompileAnyTest.compiler { JavaIrEmitter() } shouldBeRight EmitterFixtures.compileAnyTest
     }
 
     @Test

--- a/src/compiler/emitters/kotlin/fixtures/compileAnyTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileAnyTest.txt
@@ -1,0 +1,26 @@
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+data class Message(
+  val payload: Any,
+  val metadata: Any?,
+  val attachments: List<Any>,
+  val extensions: Map<String, Any>
+) : Wirespec.Shape {
+  override fun validate(): List<String> =
+    emptyList<String>()
+}
+
+package community.flock.wirespec.generated.generator
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.Message
+object MessageGenerator {
+  fun generate(generator: Wirespec.Generator, path: List<String>): Message =
+    Message(
+      payload = null,
+      metadata = generator.generate(path + listOf("metadata"), Wirespec.GeneratorFieldNullable(generate = { p0 -> null })),
+      attachments = generator.generate(path + listOf("attachments"), Wirespec.GeneratorFieldArray(generate = { p0 -> null })),
+      extensions = generator.generate(path + listOf("extensions"), Wirespec.GeneratorFieldDict(generate = { p0 -> null }))
+    )
+}

--- a/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
+++ b/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
@@ -8,6 +8,7 @@ import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
@@ -118,6 +119,13 @@ class KotlinIrEmitterTest {
         val kotlin = EmitterFixtures.compileTypeTest
 
         CompileTypeTest.compiler { KotlinIrEmitter() } shouldBeRight kotlin
+    }
+
+    @Test
+    fun compileAnyTest() {
+        val kotlin = EmitterFixtures.compileAnyTest
+
+        CompileAnyTest.compiler { KotlinIrEmitter() } shouldBeRight kotlin
     }
 
     @Test

--- a/src/compiler/emitters/python/fixtures/compileAnyTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileAnyTest.txt
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+@dataclass
+class Message(Wirespec.Shape):
+    payload: Any
+    metadata: Optional[Any]
+    attachments: list[Any]
+    extensions: dict[str, Any]
+    def validate(self) -> list[str]:
+        return []
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+from ..model.Message import Message
+class MessageGenerator:
+    @staticmethod
+    def generate(generator: Wirespec.Generator, path: list[str]) -> Message:
+        return Message(payload=None, metadata=generator.generate(path + ['metadata'], Wirespec.GeneratorFieldNullable(generate=lambda p0: None)), attachments=generator.generate(path + ['attachments'], Wirespec.GeneratorFieldArray(generate=lambda p0: None)), extensions=generator.generate(path + ['extensions'], Wirespec.GeneratorFieldDict(generate=lambda p0: None)))
+
+from . import model
+from . import endpoint
+from . import wirespec
+
+
+
+
+
+

--- a/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitterTest.kt
+++ b/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitterTest.kt
@@ -1,6 +1,7 @@
 package community.flock.wirespec.emitters.python
 
 import community.flock.wirespec.compiler.core.emit.EmitShared
+import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
@@ -65,6 +66,13 @@ class PythonIrEmitterTest {
         val python = EmitterFixtures.compileTypeTest
 
         CompileTypeTest.compiler { PythonIrEmitter() } shouldBeRight python
+    }
+
+    @Test
+    fun compileAnyTest() {
+        val python = EmitterFixtures.compileAnyTest
+
+        CompileAnyTest.compiler { PythonIrEmitter() } shouldBeRight python
     }
 
     @Test

--- a/src/compiler/emitters/rust/fixtures/compileAnyTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileAnyTest.txt
@@ -1,0 +1,29 @@
+use super::super::wirespec::*;
+use regex;
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Message {
+    pub payload: Box<dyn std::any::Any>,
+    pub metadata: Option<Box<dyn std::any::Any>>,
+    pub attachments: Vec<Box<dyn std::any::Any>>,
+    pub extensions: std::collections::HashMap<String, Box<dyn std::any::Any>>,
+}
+impl Message {
+    pub fn validate(&self) -> Vec<String> {
+        return Vec::<String>::new();
+    }
+}
+
+use super::super::wirespec::*;
+use regex;
+use super::super::model::message::Message;
+pub struct MessageGenerator;
+impl MessageGenerator {
+    pub fn generate(generator: Wirespec.Generator, path: Vec<String>) -> Message {
+        return Message { payload: None, metadata: generator.generate(vec![path.as_slice(), vec![String::from("metadata")].as_slice()].concat(), Wirespec.GeneratorFieldNullable { generate: Box::new(|p0| None) }), attachments: generator.generate(vec![path.as_slice(), vec![String::from("attachments")].as_slice()].concat(), Wirespec.GeneratorFieldArray { generate: Box::new(|p0| None) }), extensions: generator.generate(vec![path.as_slice(), vec![String::from("extensions")].as_slice()].concat(), Wirespec.GeneratorFieldDict { generate: Box::new(|p0| None) }) };
+    }
+}
+
+#![allow(warnings)]
+pub mod model;
+pub mod endpoint;
+pub mod wirespec;

--- a/src/compiler/emitters/rust/src/commonTest/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitterTest.kt
+++ b/src/compiler/emitters/rust/src/commonTest/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitterTest.kt
@@ -1,6 +1,7 @@
 package community.flock.wirespec.emitters.rust
 
 import community.flock.wirespec.compiler.core.emit.EmitShared
+import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
@@ -30,6 +31,13 @@ class RustIrEmitterTest {
         val rust = EmitterFixtures.compileTypeTest
 
         CompileTypeTest.compiler { RustIrEmitter() } shouldBeRight rust
+    }
+
+    @Test
+    fun compileAnyTest() {
+        val rust = EmitterFixtures.compileAnyTest
+
+        CompileAnyTest.compiler { RustIrEmitter() } shouldBeRight rust
     }
 
     @Test

--- a/src/compiler/emitters/scala/fixtures/compileAnyTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileAnyTest.txt
@@ -1,0 +1,26 @@
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+case class Message(
+  val payload: Any,
+  val metadata: Option[Any],
+  val attachments: List[Any],
+  val extensions: Map[String, Any]
+) extends Wirespec.Shape {
+  override def validate(): List[String] =
+    List.empty[String]
+}
+
+package community.flock.wirespec.generated.generator
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+import community.flock.wirespec.generated.model.Message
+object MessageGenerator {
+  def generate(generator: Wirespec.Generator, path: List[String]): Message =
+    new Message(
+      payload = null,
+      metadata = generator.generate(path ++ List("metadata"), new Wirespec.GeneratorFieldNullable(generate = (p0) => null)),
+      attachments = generator.generate(path ++ List("attachments"), new Wirespec.GeneratorFieldArray(generate = (p0) => null)),
+      extensions = generator.generate(path ++ List("extensions"), new Wirespec.GeneratorFieldDict(generate = (p0) => null))
+    )
+}

--- a/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
+++ b/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
@@ -8,6 +8,7 @@ import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
@@ -76,6 +77,13 @@ class ScalaIrEmitterTest {
         val scala = EmitterFixtures.compileTypeTest
 
         CompileTypeTest.compiler { ScalaIrEmitter() } shouldBeRight scala
+    }
+
+    @Test
+    fun compileAnyTest() {
+        val scala = EmitterFixtures.compileAnyTest
+
+        CompileAnyTest.compiler { ScalaIrEmitter() } shouldBeRight scala
     }
 
     @Test

--- a/src/compiler/emitters/typescript/fixtures/compileAnyTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/compileAnyTest.txt
@@ -1,0 +1,20 @@
+import {Wirespec} from '../Wirespec'
+export type Message = {
+  "payload": any,
+  "metadata": any | undefined,
+  "attachments": any[],
+  "extensions": Record<string, any>,
+}
+export function validateMessage(obj: Message): string[] {
+  return [] as string[];
+}
+
+import {Wirespec} from '../Wirespec'
+import {Message} from '../model/Message'
+export namespace MessageGenerator {
+  export function generate(generator: Wirespec.Generator, path: string[]): Message {
+    return { payload: undefined, metadata: generator.generate([...path, ...['metadata']], { kind: 'nullable', generate: (p0: string[]) => undefined }), attachments: generator.generate([...path, ...['attachments']], { kind: 'array', generate: (p0: string[]) => undefined }), extensions: generator.generate([...path, ...['extensions']], { kind: 'dict', generate: (p0: string[]) => undefined }) };
+  }
+}
+
+export {Message} from './Message'

--- a/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitterTest.kt
+++ b/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitterTest.kt
@@ -1,5 +1,6 @@
 package community.flock.wirespec.emitters.typescript
 
+import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
@@ -64,6 +65,13 @@ class TypeScriptIrEmitterTest {
         val typescript = EmitterFixtures.compileTypeTest
 
         CompileTypeTest.compiler { TypeScriptIrEmitter() } shouldBeRight typescript
+    }
+
+    @Test
+    fun compileAnyTest() {
+        val typescript = EmitterFixtures.compileAnyTest
+
+        CompileAnyTest.compiler { TypeScriptIrEmitter() } shouldBeRight typescript
     }
 
     @Test

--- a/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
+++ b/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
@@ -4,6 +4,7 @@ import community.flock.wirespec.compiler.core.exceptions.NullableRefinedReferenc
 import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
@@ -197,6 +198,21 @@ class WirespecEmitterTest {
         """.trimMargin()
 
         CompileTypeTest.compiler { WirespecEmitter() } shouldBeRight wirespec
+    }
+
+    @Test
+    fun compileAnyTest() {
+        val wirespec = """
+            |type Message {
+            |  payload: Any,
+            |  metadata: Any?,
+            |  attachments: Any[],
+            |  extensions: { Any }
+            |}
+            |
+        """.trimMargin()
+
+        CompileAnyTest.compiler { WirespecEmitter() } shouldBeRight wirespec
     }
 
     @Test

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -1055,7 +1055,7 @@ private fun Type.toTypeName(): String = when (this) {
 }
 
 fun ReferenceWirespec.convert(): Type = when (this) {
-    is ReferenceWirespec.Any -> Type.Custom("Any")
+    is ReferenceWirespec.Any -> Type.Any
     is ReferenceWirespec.Custom -> Type.Custom(Name.of(value).pascalCase())
     is ReferenceWirespec.Dict -> Type.Dict(Type.String, reference.convert())
     is ReferenceWirespec.Iterable -> Type.Array(reference.convert())

--- a/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileAnyTest.kt
+++ b/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileAnyTest.kt
@@ -1,0 +1,17 @@
+package community.flock.wirespec.compiler.test
+
+object CompileAnyTest : Fixture {
+
+    override val source =
+        // language=ws
+        """
+        |type Message {
+        |  payload: Any,
+        |  metadata: Any?,
+        |  attachments: Any[],
+        |  extensions: { Any }
+        |}
+        """.trimMargin()
+
+    override val compiler = source.let(::compile)
+}

--- a/src/compiler/test/src/jvmMain/kotlin/community/flock/wirespec/compiler/test/EmitterFixtureUpdater.kt
+++ b/src/compiler/test/src/jvmMain/kotlin/community/flock/wirespec/compiler/test/EmitterFixtureUpdater.kt
@@ -81,6 +81,7 @@ private fun compileFixtures(emitterFactory: () -> Emitter): Map<String, () -> St
     "compileFieldNameSanitizationTest" to { compile(CompileFieldNameSanitizationTest, emitterFactory) },
     "compileNestedTypeTest" to { compile(CompileNestedTypeTest, emitterFactory) },
     "compileComplexModelTest" to { compile(CompileComplexModelTest, emitterFactory) },
+    "compileAnyTest" to { compile(CompileAnyTest, emitterFactory) },
 )
 
 private fun nodeFixtures(emitterFactory: () -> Emitter): Map<String, () -> String> {

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
@@ -38,6 +38,7 @@ import community.flock.wirespec.compiler.core.tokenize.TypeIdentifier
 import community.flock.wirespec.compiler.core.tokenize.Underscore
 import community.flock.wirespec.compiler.core.tokenize.WhiteSpace
 import community.flock.wirespec.compiler.core.tokenize.WirespecIdentifier
+import community.flock.wirespec.compiler.core.tokenize.WsAny
 import community.flock.wirespec.compiler.core.tokenize.WsBoolean
 import community.flock.wirespec.compiler.core.tokenize.WsBytes
 import community.flock.wirespec.compiler.core.tokenize.WsInteger
@@ -118,6 +119,7 @@ class Lexer : IntellijLexer() {
             WsBoolean::class to Types.WS_BOOLEAN,
             WsBytes::class to Types.WS_BYTES,
             WsUnit::class to Types.UNIT,
+            WsAny::class to Types.ANY,
             Method::class to Types.METHOD,
             Path::class to Types.PATH,
             Arrow::class to Types.ARROW,

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/SyntaxHighlighter.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/SyntaxHighlighter.kt
@@ -34,6 +34,7 @@ class SyntaxHighlighter : SyntaxHighlighterBase() {
         Types.WS_NUMBER -> arrayOf(KEYWORD)
         Types.WS_STRING -> arrayOf(KEYWORD)
         Types.UNIT -> arrayOf(KEYWORD)
+        Types.ANY -> arrayOf(KEYWORD)
         Types.TYPE_DEF -> arrayOf(KEYWORD)
         Types.ENDPOINT_DEF -> arrayOf(KEYWORD)
         Types.CHANNEL_DEF -> arrayOf(KEYWORD)

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Types.kt
@@ -34,6 +34,7 @@ interface Types {
         val WS_BYTES = ElementType("BYTES")
         val TYPE_IDENTIFIER = ElementType("CUSTOM_TYPE")
         val UNIT = ElementType("UNIT")
+        val ANY = ElementType("ANY")
         val METHOD = ElementType("METHOD")
         val PATH = ElementType("PATH")
         val ARROW = ElementType("ARROW")

--- a/src/integration/avro/src/commonMain/kotlin/community/flock/wirespec/integration/avro/extension/AvroExtension.kt
+++ b/src/integration/avro/src/commonMain/kotlin/community/flock/wirespec/integration/avro/extension/AvroExtension.kt
@@ -341,9 +341,10 @@ private fun String.avroClass(): String = replace(".model.", ".avro.") + "Avro"
  */
 private fun emitAvroSchema(packageName: PackageName, definition: Definition, module: Module) = with(AvroJsonEmitter) {
     when (definition) {
-        is Type -> definition
-            .emit(module, mutableListOf(definition.identifier.value))
-            .copy(namespace = packageName.value)
+        is Type ->
+            definition
+                .emit(module, mutableListOf(definition.identifier.value))
+                .copy(namespace = packageName.value)
         is Enum -> definition.emit()
         else -> null
     }

--- a/src/integration/avro/src/jvmTest/kotlin/community/flock/wirespec/integration/avro/extension/AvroExtensionTest.kt
+++ b/src/integration/avro/src/jvmTest/kotlin/community/flock/wirespec/integration/avro/extension/AvroExtensionTest.kt
@@ -69,8 +69,7 @@ class AvroExtensionTest {
         reference = reference,
     )
 
-    private fun string(isNullable: Boolean = false) =
-        Reference.Primitive(type = Reference.Primitive.Type.String(null), isNullable = isNullable)
+    private fun string(isNullable: Boolean = false) = Reference.Primitive(type = Reference.Primitive.Type.String(null), isNullable = isNullable)
 
     private val nested = Type(
         comment = null,


### PR DESCRIPTION
## What

`Any` was already representable in the AST (`Reference.Any`, produced by the OpenAPI/Avro converters) but could not be written in Wirespec source. This PR makes `Any` a first-class type in the language, with IDE support.

## Changes

**Language (compiler core)**
- Tokenize `Any` as a built-in type (`WsAny : SpecificType`), alongside `String`, `Integer`, `Unit`, …
- Parse it to the existing `Reference.Any`, supporting `Any`, `Any?`, `Any[]` and `{ Any }`

**IR converter fix**
- `Reference.Any` now maps to IR `Type.Any` instead of `Type.Custom("Any")`, which would have emitted a reference to a non-existent `Any` class in Java/TypeScript. Emitted types per target: `Object` (Java), `Any` (Kotlin/Scala/Python), `any` (TypeScript), `Box<dyn std::any::Any>` (Rust). No existing fixtures changed.

**IDE**
- IntelliJ plugin: new `ANY` element type, lexer mapping, and keyword highlighting
- LSP (VS Code/Zed) needed no change — it already treats every `SpecificType` generically

**Tests**
- Parser coverage for `Any`, `Any?`, `Any[]` in `ParseTypeTest`
- New shared `CompileAnyTest` fixture wired into the fixture updater, with generated fixtures and tests in all six IR emitters (Java, Kotlin, Python, Rust, Scala, TypeScript)
- Wirespec emitter round-trip test proving `Any` re-emits as `Any`

## Notes

- Rust's existing `Type.Any` mapping (`Box<dyn Any>` inside `#[derive(Clone, PartialEq, …)]` structs) likely won't compile as real Rust; that mapping predates this PR and may deserve a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)