### PR TITLE
feat: GraphQL support — graphql keyword, typed codegen, and SDL converter/emitter

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ include(
     "src:plugin:gradle",
     "src:converter:common",
     "src:converter:avro",
+    "src:converter:graphql",
     "src:converter:openapi",
     "src:integration:avro",
     "src:integration:jackson",

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/LanguageSpec.kt
@@ -15,6 +15,7 @@ import community.flock.wirespec.compiler.core.tokenize.EnumTypeDefinition
 import community.flock.wirespec.compiler.core.tokenize.Equals
 import community.flock.wirespec.compiler.core.tokenize.FieldIdentifier
 import community.flock.wirespec.compiler.core.tokenize.ForwardSlash
+import community.flock.wirespec.compiler.core.tokenize.GraphqlDefinition
 import community.flock.wirespec.compiler.core.tokenize.Hash
 import community.flock.wirespec.compiler.core.tokenize.Integer
 import community.flock.wirespec.compiler.core.tokenize.KebabCaseIdentifier
@@ -70,6 +71,7 @@ object WirespecSpec : LanguageSpec {
         Regex("^\\benum\\b") to EnumTypeDefinition,
         Regex("^\\bendpoint\\b") to EndpointDefinition,
         Regex("^\\bchannel\\b") to ChannelDefinition,
+        Regex("^\\bgraphql\\b") to GraphqlDefinition,
         Regex("^[^\\S\\r\\n]+") to WhiteSpaceExceptNewLine,
         Regex("^[\\r\\n]") to NewLine,
         Regex("^\\{") to LeftCurly,

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/Defaults.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/Defaults.kt
@@ -3,6 +3,7 @@ package community.flock.wirespec.compiler.core.emit
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Model
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 
@@ -13,6 +14,7 @@ const val DEFAULT_GENERATED_PACKAGE_STRING = "$DEFAULT_PACKAGE.generated"
 fun Definition.namespace() = when (this) {
     is Endpoint -> "endpoint"
     is Channel -> "channel"
+    is Graphql -> "graphql"
     is Model -> "model"
 }
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/EmitterExtensions.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/EmitterExtensions.kt
@@ -4,6 +4,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
 import community.flock.wirespec.compiler.core.parse.ast.Type
@@ -26,6 +27,11 @@ fun Definition.importReferences(): List<Reference.Custom> = when (this) {
             .distinct()
     is Union -> entries.filterIsInstance<Reference.Custom>()
     is Channel -> if (reference is Reference.Custom) listOf(reference) else emptyList()
+    is Graphql ->
+        (inputs.map { it.reference } + output)
+            .map { it.flattenListDict() }
+            .filterIsInstance<Reference.Custom>()
+            .distinct()
     is Enum -> emptyList()
     is Refined -> emptyList()
 }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/Emitters.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/Emitters.kt
@@ -5,6 +5,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Identifier
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
@@ -20,6 +21,7 @@ interface Emitters :
     UnionDefinitionEmitter,
     IdentifierEmitter,
     ChannelDefinitionEmitter,
+    GraphqlDefinitionEmitter,
     NotYetImplemented
 
 interface TypeDefinitionEmitter {
@@ -57,6 +59,10 @@ interface UnionDefinitionEmitter {
 
 interface ChannelDefinitionEmitter {
     fun emit(channel: Channel): String
+}
+
+interface GraphqlDefinitionEmitter {
+    fun emit(graphql: Graphql): String
 }
 
 interface IdentifierEmitter {

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/FileExtension.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/FileExtension.kt
@@ -14,4 +14,5 @@ enum class FileExtension(override val value: String) : Value<String> {
     YAML("yaml"),
     AvroJson("avsc"),
     AvroIdl("avdl"),
+    GraphQL("graphqls"),
 }

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/LanguageEmitter.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/emit/LanguageEmitter.kt
@@ -6,6 +6,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Refined
 import community.flock.wirespec.compiler.core.parse.ast.Type
@@ -38,6 +39,7 @@ abstract class LanguageEmitter :
             is Refined -> Emitted(emit(definition.identifier), emit(definition))
             is Union -> Emitted(emit(definition.identifier), emit(definition))
             is Channel -> Emitted(emit(definition.identifier), emit(definition))
+            is Graphql -> Emitted(emit(definition.identifier), emit(definition))
         }
     }
 
@@ -46,7 +48,7 @@ abstract class LanguageEmitter :
         fun String.firstToLower() = replaceFirstChar(Char::lowercase)
         fun Module.needImports() = statements.any { it is Endpoint || it is Enum || it is Refined }
         fun Module.irNeedsWirespecImport() = statements.any {
-            it is Endpoint || it is Enum || it is Refined || it is Type || it is Channel
+            it is Endpoint || it is Enum || it is Refined || it is Type || it is Channel || it is Graphql
         }
         fun Module.hasEndpoints() = statements.any { it is Endpoint }
         fun String.isStatusCode() = toIntOrNull()?.let { it in 100..599 } ?: false

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/ParserException.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/ParserException.kt
@@ -28,6 +28,13 @@ class DefinitionNotExistsException(fileUri: FileUri, referenceName: String, coor
         message = "Cannot find reference: $referenceName",
     )
 
+class WrongGraphqlKindException(fileUri: FileUri, actual: Token) :
+    ParserException(
+        fileUri,
+        coordinates = actual.coordinates,
+        message = "Query, Mutation or Subscription expected, not: ${actual.value} at line ${actual.coordinates.line} and position ${actual.coordinates.position - actual.value.length}",
+    )
+
 class NullableRefinedReferenceException(fileUri: FileUri, referenceName: String, coordinates: Token.Coordinates) :
     ParserException(
         fileUri,

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/ValidationError.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/exceptions/ValidationError.kt
@@ -39,3 +39,15 @@ class DuplicateChannelError(typeName: String) :
         coordinates = Token.Coordinates(),
         message = "Channel '$typeName' is already defined",
     )
+
+class DuplicateGraphqlError(name: String) :
+    ValidationError(
+        coordinates = Token.Coordinates(),
+        message = "Graphql operation '$name' is already defined",
+    )
+
+class DuplicateGraphqlOperationError(kind: String, operation: String) :
+    ValidationError(
+        coordinates = Token.Coordinates(),
+        message = "Graphql $kind field '$operation' is already defined",
+    )

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/GraphqlParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/GraphqlParser.kt
@@ -1,0 +1,74 @@
+package community.flock.wirespec.compiler.core.parse
+
+import arrow.core.Either
+import community.flock.wirespec.compiler.core.exceptions.WirespecException
+import community.flock.wirespec.compiler.core.exceptions.WrongGraphqlKindException
+import community.flock.wirespec.compiler.core.parse.TypeParser.parseParenthesizedFields
+import community.flock.wirespec.compiler.core.parse.ast.Annotation
+import community.flock.wirespec.compiler.core.parse.ast.Comment
+import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
+import community.flock.wirespec.compiler.core.tokenize.Arrow
+import community.flock.wirespec.compiler.core.tokenize.LeftCurly
+import community.flock.wirespec.compiler.core.tokenize.LeftParenthesis
+import community.flock.wirespec.compiler.core.tokenize.TypeIdentifier
+import community.flock.wirespec.compiler.core.tokenize.WirespecIdentifier
+import community.flock.wirespec.compiler.core.tokenize.WirespecType
+
+object GraphqlParser {
+
+    fun TokenProvider.parseGraphql(comment: Comment?, annotations: List<Annotation>): Either<WirespecException, Graphql> = parseToken {
+        when (token.type) {
+            is WirespecType -> parseGraphqlDefinition(comment, annotations, DefinitionIdentifier(token.value)).bind()
+            else -> raiseWrongToken<WirespecType>().bind()
+        }
+    }
+
+    private fun TokenProvider.parseGraphqlDefinition(
+        comment: Comment?,
+        annotations: List<Annotation>,
+        identifier: DefinitionIdentifier,
+    ) = parseToken {
+        val kind = when (token.type) {
+            is TypeIdentifier ->
+                Graphql.Kind.entries.find { it.name == token.value }
+                    ?: raise(WrongGraphqlKindException(fileUri, token))
+
+            else -> raiseWrongToken<TypeIdentifier>().bind()
+        }.also { eatToken().bind() }
+
+        val operation = when (token.type) {
+            is WirespecIdentifier -> FieldIdentifier(token.value).also { eatToken().bind() }
+            else -> raiseWrongToken<WirespecIdentifier>().bind()
+        }
+
+        val inputs = when (token.type) {
+            is LeftParenthesis -> parseParenthesizedFields().bind()
+            else -> emptyList()
+        }
+
+        when (token.type) {
+            is Arrow -> eatToken().bind()
+            else -> raiseWrongToken<Arrow>().bind()
+        }
+
+        val output = with(TypeParser) {
+            when (token.type) {
+                is LeftCurly -> parseDict().bind()
+                is WirespecType -> parseType().bind()
+                else -> raiseWrongToken<WirespecType>().bind()
+            }
+        }
+
+        Graphql(
+            comment = comment,
+            annotations = annotations,
+            identifier = identifier,
+            kind = kind,
+            operation = operation,
+            inputs = inputs,
+            output = output,
+        )
+    }
+}

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/GraphqlParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/GraphqlParser.kt
@@ -3,17 +3,14 @@ package community.flock.wirespec.compiler.core.parse
 import arrow.core.Either
 import community.flock.wirespec.compiler.core.exceptions.WirespecException
 import community.flock.wirespec.compiler.core.exceptions.WrongGraphqlKindException
-import community.flock.wirespec.compiler.core.parse.TypeParser.parseParenthesizedFields
+import community.flock.wirespec.compiler.core.parse.TypeParser.parseCurlyFields
 import community.flock.wirespec.compiler.core.parse.ast.Annotation
 import community.flock.wirespec.compiler.core.parse.ast.Comment
 import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
-import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.tokenize.Arrow
 import community.flock.wirespec.compiler.core.tokenize.LeftCurly
-import community.flock.wirespec.compiler.core.tokenize.LeftParenthesis
 import community.flock.wirespec.compiler.core.tokenize.TypeIdentifier
-import community.flock.wirespec.compiler.core.tokenize.WirespecIdentifier
 import community.flock.wirespec.compiler.core.tokenize.WirespecType
 
 object GraphqlParser {
@@ -38,14 +35,9 @@ object GraphqlParser {
             else -> raiseWrongToken<TypeIdentifier>().bind()
         }.also { eatToken().bind() }
 
-        val operation = when (token.type) {
-            is WirespecIdentifier -> FieldIdentifier(token.value).also { eatToken().bind() }
-            else -> raiseWrongToken<WirespecIdentifier>().bind()
-        }
-
         val inputs = when (token.type) {
-            is LeftParenthesis -> parseParenthesizedFields().bind()
-            else -> emptyList()
+            is LeftCurly -> parseCurlyFields().bind()
+            else -> raiseWrongToken<LeftCurly>().bind()
         }
 
         when (token.type) {
@@ -66,7 +58,6 @@ object GraphqlParser {
             annotations = annotations,
             identifier = identifier,
             kind = kind,
-            operation = operation,
             inputs = inputs,
             output = output,
         )

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Parser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/Parser.kt
@@ -22,6 +22,7 @@ import community.flock.wirespec.compiler.core.tokenize.ChannelDefinition
 import community.flock.wirespec.compiler.core.tokenize.Comment
 import community.flock.wirespec.compiler.core.tokenize.EndpointDefinition
 import community.flock.wirespec.compiler.core.tokenize.EnumTypeDefinition
+import community.flock.wirespec.compiler.core.tokenize.GraphqlDefinition
 import community.flock.wirespec.compiler.core.tokenize.Token
 import community.flock.wirespec.compiler.core.tokenize.TokenType
 import community.flock.wirespec.compiler.core.tokenize.TypeDefinition
@@ -103,6 +104,7 @@ private fun TokenProvider.parseDefinition() = either {
             is EnumTypeDefinition -> with(EnumParser) { parseEnum(comment, annotations) }.bind()
             is EndpointDefinition -> with(EndpointParser) { parseEndpoint(comment, annotations) }.bind()
             is ChannelDefinition -> with(ChannelParser) { parseChannel(comment, annotations) }.bind()
+            is GraphqlDefinition -> with(GraphqlParser) { parseGraphql(comment, annotations) }.bind()
         }
 
         else -> raiseWrongToken<WirespecDefinition>().bind()

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
@@ -81,6 +81,31 @@ object TypeParser {
         }.let(Type::Shape)
     }
 
+    fun TokenProvider.parseCurlyFields(): Either<WirespecException, List<Field>> = parseToken {
+        mutableListOf<Field>().apply {
+            if (token.type !is RightCurly) {
+                val firstFieldAnnotations = parseAnnotations().bind()
+                when (token.type) {
+                    is WirespecIdentifier -> add(parseField(FieldIdentifier(token.value), firstFieldAnnotations).bind())
+                    else -> raiseWrongToken<WirespecIdentifier>().bind()
+                }
+                while (token.type is Comma) {
+                    eatToken().bind()
+                    val fieldAnnotations = parseAnnotations().bind()
+                    when (token.type) {
+                        is WirespecIdentifier -> add(parseField(FieldIdentifier(token.value), fieldAnnotations).bind())
+                        else -> raiseWrongToken<WirespecIdentifier>().bind()
+                    }
+                }
+            }
+        }.also {
+            when (token.type) {
+                is RightCurly -> eatToken().bind()
+                else -> raiseWrongToken<RightCurly>().bind()
+            }
+        }.toList()
+    }
+
     fun TokenProvider.parseParenthesizedFields(): Either<WirespecException, List<Field>> = parseToken {
         mutableListOf<Field>().apply {
             val firstFieldAnnotations = parseAnnotations().bind()

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/TypeParser.kt
@@ -81,6 +81,29 @@ object TypeParser {
         }.let(Type::Shape)
     }
 
+    fun TokenProvider.parseParenthesizedFields(): Either<WirespecException, List<Field>> = parseToken {
+        mutableListOf<Field>().apply {
+            val firstFieldAnnotations = parseAnnotations().bind()
+            when (token.type) {
+                is WirespecIdentifier -> add(parseField(FieldIdentifier(token.value), firstFieldAnnotations).bind())
+                else -> raiseWrongToken<WirespecIdentifier>().bind()
+            }
+            while (token.type is Comma) {
+                eatToken().bind()
+                val fieldAnnotations = parseAnnotations().bind()
+                when (token.type) {
+                    is WirespecIdentifier -> add(parseField(FieldIdentifier(token.value), fieldAnnotations).bind())
+                    else -> raiseWrongToken<WirespecIdentifier>().bind()
+                }
+            }
+        }.also {
+            when (token.type) {
+                is RightParenthesis -> eatToken().bind()
+                else -> raiseWrongToken<RightParenthesis>().bind()
+            }
+        }.toList()
+    }
+
     fun TokenProvider.parseDict(): Either<WirespecException, Reference.Dict> = parseToken {
         when (token.type) {
             is WirespecType -> Reference.Dict(
@@ -306,6 +329,11 @@ private fun TokenProvider.parsePrimitiveType(previousToken: Token) = either {
 }
 
 private fun TokenProvider.parseField(identifier: FieldIdentifier, annotations: List<Annotation>) = parseToken {
+    val parameters = when (token.type) {
+        is LeftParenthesis -> with(TypeParser) { parseParenthesizedFields().bind() }
+        else -> emptyList()
+    }
+
     when (token.type) {
         is Colon -> eatToken().bind()
         else -> raiseWrongToken<Colon>().bind()
@@ -316,12 +344,14 @@ private fun TokenProvider.parseField(identifier: FieldIdentifier, annotations: L
             identifier = identifier,
             reference = parseDict().bind(),
             annotations = annotations,
+            parameters = parameters,
         )
 
         is WirespecType -> Field(
             identifier = identifier,
             reference = parseType().bind(),
             annotations = annotations,
+            parameters = parameters,
         )
 
         else -> raiseWrongToken<WirespecType>().bind()

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
@@ -12,6 +12,7 @@ data class Field(
     override val annotations: List<Annotation>,
     val identifier: FieldIdentifier,
     val reference: Reference,
+    val parameters: List<Field> = emptyList(),
 ) : HasAnnotations
 
 data class Endpoint(
@@ -47,6 +48,18 @@ data class Channel(
     override val identifier: DefinitionIdentifier,
     val reference: Reference,
 ) : Definition
+
+data class Graphql(
+    override val comment: Comment?,
+    override val annotations: List<Annotation>,
+    override val identifier: DefinitionIdentifier,
+    val kind: Kind,
+    val operation: FieldIdentifier,
+    val inputs: List<Field>,
+    val output: Reference,
+) : Definition {
+    enum class Kind { Query, Mutation, Subscription }
+}
 
 sealed interface Model : Definition
 

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/parse/ast/Definition.kt
@@ -54,11 +54,18 @@ data class Graphql(
     override val annotations: List<Annotation>,
     override val identifier: DefinitionIdentifier,
     val kind: Kind,
-    val operation: FieldIdentifier,
     val inputs: List<Field>,
     val output: Reference,
 ) : Definition {
     enum class Kind { Query, Mutation, Subscription }
+
+    // The GraphQL root field name: the identifier, minus a trailing kind suffix, dromedary-cased.
+    // GetPet (Query) -> getPet; PetQuery (Query) -> pet, restoring converted schemas' field names.
+    val operation: String
+        get() = identifier.value
+            .removeSuffix(kind.name)
+            .ifEmpty { identifier.value }
+            .replaceFirstChar(Char::lowercaseChar)
 }
 
 sealed interface Model : Definition

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/tokenize/TokenTypes.kt
@@ -59,6 +59,7 @@ data object TypeDefinition : WirespecDefinition
 data object EnumTypeDefinition : WirespecDefinition
 data object ChannelDefinition : WirespecDefinition
 data object EndpointDefinition : WirespecDefinition
+data object GraphqlDefinition : WirespecDefinition
 
 sealed interface ChannelTokenType : TokenType
 data object Method : ChannelTokenType

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/validate/Validator.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/validate/Validator.kt
@@ -9,6 +9,8 @@ import arrow.core.right
 import arrow.core.toNonEmptyListOrNull
 import community.flock.wirespec.compiler.core.exceptions.DuplicateChannelError
 import community.flock.wirespec.compiler.core.exceptions.DuplicateEndpointError
+import community.flock.wirespec.compiler.core.exceptions.DuplicateGraphqlError
+import community.flock.wirespec.compiler.core.exceptions.DuplicateGraphqlOperationError
 import community.flock.wirespec.compiler.core.exceptions.DuplicateTypeError
 import community.flock.wirespec.compiler.core.exceptions.UnionError
 import community.flock.wirespec.compiler.core.exceptions.WirespecException
@@ -17,6 +19,7 @@ import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
@@ -31,7 +34,8 @@ object Validator {
         validateEndpoints(ast),
         validateTypes(ast),
         validateChannels(ast),
-    ) { a, _, _, _ -> a }
+        validateGraphql(ast),
+    ) { a, _, _, _, _ -> a }
 
     private fun validateWithOptions(ast: AST, options: ParseOptions): EitherNel<WirespecException, AST> = ast.modules
         .map { (uri, statements) -> runValidateOptions(options)(statements).map { Module(uri, it) } }
@@ -47,6 +51,7 @@ object Validator {
             when (definition) {
                 is Channel -> definition
                 is Endpoint -> definition
+                is Graphql -> definition
                 is Enum -> definition
                 is Refined -> definition
                 is Type -> definition.copy(
@@ -98,6 +103,23 @@ object Validator {
         .filter { it.value.size > 1 }
         .map { (name, channels) -> channels.map { DuplicateChannelError(name) } }
         .flatten()
+        .toNonEmptyListOrNull()
+        ?.left()
+        ?: ast.right()
+
+    private fun validateGraphql(ast: AST): EitherNel<WirespecException, AST> = ast.modules.toList()
+        .flatMap { it.statements.filterIsInstance<Graphql>() }
+        .let { definitions ->
+            val duplicateNames = definitions
+                .groupBy { it.identifier.value }
+                .filter { it.value.size > 1 }
+                .flatMap { (name, defs) -> defs.map { DuplicateGraphqlError(name) } }
+            val duplicateOperations = definitions
+                .groupBy { it.kind to it.operation.value }
+                .filter { it.value.size > 1 }
+                .flatMap { (key, defs) -> defs.map { DuplicateGraphqlOperationError(key.first.name, key.second) } }
+            duplicateNames + duplicateOperations
+        }
         .toNonEmptyListOrNull()
         ?.left()
         ?: ast.right()

--- a/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/validate/Validator.kt
+++ b/src/compiler/core/src/commonMain/kotlin/community/flock/wirespec/compiler/core/validate/Validator.kt
@@ -115,7 +115,7 @@ object Validator {
                 .filter { it.value.size > 1 }
                 .flatMap { (name, defs) -> defs.map { DuplicateGraphqlError(name) } }
             val duplicateOperations = definitions
-                .groupBy { it.kind to it.operation.value }
+                .groupBy { it.kind to it.operation }
                 .filter { it.value.size > 1 }
                 .flatMap { (key, defs) -> defs.map { DuplicateGraphqlOperationError(key.first.name, key.second) } }
             duplicateNames + duplicateOperations

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseGraphqlTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseGraphqlTest.kt
@@ -31,7 +31,7 @@ class ParseGraphqlTest {
             // language=ws
             """
             |type Pet { id: String, name: String? }
-            |graphql GetPet Query pet(id: String) -> Pet?
+            |graphql GetPet Query {id: String} -> Pet?
             """.trimMargin()
 
         parser(source)
@@ -41,7 +41,7 @@ class ParseGraphqlTest {
             .run {
                 identifier.value shouldBe "GetPet"
                 kind shouldBe Graphql.Kind.Query
-                operation.value shouldBe "pet"
+                operation shouldBe "getPet"
                 inputs.shouldHaveSize(1).first().run {
                     identifier.value shouldBe "id"
                     reference.shouldBeInstanceOf<Reference.Primitive>().type.shouldBeInstanceOf<Reference.Primitive.Type.String>()
@@ -59,7 +59,7 @@ class ParseGraphqlTest {
             // language=ws
             """
             |type Pet { id: String }
-            |graphql GetPets Query pets -> Pet[]
+            |graphql GetPets Query {} -> Pet[]
             """.trimMargin()
 
         parser(source)
@@ -69,7 +69,7 @@ class ParseGraphqlTest {
             .run {
                 identifier.value shouldBe "GetPets"
                 kind shouldBe Graphql.Kind.Query
-                operation.value shouldBe "pets"
+                operation shouldBe "getPets"
                 inputs.shouldHaveSize(0)
                 output.shouldBeInstanceOf<Reference.Iterable>().run {
                     isNullable shouldBe false
@@ -85,7 +85,7 @@ class ParseGraphqlTest {
             """
             |type Pet { id: String }
             |type PetInput { name: String }
-            |graphql AddPet Mutation addPet(input: PetInput, tag: String?) -> Pet
+            |graphql AddPet Mutation {input: PetInput, tag: String?} -> Pet
             """.trimMargin()
 
         parser(source)
@@ -94,7 +94,7 @@ class ParseGraphqlTest {
             .shouldBeInstanceOf<Graphql>()
             .run {
                 kind shouldBe Graphql.Kind.Mutation
-                operation.value shouldBe "addPet"
+                operation shouldBe "addPet"
                 inputs.shouldHaveSize(2)
                 inputs[0].reference.shouldBeInstanceOf<Reference.Custom>().value shouldBe "PetInput"
                 inputs[1].reference.isNullable shouldBe true
@@ -107,7 +107,7 @@ class ParseGraphqlTest {
             // language=ws
             """
             |type Pet { id: String }
-            |graphql OnPetAdded Subscription petAdded -> Pet
+            |graphql OnPetAdded Subscription {} -> Pet
             """.trimMargin()
 
         parser(source)
@@ -123,7 +123,7 @@ class ParseGraphqlTest {
             // language=ws
             """
             |type Pet { id: String }
-            |graphql GetPet Fetch pet -> Pet
+            |graphql GetPet Fetch {} -> Pet
             """.trimMargin()
 
         parser(source)
@@ -139,15 +139,15 @@ class ParseGraphqlTest {
             // language=ws
             """
             |type Pet { id: String }
-            |graphql GetPet Query pet -> Pet
-            |graphql GetPetAgain Query pet -> Pet
+            |graphql GetPet Query {} -> Pet
+            |graphql GetPetQuery Query {} -> Pet
             """.trimMargin()
 
         parser(source)
             .shouldBeLeft()
             .first()
             .message
-            .shouldContain("Graphql Query field 'pet' is already defined")
+            .shouldContain("Graphql Query field 'getPet' is already defined")
     }
 
     @Test
@@ -156,8 +156,8 @@ class ParseGraphqlTest {
             // language=ws
             """
             |type Pet { id: String }
-            |graphql GetPet Query pet -> Pet
-            |graphql SetPet Mutation pet(id: String) -> Pet
+            |graphql GetPet Query {} -> Pet
+            |graphql GetPetMutation Mutation {id: String} -> Pet
             """.trimMargin()
 
         parser(source).shouldBeRight().shouldHaveSize(3)
@@ -170,7 +170,7 @@ class ParseGraphqlTest {
             """
             |type Post { id: String }
             |type User { posts(first: Integer?, after: String?): Post[] }
-            |graphql GetUser Query user(id: String) -> User?
+            |graphql GetUser Query {id: String} -> User?
             """.trimMargin()
 
         parser(source)

--- a/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseGraphqlTest.kt
+++ b/src/compiler/core/src/commonTest/kotlin/community/flock/wirespec/compiler/core/parse/ParseGraphqlTest.kt
@@ -1,0 +1,190 @@
+package community.flock.wirespec.compiler.core.parse
+
+import arrow.core.nonEmptyListOf
+import community.flock.wirespec.compiler.core.FileUri
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.core.ParseContext
+import community.flock.wirespec.compiler.core.WirespecSpec
+import community.flock.wirespec.compiler.core.parse
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
+import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Type
+import community.flock.wirespec.compiler.utils.NoLogger
+import io.kotest.assertions.arrow.core.shouldBeLeft
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+
+class ParseGraphqlTest {
+
+    private fun parser(source: String) = object : ParseContext, NoLogger {
+        override val spec = WirespecSpec
+    }.parse(nonEmptyListOf(ModuleContent(FileUri("test.ws"), source))).map { it.modules.flatMap(Module::statements) }
+
+    @Test
+    fun testQueryWithArguments() {
+        val source =
+            // language=ws
+            """
+            |type Pet { id: String, name: String? }
+            |graphql GetPet Query pet(id: String) -> Pet?
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(2)[1]
+            .shouldBeInstanceOf<Graphql>()
+            .run {
+                identifier.value shouldBe "GetPet"
+                kind shouldBe Graphql.Kind.Query
+                operation.value shouldBe "pet"
+                inputs.shouldHaveSize(1).first().run {
+                    identifier.value shouldBe "id"
+                    reference.shouldBeInstanceOf<Reference.Primitive>().type.shouldBeInstanceOf<Reference.Primitive.Type.String>()
+                }
+                output.shouldBeInstanceOf<Reference.Custom>().run {
+                    value shouldBe "Pet"
+                    isNullable shouldBe true
+                }
+            }
+    }
+
+    @Test
+    fun testQueryWithoutArguments() {
+        val source =
+            // language=ws
+            """
+            |type Pet { id: String }
+            |graphql GetPets Query pets -> Pet[]
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(2)[1]
+            .shouldBeInstanceOf<Graphql>()
+            .run {
+                identifier.value shouldBe "GetPets"
+                kind shouldBe Graphql.Kind.Query
+                operation.value shouldBe "pets"
+                inputs.shouldHaveSize(0)
+                output.shouldBeInstanceOf<Reference.Iterable>().run {
+                    isNullable shouldBe false
+                    reference.shouldBeInstanceOf<Reference.Custom>().value shouldBe "Pet"
+                }
+            }
+    }
+
+    @Test
+    fun testMutation() {
+        val source =
+            // language=ws
+            """
+            |type Pet { id: String }
+            |type PetInput { name: String }
+            |graphql AddPet Mutation addPet(input: PetInput, tag: String?) -> Pet
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(3)[2]
+            .shouldBeInstanceOf<Graphql>()
+            .run {
+                kind shouldBe Graphql.Kind.Mutation
+                operation.value shouldBe "addPet"
+                inputs.shouldHaveSize(2)
+                inputs[0].reference.shouldBeInstanceOf<Reference.Custom>().value shouldBe "PetInput"
+                inputs[1].reference.isNullable shouldBe true
+            }
+    }
+
+    @Test
+    fun testSubscription() {
+        val source =
+            // language=ws
+            """
+            |type Pet { id: String }
+            |graphql OnPetAdded Subscription petAdded -> Pet
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(2)[1]
+            .shouldBeInstanceOf<Graphql>()
+            .kind shouldBe Graphql.Kind.Subscription
+    }
+
+    @Test
+    fun testWrongKind() {
+        val source =
+            // language=ws
+            """
+            |type Pet { id: String }
+            |graphql GetPet Fetch pet -> Pet
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeLeft()
+            .first()
+            .message
+            .shouldContain("Query, Mutation or Subscription expected")
+    }
+
+    @Test
+    fun testDuplicateOperationPerKind() {
+        val source =
+            // language=ws
+            """
+            |type Pet { id: String }
+            |graphql GetPet Query pet -> Pet
+            |graphql GetPetAgain Query pet -> Pet
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeLeft()
+            .first()
+            .message
+            .shouldContain("Graphql Query field 'pet' is already defined")
+    }
+
+    @Test
+    fun testSameOperationDifferentKindIsAllowed() {
+        val source =
+            // language=ws
+            """
+            |type Pet { id: String }
+            |graphql GetPet Query pet -> Pet
+            |graphql SetPet Mutation pet(id: String) -> Pet
+            """.trimMargin()
+
+        parser(source).shouldBeRight().shouldHaveSize(3)
+    }
+
+    @Test
+    fun testNestedFieldParameters() {
+        val source =
+            // language=ws
+            """
+            |type Post { id: String }
+            |type User { posts(first: Integer?, after: String?): Post[] }
+            |graphql GetUser Query user(id: String) -> User?
+            """.trimMargin()
+
+        parser(source)
+            .shouldBeRight()
+            .shouldHaveSize(3)[1]
+            .shouldBeInstanceOf<Type>()
+            .shape.value.shouldHaveSize(1)
+            .first()
+            .run {
+                identifier.value shouldBe "posts"
+                parameters.shouldHaveSize(2)
+                parameters[0].identifier.value shouldBe "first"
+                parameters[0].reference.isNullable shouldBe true
+                parameters[1].identifier.value shouldBe "after"
+            }
+    }
+}

--- a/src/compiler/emitters/java/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileGraphqlTest.txt
@@ -1,0 +1,274 @@
+package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
+public record Pet (
+  String id,
+  java.util.Optional<String> name,
+  java.util.List<String> tags
+) implements Wirespec.Shape {
+  @Override
+  public java.util.List<String> validate() {
+    return java.util.List.<String>of();
+  }
+};
+
+package community.flock.wirespec.generated.model;
+import community.flock.wirespec.java.Wirespec;
+public record PetInput (
+  String name
+) implements Wirespec.Shape {
+  @Override
+  public java.util.List<String> validate() {
+    return java.util.List.<String>of();
+  }
+};
+
+package community.flock.wirespec.generated.graphql;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.Pet;
+public interface GetPet extends Wirespec.GraphQL {
+  public static record Input (
+    String id
+  ) {
+  };
+  public static record Data (
+    java.util.Optional<Pet> pet
+  ) {
+  };
+  public static record Result (
+    java.util.Optional<Data> data,
+    java.util.Optional<java.util.List<Wirespec.GraphQLError>> errors
+  ) {
+  };
+  public static record RequestBody (
+    String query,
+    Input variables
+  ) {
+  };
+  public static String document() {
+    return "query GetPet($id: String!) { pet(id: $id) { id name tags } }";
+  }
+  public static Wirespec.RawRequest toRawRequest(Wirespec.Serializer serialization, Input input) {
+    return new Wirespec.RawRequest(
+      "POST",
+      java.util.List.of("graphql"),
+      java.util.Collections.emptyMap(),
+      java.util.Collections.emptyMap(),
+      java.util.Optional.of(serialization.<RequestBody>serializeBody(new RequestBody(
+        document(),
+        input
+      ), Wirespec.getType(RequestBody.class, null)))
+    );
+  }
+  public static Result fromRawResponse(Wirespec.Deserializer serialization, Wirespec.RawResponse response) {
+    return response.body().map(it -> serialization.<Result>deserializeBody(it, Wirespec.getType(Result.class, null))).orElseThrow(() -> new IllegalStateException("body is null"));
+  }
+  public interface Handler extends Wirespec.Handler {
+    public java.util.concurrent.CompletableFuture<Result> getPet(Input input);
+  }
+  public interface Call extends Wirespec.Call {
+    public java.util.concurrent.CompletableFuture<Result> getPet(Input input);
+  }
+}
+
+package community.flock.wirespec.generated.graphql;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.PetInput;
+import community.flock.wirespec.generated.model.Pet;
+public interface AddPet extends Wirespec.GraphQL {
+  public static record Input (
+    PetInput input
+  ) {
+  };
+  public static record Data (
+    Pet addPet
+  ) {
+  };
+  public static record Result (
+    java.util.Optional<Data> data,
+    java.util.Optional<java.util.List<Wirespec.GraphQLError>> errors
+  ) {
+  };
+  public static record RequestBody (
+    String query,
+    Input variables
+  ) {
+  };
+  public static String document() {
+    return "mutation AddPet($input: PetInput!) { addPet(input: $input) { id name tags } }";
+  }
+  public static Wirespec.RawRequest toRawRequest(Wirespec.Serializer serialization, Input input) {
+    return new Wirespec.RawRequest(
+      "POST",
+      java.util.List.of("graphql"),
+      java.util.Collections.emptyMap(),
+      java.util.Collections.emptyMap(),
+      java.util.Optional.of(serialization.<RequestBody>serializeBody(new RequestBody(
+        document(),
+        input
+      ), Wirespec.getType(RequestBody.class, null)))
+    );
+  }
+  public static Result fromRawResponse(Wirespec.Deserializer serialization, Wirespec.RawResponse response) {
+    return response.body().map(it -> serialization.<Result>deserializeBody(it, Wirespec.getType(Result.class, null))).orElseThrow(() -> new IllegalStateException("body is null"));
+  }
+  public interface Handler extends Wirespec.Handler {
+    public java.util.concurrent.CompletableFuture<Result> addPet(Input input);
+  }
+  public interface Call extends Wirespec.Call {
+    public java.util.concurrent.CompletableFuture<Result> addPet(Input input);
+  }
+}
+
+package community.flock.wirespec.generated.graphql;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.Pet;
+public interface OnPetAdded extends Wirespec.GraphQL {
+  public static record Input () {
+  };
+  public static record Data (
+    Pet petAdded
+  ) {
+  };
+  public static record Result (
+    java.util.Optional<Data> data,
+    java.util.Optional<java.util.List<Wirespec.GraphQLError>> errors
+  ) {
+  };
+  public static record RequestBody (
+    String query,
+    Input variables
+  ) {
+  };
+  public static String document() {
+    return "subscription OnPetAdded { petAdded { id name tags } }";
+  }
+  public static Wirespec.RawRequest toRawRequest(Wirespec.Serializer serialization, Input input) {
+    return new Wirespec.RawRequest(
+      "POST",
+      java.util.List.of("graphql"),
+      java.util.Collections.emptyMap(),
+      java.util.Collections.emptyMap(),
+      java.util.Optional.of(serialization.<RequestBody>serializeBody(new RequestBody(
+        document(),
+        input
+      ), Wirespec.getType(RequestBody.class, null)))
+    );
+  }
+  public static Result fromRawResponse(Wirespec.Deserializer serialization, Wirespec.RawResponse response) {
+    return response.body().map(it -> serialization.<Result>deserializeBody(it, Wirespec.getType(Result.class, null))).orElseThrow(() -> new IllegalStateException("body is null"));
+  }
+  public interface Handler extends Wirespec.Handler {
+    public Wirespec.Cancellable onPetAdded(Input input, java.util.function.Function<Result, Void> onNext);
+  }
+  public interface Call extends Wirespec.Call {
+    public Wirespec.Cancellable onPetAdded(Input input, java.util.function.Function<Result, Void> onNext);
+  }
+}
+
+package community.flock.wirespec.generated.client;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.Pet;
+import community.flock.wirespec.generated.graphql.GetPet;
+public record GetPetClient (
+  Wirespec.Serialization serialization,
+  Wirespec.Transportation transportation
+) implements GetPet.Call {
+  @Override
+  public java.util.concurrent.CompletableFuture<GetPet.Result> getPet(GetPet.Input input) {
+    final var rawRequest = GetPet.toRawRequest(serialization(), input);
+    return transportation().transport(rawRequest).thenApply(rawResponse -> GetPet.fromRawResponse(serialization(), rawResponse));
+  }
+};
+
+package community.flock.wirespec.generated.client;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.PetInput;
+import community.flock.wirespec.generated.model.Pet;
+import community.flock.wirespec.generated.graphql.AddPet;
+public record AddPetClient (
+  Wirespec.Serialization serialization,
+  Wirespec.Transportation transportation
+) implements AddPet.Call {
+  @Override
+  public java.util.concurrent.CompletableFuture<AddPet.Result> addPet(AddPet.Input input) {
+    final var rawRequest = AddPet.toRawRequest(serialization(), input);
+    return transportation().transport(rawRequest).thenApply(rawResponse -> AddPet.fromRawResponse(serialization(), rawResponse));
+  }
+};
+
+package community.flock.wirespec.generated.client;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.Pet;
+import community.flock.wirespec.generated.graphql.OnPetAdded;
+public record OnPetAddedClient (
+  Wirespec.Serialization serialization,
+  Wirespec.StreamTransportation transportation
+) implements OnPetAdded.Call {
+  @Override
+  public Wirespec.Cancellable onPetAdded(OnPetAdded.Input input, java.util.function.Function<OnPetAdded.Result, Void> onNext) {
+    final var rawRequest = OnPetAdded.toRawRequest(serialization(), input);
+    return transportation().stream(rawRequest, (raw) -> onNext.apply(OnPetAdded.fromRawResponse(serialization(), raw)));
+  }
+};
+
+package community.flock.wirespec.generated.generator;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.Pet;
+public interface PetGenerator {
+  public static Pet generate(Wirespec.Generator generator, java.util.List<String> path) {
+    return new Pet(
+      generator.generate(java.util.stream.Stream.of(path, java.util.List.of("id")).flatMap(java.util.Collection::stream).toList(), new Wirespec.GeneratorFieldString(
+        java.util.Optional.empty(),
+        java.util.List.<java.util.Map<String, Object>>of()
+      )),
+      generator.generate(java.util.stream.Stream.of(path, java.util.List.of("name")).flatMap(java.util.Collection::stream).toList(), new Wirespec.GeneratorFieldNullable<>((p0) -> generator.generate(p0, new Wirespec.GeneratorFieldString(
+        java.util.Optional.empty(),
+        java.util.List.<java.util.Map<String, Object>>of()
+      )))),
+      generator.generate(java.util.stream.Stream.of(path, java.util.List.of("tags")).flatMap(java.util.Collection::stream).toList(), new Wirespec.GeneratorFieldArray<>((p0) -> generator.generate(p0, new Wirespec.GeneratorFieldString(
+        java.util.Optional.empty(),
+        java.util.List.<java.util.Map<String, Object>>of()
+      ))))
+    );
+  }
+}
+
+package community.flock.wirespec.generated.generator;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.PetInput;
+public interface PetInputGenerator {
+  public static PetInput generate(Wirespec.Generator generator, java.util.List<String> path) {
+    return new PetInput(generator.generate(java.util.stream.Stream.of(path, java.util.List.of("name")).flatMap(java.util.Collection::stream).toList(), new Wirespec.GeneratorFieldString(
+      java.util.Optional.empty(),
+      java.util.List.<java.util.Map<String, Object>>of()
+    )));
+  }
+}
+
+package community.flock.wirespec.generated;
+import community.flock.wirespec.java.Wirespec;
+import community.flock.wirespec.generated.model.Pet;
+import community.flock.wirespec.generated.model.PetInput;
+import community.flock.wirespec.generated.graphql.GetPet;
+import community.flock.wirespec.generated.graphql.AddPet;
+import community.flock.wirespec.generated.client.GetPetClient;
+import community.flock.wirespec.generated.client.AddPetClient;
+public record Client (
+  Wirespec.Serialization serialization,
+  Wirespec.Transportation transportation
+) implements GetPet.Call, AddPet.Call {
+  @Override
+  public java.util.concurrent.CompletableFuture<GetPet.Result> getPet(GetPet.Input input) {
+    return new GetPetClient(
+      serialization(),
+      transportation()
+    ).getPet(input);
+  }
+  @Override
+  public java.util.concurrent.CompletableFuture<AddPet.Result> addPet(AddPet.Input input) {
+    return new AddPetClient(
+      serialization(),
+      transportation()
+    ).addPet(input);
+  }
+};

--- a/src/compiler/emitters/java/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/java/fixtures/compileGraphqlTest.txt
@@ -31,7 +31,7 @@ public interface GetPet extends Wirespec.GraphQL {
   ) {
   };
   public static record Data (
-    java.util.Optional<Pet> pet
+    java.util.Optional<Pet> getPet
   ) {
   };
   public static record Result (
@@ -45,7 +45,7 @@ public interface GetPet extends Wirespec.GraphQL {
   ) {
   };
   public static String document() {
-    return "query GetPet($id: String!) { pet(id: $id) { id name tags } }";
+    return "query GetPet($id: String!) { getPet(id: $id) { id name tags } }";
   }
   public static Wirespec.RawRequest toRawRequest(Wirespec.Serializer serialization, Input input) {
     return new Wirespec.RawRequest(
@@ -126,7 +126,7 @@ public interface OnPetAdded extends Wirespec.GraphQL {
   public static record Input () {
   };
   public static record Data (
-    Pet petAdded
+    Pet onPetAdded
   ) {
   };
   public static record Result (
@@ -140,7 +140,7 @@ public interface OnPetAdded extends Wirespec.GraphQL {
   ) {
   };
   public static String document() {
-    return "subscription OnPetAdded { petAdded { id name tags } }";
+    return "subscription OnPetAdded { onPetAdded { id name tags } }";
   }
   public static Wirespec.RawRequest toRawRequest(Wirespec.Serializer serialization, Input input) {
     return new Wirespec.RawRequest(

--- a/src/compiler/emitters/java/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/java/fixtures/sharedOutputTest.txt
@@ -20,6 +20,8 @@ public interface Wirespec {
   }
   public interface Channel {
   }
+  public interface GraphQL {
+  }
   public interface Path {
   }
   public interface Queries {
@@ -101,6 +103,24 @@ public interface Wirespec {
   };
   public interface Transportation {
     public java.util.concurrent.CompletableFuture<RawResponse> transport(RawRequest request);
+  }
+  public static record GraphQLErrorLocation (
+    Integer line,
+    Integer column
+  ) {
+  };
+  public static record GraphQLError (
+    String message,
+    java.util.Optional<java.util.List<GraphQLErrorLocation>> locations,
+    java.util.Optional<java.util.List<Object>> path,
+    java.util.Optional<Object> extensions
+  ) {
+  };
+  public interface Cancellable {
+    public void cancel();
+  }
+  public interface StreamTransportation {
+    public Cancellable stream(RawRequest request, java.util.function.Function<RawResponse, Void> onNext);
   }
   public sealed interface GeneratorField<T> {
   }

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
@@ -213,6 +213,38 @@ open class JavaIrEmitter(
             .qualifyChannelReferences(fullyQualifiedPrefix)
     }
 
+    override fun emit(graphql: Graphql, module: Module): File = super.emit(graphql, module)
+        .transformTypeDescriptors()
+        .sanitizeNames(sanitizationConfig)
+        .prependImports(graphql.buildModelImports(packageName).takeIf { it.isNotEmpty() })
+
+    override fun emitGraphqlClient(graphql: Graphql): File {
+        val imports = graphql.buildModelImports(packageName)
+        val graphqlImport = import("${packageName.value}.graphql", graphql.identifier.value)
+        val graphqlName = graphql.identifier.value
+
+        val file = super.emitGraphqlClient(graphql)
+            .sanitizeNames(sanitizationConfig)
+            .transformTypeDescriptors()
+            .let {
+                if (graphql.kind != Graphql.Kind.Subscription) {
+                    it.wrapAsyncReturnInThenApply(graphqlName)
+                } else {
+                    it.callFunctionalParameterWithApply("onNext")
+                }
+            }
+
+        val subPackageName = packageName + "client"
+        return File(
+            name = Name.of(subPackageName.toDir() + file.name.pascalCase().sanitizeSymbol()),
+            elements = listOf(Package(subPackageName.value)) +
+                    wirespecImports +
+                    imports +
+                    listOf(graphqlImport) +
+                    file.elements
+        )
+    }
+
     override fun emitEndpointClient(endpoint: Endpoint): File {
         val imports = endpoint.buildModelImports(packageName)
         val endpointImport = import("${packageName.value}.endpoint", endpoint.identifier.value)

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitter.kt
@@ -14,6 +14,7 @@ import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Refined
@@ -233,14 +234,17 @@ open class JavaIrEmitter(
         )
     }
 
-    override fun emitClient(endpoints: List<Endpoint>, logger: Logger): File {
-        val imports = endpoints.flatMap { it.importReferences() }.distinctBy { it.value }
+    override fun emitClient(endpoints: List<Endpoint>, graphqls: List<Graphql>, logger: Logger): File {
+        val imports = (endpoints.flatMap { it.importReferences() } + graphqls.flatMap { it.importReferences() })
+            .distinctBy { it.value }
             .filter { imp -> endpoints.none { it.identifier.value == imp.value } }
             .map { import("${packageName.value}.model", it.value) }
         val endpointImports = endpoints.map { import("${packageName.value}.endpoint", it.identifier.value) }
-        val clientImports = endpoints.map { import("${packageName.value}.client", "${it.identifier.value}Client") }
-        val allImports = imports + endpointImports + clientImports
-        val file = super.emitClient(endpoints, logger).sanitizeNames(sanitizationConfig)
+        val graphqlImports = graphqls.map { import("${packageName.value}.graphql", it.identifier.value) }
+        val clientImports = (endpoints.map { it.identifier.value } + graphqls.map { it.identifier.value })
+            .map { import("${packageName.value}.client", "${it}Client") }
+        val allImports = imports + endpointImports + graphqlImports + clientImports
+        val file = super.emitClient(endpoints, graphqls, logger).sanitizeNames(sanitizationConfig)
         return File(
             name = Name.of(packageName.toDir() + file.name.pascalCase().sanitizeSymbol()),
             elements = listOf(Package(packageName.value)) +

--- a/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrTransformer.kt
+++ b/src/compiler/emitters/java/src/commonMain/kotlin/community/flock/wirespec/emitters/java/JavaIrTransformer.kt
@@ -170,6 +170,22 @@ internal fun Interface.withFullyQualifiedPrefix(prefix: String): Interface = if 
     this
 }
 
+// Java cannot invoke a java.util.function.Function-typed parameter as a bare call;
+// rewrite `param(...)` to `param.apply(...)`.
+internal fun <T : Element> T.callFunctionalParameterWithApply(parameterName: String): T = transform {
+    statementAndExpression { stmt, tr ->
+        when {
+            stmt is FunctionCall && stmt.receiver == null && stmt.name.camelCase() == parameterName -> FunctionCall(
+                receiver = VariableReference(Name.of(parameterName)),
+                name = Name.of("apply"),
+                arguments = stmt.arguments.mapValues { (_, value) -> tr.transformExpression(value) },
+            )
+
+            else -> stmt.transformChildren(tr)
+        }
+    }
+}
+
 internal fun <T : Element> T.transformTypeDescriptors(): T = transform {
     statementAndExpression { stmt, tr ->
         when (stmt) {

--- a/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitterTest.kt
+++ b/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitterTest.kt
@@ -10,6 +10,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
@@ -60,6 +61,11 @@ class JavaIrEmitterTest {
     @Test
     fun compileChannelTest() {
         CompileChannelTest.compiler { JavaIrEmitter() } shouldBeRight EmitterFixtures.compileChannelTest
+    }
+
+    @Test
+    fun compileGraphqlTest() {
+        CompileGraphqlTest.compiler { JavaIrEmitter() } shouldBeRight EmitterFixtures.compileGraphqlTest
     }
 
     @Test

--- a/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitterTest.kt
+++ b/src/compiler/emitters/java/src/commonTest/kotlin/community/flock/wirespec/emitters/java/JavaIrEmitterTest.kt
@@ -10,11 +10,11 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
-import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
 import community.flock.wirespec.compiler.test.CompileFullEndpointTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest

--- a/src/compiler/emitters/kotlin/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileGraphqlTest.txt
@@ -29,7 +29,7 @@ object GetPet : Wirespec.GraphQL {
       val id: String
     )
   data class Data(
-      val pet: Pet?
+      val getPet: Pet?
     )
   data class Result(
       val data: Data?,
@@ -40,7 +40,7 @@ object GetPet : Wirespec.GraphQL {
       val variables: Input
     )
   fun document(): String =
-    "query GetPet(\$id: String!) { pet(id: \$id) { id name tags } }"
+    "query GetPet(\$id: String!) { getPet(id: \$id) { id name tags } }"
   fun toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest =
     Wirespec.RawRequest(
       method = "POST",
@@ -112,7 +112,7 @@ import community.flock.wirespec.generated.model.Pet
 object OnPetAdded : Wirespec.GraphQL {
   object Input
   data class Data(
-      val petAdded: Pet
+      val onPetAdded: Pet
     )
   data class Result(
       val data: Data?,
@@ -123,7 +123,7 @@ object OnPetAdded : Wirespec.GraphQL {
       val variables: Input
     )
   fun document(): String =
-    "subscription OnPetAdded { petAdded { id name tags } }"
+    "subscription OnPetAdded { onPetAdded { id name tags } }"
   fun toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest =
     Wirespec.RawRequest(
       method = "POST",

--- a/src/compiler/emitters/kotlin/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/compileGraphqlTest.txt
@@ -1,0 +1,253 @@
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+data class Pet(
+  val id: String,
+  val name: String?,
+  val tags: List<String>
+) : Wirespec.Shape {
+  override fun validate(): List<String> =
+    emptyList<String>()
+}
+
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+data class PetInput(
+  val name: String
+) : Wirespec.Shape {
+  override fun validate(): List<String> =
+    emptyList<String>()
+}
+
+package community.flock.wirespec.generated.graphql
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.Pet
+object GetPet : Wirespec.GraphQL {
+  data class Input(
+      val id: String
+    )
+  data class Data(
+      val pet: Pet?
+    )
+  data class Result(
+      val data: Data?,
+      val errors: List<Wirespec.GraphQLError>?
+    )
+  data class RequestBody(
+      val query: String,
+      val variables: Input
+    )
+  fun document(): String =
+    "query GetPet(\$id: String!) { pet(id: \$id) { id name tags } }"
+  fun toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest =
+    Wirespec.RawRequest(
+      method = "POST",
+      path = listOf("graphql"),
+      queries = emptyMap<String, List<String>>(),
+      headers = emptyMap<String, List<String>>(),
+      body = serialization.serializeBody<RequestBody>(RequestBody(
+        query = document(),
+        variables = input
+      ), typeOf<RequestBody>())
+    )
+  fun fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Result =
+    (response.body?.let { serialization.deserializeBody<Result>(it, typeOf<Result>()) } ?: error("body is null"))
+  fun interface Handler : Wirespec.Handler {
+      suspend fun getPet(input: Input): Result
+  }
+  fun interface Call : Wirespec.Call {
+      suspend fun getPet(input: Input): Result
+  }
+}
+
+package community.flock.wirespec.generated.graphql
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.PetInput
+import community.flock.wirespec.generated.model.Pet
+object AddPet : Wirespec.GraphQL {
+  data class Input(
+      val input: PetInput
+    )
+  data class Data(
+      val addPet: Pet
+    )
+  data class Result(
+      val data: Data?,
+      val errors: List<Wirespec.GraphQLError>?
+    )
+  data class RequestBody(
+      val query: String,
+      val variables: Input
+    )
+  fun document(): String =
+    "mutation AddPet(\$input: PetInput!) { addPet(input: \$input) { id name tags } }"
+  fun toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest =
+    Wirespec.RawRequest(
+      method = "POST",
+      path = listOf("graphql"),
+      queries = emptyMap<String, List<String>>(),
+      headers = emptyMap<String, List<String>>(),
+      body = serialization.serializeBody<RequestBody>(RequestBody(
+        query = document(),
+        variables = input
+      ), typeOf<RequestBody>())
+    )
+  fun fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Result =
+    (response.body?.let { serialization.deserializeBody<Result>(it, typeOf<Result>()) } ?: error("body is null"))
+  fun interface Handler : Wirespec.Handler {
+      suspend fun addPet(input: Input): Result
+  }
+  fun interface Call : Wirespec.Call {
+      suspend fun addPet(input: Input): Result
+  }
+}
+
+package community.flock.wirespec.generated.graphql
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.Pet
+object OnPetAdded : Wirespec.GraphQL {
+  object Input
+  data class Data(
+      val petAdded: Pet
+    )
+  data class Result(
+      val data: Data?,
+      val errors: List<Wirespec.GraphQLError>?
+    )
+  data class RequestBody(
+      val query: String,
+      val variables: Input
+    )
+  fun document(): String =
+    "subscription OnPetAdded { petAdded { id name tags } }"
+  fun toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest =
+    Wirespec.RawRequest(
+      method = "POST",
+      path = listOf("graphql"),
+      queries = emptyMap<String, List<String>>(),
+      headers = emptyMap<String, List<String>>(),
+      body = serialization.serializeBody<RequestBody>(RequestBody(
+        query = document(),
+        variables = input
+      ), typeOf<RequestBody>())
+    )
+  fun fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Result =
+    (response.body?.let { serialization.deserializeBody<Result>(it, typeOf<Result>()) } ?: error("body is null"))
+  fun interface Handler : Wirespec.Handler {
+      fun onPetAdded(input: Input, onNext: (Result) -> Unit): Wirespec.Cancellable
+  }
+  fun interface Call : Wirespec.Call {
+      fun onPetAdded(input: Input, onNext: (Result) -> Unit): Wirespec.Cancellable
+  }
+}
+
+package community.flock.wirespec.generated.client
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.Pet
+import community.flock.wirespec.generated.graphql.GetPet
+data class GetPetClient(
+  val serialization: Wirespec.Serialization,
+  val transportation: Wirespec.Transportation
+) : GetPet.Call {
+  override suspend fun getPet(input: GetPet.Input): GetPet.Result {
+    val rawRequest = GetPet.toRawRequest(serialization, input)
+    val rawResponse = transportation.transport(rawRequest)
+    return GetPet.fromRawResponse(serialization, rawResponse)
+  }
+}
+
+package community.flock.wirespec.generated.client
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.PetInput
+import community.flock.wirespec.generated.model.Pet
+import community.flock.wirespec.generated.graphql.AddPet
+data class AddPetClient(
+  val serialization: Wirespec.Serialization,
+  val transportation: Wirespec.Transportation
+) : AddPet.Call {
+  override suspend fun addPet(input: AddPet.Input): AddPet.Result {
+    val rawRequest = AddPet.toRawRequest(serialization, input)
+    val rawResponse = transportation.transport(rawRequest)
+    return AddPet.fromRawResponse(serialization, rawResponse)
+  }
+}
+
+package community.flock.wirespec.generated.client
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.Pet
+import community.flock.wirespec.generated.graphql.OnPetAdded
+data class OnPetAddedClient(
+  val serialization: Wirespec.Serialization,
+  val transportation: Wirespec.StreamTransportation
+) : OnPetAdded.Call {
+  override fun onPetAdded(input: OnPetAdded.Input, onNext: (OnPetAdded.Result) -> Unit): Wirespec.Cancellable {
+    val rawRequest = OnPetAdded.toRawRequest(serialization, input)
+    return transportation.stream(rawRequest, { raw -> onNext(OnPetAdded.fromRawResponse(serialization, raw)) })
+  }
+}
+
+package community.flock.wirespec.generated.generator
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.Pet
+object PetGenerator {
+  fun generate(generator: Wirespec.Generator, path: List<String>): Pet =
+    Pet(
+      id = generator.generate(path + listOf("id"), Wirespec.GeneratorFieldString(
+        regex = null,
+        annotations = emptyList<Map<String, Any>>()
+      )),
+      name = generator.generate(path + listOf("name"), Wirespec.GeneratorFieldNullable(generate = { p0 -> generator.generate(p0, Wirespec.GeneratorFieldString(
+        regex = null,
+        annotations = emptyList<Map<String, Any>>()
+      )) })),
+      tags = generator.generate(path + listOf("tags"), Wirespec.GeneratorFieldArray(generate = { p0 -> generator.generate(p0, Wirespec.GeneratorFieldString(
+        regex = null,
+        annotations = emptyList<Map<String, Any>>()
+      )) }))
+    )
+}
+
+package community.flock.wirespec.generated.generator
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.PetInput
+object PetInputGenerator {
+  fun generate(generator: Wirespec.Generator, path: List<String>): PetInput =
+    PetInput(name = generator.generate(path + listOf("name"), Wirespec.GeneratorFieldString(
+      regex = null,
+      annotations = emptyList<Map<String, Any>>()
+    )))
+}
+
+package community.flock.wirespec.generated
+import community.flock.wirespec.kotlin.Wirespec
+import kotlin.reflect.typeOf
+import community.flock.wirespec.generated.model.Pet
+import community.flock.wirespec.generated.model.PetInput
+import community.flock.wirespec.generated.graphql.GetPet
+import community.flock.wirespec.generated.graphql.AddPet
+import community.flock.wirespec.generated.client.GetPetClient
+import community.flock.wirespec.generated.client.AddPetClient
+data class Client(
+  val serialization: Wirespec.Serialization,
+  val transportation: Wirespec.Transportation
+) : GetPet.Call, AddPet.Call {
+  override suspend fun getPet(input: GetPet.Input): GetPet.Result =
+    GetPetClient(
+      serialization = serialization,
+      transportation = transportation
+    ).getPet(input)
+  override suspend fun addPet(input: AddPet.Input): AddPet.Result =
+    AddPetClient(
+      serialization = serialization,
+      transportation = transportation
+    ).addPet(input)
+}

--- a/src/compiler/emitters/kotlin/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/kotlin/fixtures/sharedOutputTest.txt
@@ -14,6 +14,7 @@ object Wirespec {
   }
   interface Endpoint
   interface Channel
+  interface GraphQL
   interface Path
   interface Queries
   interface Headers
@@ -80,6 +81,22 @@ object Wirespec {
     )
   fun interface Transportation {
       suspend fun transport(request: RawRequest): RawResponse
+  }
+  data class GraphQLErrorLocation(
+      val line: Int,
+      val column: Int
+    )
+  data class GraphQLError(
+      val message: String,
+      val locations: List<GraphQLErrorLocation>?,
+      val path: List<Any>?,
+      val extensions: Any?
+    )
+  fun interface Cancellable {
+      fun cancel()
+  }
+  fun interface StreamTransportation {
+      fun stream(request: RawRequest, onNext: (RawResponse) -> Unit): Cancellable
   }
   sealed interface GeneratorField<T: Any?>
   data class GeneratorFieldString(

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
@@ -228,6 +228,23 @@ open class KotlinIrEmitter(
         )
     }
 
+    override fun emitGraphqlClient(graphql: Graphql): File {
+        val imports = graphql.buildModelImports(packageName)
+        val graphqlImport = import("${packageName.value}.graphql", graphql.identifier.value)
+        val file = super.emitGraphqlClient(graphql).sanitizeNames(sanitizationConfig)
+        val subPackageName = packageName + "client"
+        return File(
+            name = Name.of(subPackageName.toDir() + file.name.pascalCase()),
+            elements = buildList {
+                add(LanguagePackage(subPackageName.value))
+                addAll(wirespecImports)
+                addAll(imports)
+                add(graphqlImport)
+                addAll(file.elements)
+            }
+        )
+    }
+
     override fun emitClient(endpoints: List<Endpoint>, graphqls: List<Graphql>, logger: Logger): File {
         val imports = (endpoints.flatMap { it.importReferences() } + graphqls.flatMap { it.importReferences() })
             .distinctBy { it.value }

--- a/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
+++ b/src/compiler/emitters/kotlin/src/commonMain/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitter.kt
@@ -29,6 +29,7 @@ import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Identifier
@@ -206,6 +207,10 @@ open class KotlinIrEmitter(
         .sanitizeNames(sanitizationConfig)
         .prependImports(channel.buildModelImports(packageName).takeIf { it.isNotEmpty() })
 
+    override fun emit(graphql: Graphql, module: Module): File = super.emit(graphql, module)
+        .sanitizeNames(sanitizationConfig)
+        .prependImports(graphql.buildModelImports(packageName).takeIf { it.isNotEmpty() })
+
     override fun emitEndpointClient(endpoint: Endpoint): File {
         val imports = endpoint.buildModelImports(packageName)
         val endpointImport = import("${packageName.value}.endpoint", endpoint.identifier.value)
@@ -223,15 +228,18 @@ open class KotlinIrEmitter(
         )
     }
 
-    override fun emitClient(endpoints: List<Endpoint>, logger: Logger): File {
-        val imports = endpoints.flatMap { it.importReferences() }.distinctBy { it.value }
+    override fun emitClient(endpoints: List<Endpoint>, graphqls: List<Graphql>, logger: Logger): File {
+        val imports = (endpoints.flatMap { it.importReferences() } + graphqls.flatMap { it.importReferences() })
+            .distinctBy { it.value }
             .map { import("${packageName.value}.model", it.value) }
         val endpointImports = endpoints
             .map { import("${packageName.value}.endpoint", it.identifier.value) }
-        val clientImports = endpoints
-            .map { import("${packageName.value}.client", "${it.identifier.value}Client") }
-        val allImports = imports + endpointImports + clientImports
-        val file = super.emitClient(endpoints, logger).sanitizeNames(sanitizationConfig)
+        val graphqlImports = graphqls
+            .map { import("${packageName.value}.graphql", it.identifier.value) }
+        val clientImports = (endpoints.map { it.identifier.value } + graphqls.map { it.identifier.value })
+            .map { import("${packageName.value}.client", "${it}Client") }
+        val allImports = imports + endpointImports + graphqlImports + clientImports
+        val file = super.emitClient(endpoints, graphqls, logger).sanitizeNames(sanitizationConfig)
         return File(
             name = Name.of(packageName.toDir() + file.name.pascalCase()),
             elements = buildList {

--- a/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
+++ b/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
@@ -10,6 +10,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
@@ -84,6 +85,13 @@ class KotlinIrEmitterTest {
         val kotlin = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { KotlinIrEmitter() } shouldBeRight kotlin
+    }
+
+    @Test
+    fun compileGraphqlTest() {
+        val kotlin = EmitterFixtures.compileGraphqlTest
+
+        CompileGraphqlTest.compiler { KotlinIrEmitter() } shouldBeRight kotlin
     }
 
     @Test

--- a/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
+++ b/src/compiler/emitters/kotlin/src/commonTest/kotlin/community/flock/wirespec/emitters/kotlin/KotlinIrEmitterTest.kt
@@ -10,11 +10,11 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
-import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
 import community.flock.wirespec.compiler.test.CompileFullEndpointTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest

--- a/src/compiler/emitters/python/fixtures/compileFullEndpointTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileFullEndpointTest.txt
@@ -211,9 +211,9 @@ class PutTodoClient(PutTodo.Call):
     transportation: Wirespec.Transportation
     async def put_todo(self, id: str, done: bool, name: Optional[str], token: Token, refreshToken: Optional[Token], body: PotentialTodoDto) -> Response[Any]:
         request = Request(id=id, done=done, name=name, token=token, refreshToken=refreshToken, body=body)
-        rawRequest = PutTodo.toRawRequest(serialization=self.serialization, request=request)
+        rawRequest = PutTodo.toRawRequest(self.serialization, request)
         rawResponse = await self.transportation.transport(rawRequest)
-        return PutTodo.fromRawResponse(serialization=self.serialization, response=rawResponse)
+        return PutTodo.fromRawResponse(self.serialization, rawResponse)
 
 from __future__ import annotations
 import re

--- a/src/compiler/emitters/python/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileGraphqlTest.txt
@@ -1,0 +1,231 @@
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+@dataclass
+class Pet(Wirespec.Shape):
+    id: str
+    name: Optional[str]
+    tags: list[str]
+    def validate(self) -> list[str]:
+        return []
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+@dataclass
+class PetInput(Wirespec.Shape):
+    name: str
+    def validate(self) -> list[str]:
+        return []
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+class GetPet(Wirespec.GraphQL):
+    @dataclass
+    class Input:
+        id: str
+    @dataclass
+    class Data:
+        pet: Optional[Pet]
+    @dataclass
+    class Result:
+        data: Optional[GetPet.Data]
+        errors: Optional[list[Wirespec.GraphQLError]]
+    @dataclass
+    class RequestBody:
+        query: str
+        variables: GetPet.Input
+    @staticmethod
+    def document() -> str:
+        return 'query GetPet($id: String!) { pet(id: $id) { id name tags } }'
+    @staticmethod
+    def toRawRequest(serialization: Wirespec.Serializer, input: GetPet.Input) -> Wirespec.RawRequest:
+        return Wirespec.RawRequest(method='POST', path=['graphql'], queries={}, headers={}, body=serialization.serializeBody(RequestBody(query=document(), variables=input), RequestBody))
+    @staticmethod
+    def fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> GetPet.Result:
+        return (serialization.deserializeBody(response.body, Result) if response.body is not None else _raise('body is null'))
+    class Handler(Wirespec.Handler, ABC):
+        @abstractmethod
+        async def GetPet(self, input: GetPet.Input) -> GetPet.Result:
+            ...
+    class Call(Wirespec.Call, ABC):
+        @abstractmethod
+        async def GetPet(self, input: GetPet.Input) -> GetPet.Result:
+            ...
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+class AddPet(Wirespec.GraphQL):
+    @dataclass
+    class Input:
+        input: PetInput
+    @dataclass
+    class Data:
+        addPet: Pet
+    @dataclass
+    class Result:
+        data: Optional[AddPet.Data]
+        errors: Optional[list[Wirespec.GraphQLError]]
+    @dataclass
+    class RequestBody:
+        query: str
+        variables: AddPet.Input
+    @staticmethod
+    def document() -> str:
+        return 'mutation AddPet($input: PetInput!) { addPet(input: $input) { id name tags } }'
+    @staticmethod
+    def toRawRequest(serialization: Wirespec.Serializer, input: AddPet.Input) -> Wirespec.RawRequest:
+        return Wirespec.RawRequest(method='POST', path=['graphql'], queries={}, headers={}, body=serialization.serializeBody(RequestBody(query=document(), variables=input), RequestBody))
+    @staticmethod
+    def fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> AddPet.Result:
+        return (serialization.deserializeBody(response.body, Result) if response.body is not None else _raise('body is null'))
+    class Handler(Wirespec.Handler, ABC):
+        @abstractmethod
+        async def AddPet(self, input: AddPet.Input) -> AddPet.Result:
+            ...
+    class Call(Wirespec.Call, ABC):
+        @abstractmethod
+        async def AddPet(self, input: AddPet.Input) -> AddPet.Result:
+            ...
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+class OnPetAdded(Wirespec.GraphQL):
+    @dataclass
+    class Input:
+        pass
+    @dataclass
+    class Data:
+        petAdded: Pet
+    @dataclass
+    class Result:
+        data: Optional[OnPetAdded.Data]
+        errors: Optional[list[Wirespec.GraphQLError]]
+    @dataclass
+    class RequestBody:
+        query: str
+        variables: OnPetAdded.Input
+    @staticmethod
+    def document() -> str:
+        return 'subscription OnPetAdded { petAdded { id name tags } }'
+    @staticmethod
+    def toRawRequest(serialization: Wirespec.Serializer, input: OnPetAdded.Input) -> Wirespec.RawRequest:
+        return Wirespec.RawRequest(method='POST', path=['graphql'], queries={}, headers={}, body=serialization.serializeBody(RequestBody(query=document(), variables=input), RequestBody))
+    @staticmethod
+    def fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> OnPetAdded.Result:
+        return (serialization.deserializeBody(response.body, Result) if response.body is not None else _raise('body is null'))
+    class Handler(Wirespec.Handler, ABC):
+        @abstractmethod
+        def OnPetAdded(self, input: OnPetAdded.Input, onNext: Callable[[OnPetAdded.Result], None]) -> Wirespec.Cancellable:
+            ...
+    class Call(Wirespec.Call, ABC):
+        @abstractmethod
+        def OnPetAdded(self, input: OnPetAdded.Input, onNext: Callable[[OnPetAdded.Result], None]) -> Wirespec.Cancellable:
+            ...
+
+@dataclass
+class GetPetClient(GetPet.Call):
+    serialization: Wirespec.Serialization
+    transportation: Wirespec.Transportation
+    async def GetPet(self, input: GetPet.Input) -> GetPet.Result:
+        rawRequest = GetPet.toRawRequest(serialization=serialization, input=input)
+        rawResponse = transportation.transport(rawRequest)
+        return GetPet.fromRawResponse(serialization=serialization, response=rawResponse)
+
+@dataclass
+class AddPetClient(AddPet.Call):
+    serialization: Wirespec.Serialization
+    transportation: Wirespec.Transportation
+    async def AddPet(self, input: AddPet.Input) -> AddPet.Result:
+        rawRequest = AddPet.toRawRequest(serialization=serialization, input=input)
+        rawResponse = transportation.transport(rawRequest)
+        return AddPet.fromRawResponse(serialization=serialization, response=rawResponse)
+
+@dataclass
+class OnPetAddedClient(OnPetAdded.Call):
+    serialization: Wirespec.Serialization
+    transportation: Wirespec.StreamTransportation
+    def OnPetAdded(self, input: OnPetAdded.Input, onNext: Callable[[OnPetAdded.Result], None]) -> Wirespec.Cancellable:
+        rawRequest = OnPetAdded.toRawRequest(serialization=serialization, input=input)
+        return transportation.stream(rawRequest, lambda raw: onNext(value=OnPetAdded.fromRawResponse(serialization=serialization, response=raw)))
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+from ..model.Pet import Pet
+class PetGenerator:
+    @staticmethod
+    def generate(generator: Wirespec.Generator, path: list[str]) -> Pet:
+        return Pet(id=generator.generate(path + ['id'], Wirespec.GeneratorFieldString(regex=None, annotations=[])), name=generator.generate(path + ['name'], Wirespec.GeneratorFieldNullable(generate=lambda p0: generator.generate(p0, Wirespec.GeneratorFieldString(regex=None, annotations=[])))), tags=generator.generate(path + ['tags'], Wirespec.GeneratorFieldArray(generate=lambda p0: generator.generate(p0, Wirespec.GeneratorFieldString(regex=None, annotations=[])))))
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from ..wirespec import T, Wirespec, _raise
+from ..model.PetInput import PetInput
+class PetInputGenerator:
+    @staticmethod
+    def generate(generator: Wirespec.Generator, path: list[str]) -> PetInput:
+        return PetInput(name=generator.generate(path + ['name'], Wirespec.GeneratorFieldString(regex=None, annotations=[])))
+
+from . import model
+from . import endpoint
+from . import wirespec
+
+
+
+
+
+
+
+from __future__ import annotations
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, List, Optional
+import enum
+from .wirespec import T, Wirespec, _raise
+from .model.Pet import Pet
+from .model.PetInput import PetInput
+from .graphql.GetPet import *
+from .graphql.AddPet import *
+from .client.GetPetClient import GetPetClient
+from .client.AddPetClient import AddPetClient
+@dataclass
+class Client(GetPet.Call, AddPet.Call):
+    serialization: Wirespec.Serialization
+    transportation: Wirespec.Transportation
+    async def get_pet(self, input: GetPet.Input) -> GetPet.Result:
+        return await GetPetClient(serialization=self.serialization, transportation=self.transportation).get_pet(input)
+    async def add_pet(self, input: AddPet.Input) -> AddPet.Result:
+        return await AddPetClient(serialization=self.serialization, transportation=self.transportation).add_pet(input)

--- a/src/compiler/emitters/python/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileGraphqlTest.txt
@@ -39,7 +39,7 @@ class GetPet(Wirespec.GraphQL):
         id: str
     @dataclass
     class Data:
-        pet: Optional[Pet]
+        getPet: Optional[Pet]
     @dataclass
     class Result:
         data: Optional[GetPet.Data]
@@ -50,7 +50,7 @@ class GetPet(Wirespec.GraphQL):
         variables: GetPet.Input
     @staticmethod
     def document() -> str:
-        return 'query GetPet($id: String!) { pet(id: $id) { id name tags } }'
+        return 'query GetPet($id: String!) { getPet(id: $id) { id name tags } }'
     @staticmethod
     def toRawRequest(serialization: Wirespec.Serializer, input: GetPet.Input) -> Wirespec.RawRequest:
         return Wirespec.RawRequest(method='POST', path=['graphql'], queries={}, headers={}, body=serialization.serializeBody(RequestBody(query=document(), variables=input), RequestBody))
@@ -119,7 +119,7 @@ class OnPetAdded(Wirespec.GraphQL):
         pass
     @dataclass
     class Data:
-        petAdded: Pet
+        onPetAdded: Pet
     @dataclass
     class Result:
         data: Optional[OnPetAdded.Data]
@@ -130,7 +130,7 @@ class OnPetAdded(Wirespec.GraphQL):
         variables: OnPetAdded.Input
     @staticmethod
     def document() -> str:
-        return 'subscription OnPetAdded { petAdded { id name tags } }'
+        return 'subscription OnPetAdded { onPetAdded { id name tags } }'
     @staticmethod
     def toRawRequest(serialization: Wirespec.Serializer, input: OnPetAdded.Input) -> Wirespec.RawRequest:
         return Wirespec.RawRequest(method='POST', path=['graphql'], queries={}, headers={}, body=serialization.serializeBody(RequestBody(query=document(), variables=input), RequestBody))

--- a/src/compiler/emitters/python/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileGraphqlTest.txt
@@ -151,26 +151,26 @@ class GetPetClient(GetPet.Call):
     serialization: Wirespec.Serialization
     transportation: Wirespec.Transportation
     async def GetPet(self, input: GetPet.Input) -> GetPet.Result:
-        rawRequest = GetPet.toRawRequest(serialization=serialization, input=input)
+        rawRequest = GetPet.toRawRequest(serialization, input)
         rawResponse = transportation.transport(rawRequest)
-        return GetPet.fromRawResponse(serialization=serialization, response=rawResponse)
+        return GetPet.fromRawResponse(serialization, rawResponse)
 
 @dataclass
 class AddPetClient(AddPet.Call):
     serialization: Wirespec.Serialization
     transportation: Wirespec.Transportation
     async def AddPet(self, input: AddPet.Input) -> AddPet.Result:
-        rawRequest = AddPet.toRawRequest(serialization=serialization, input=input)
+        rawRequest = AddPet.toRawRequest(serialization, input)
         rawResponse = transportation.transport(rawRequest)
-        return AddPet.fromRawResponse(serialization=serialization, response=rawResponse)
+        return AddPet.fromRawResponse(serialization, rawResponse)
 
 @dataclass
 class OnPetAddedClient(OnPetAdded.Call):
     serialization: Wirespec.Serialization
     transportation: Wirespec.StreamTransportation
     def OnPetAdded(self, input: OnPetAdded.Input, onNext: Callable[[OnPetAdded.Result], None]) -> Wirespec.Cancellable:
-        rawRequest = OnPetAdded.toRawRequest(serialization=serialization, input=input)
-        return transportation.stream(rawRequest, lambda raw: onNext(value=OnPetAdded.fromRawResponse(serialization=serialization, response=raw)))
+        rawRequest = OnPetAdded.toRawRequest(serialization, input)
+        return transportation.stream(rawRequest, lambda raw: onNext(OnPetAdded.fromRawResponse(serialization, raw)))
 
 from __future__ import annotations
 import re

--- a/src/compiler/emitters/python/fixtures/compileMinimalEndpointTest.txt
+++ b/src/compiler/emitters/python/fixtures/compileMinimalEndpointTest.txt
@@ -107,9 +107,9 @@ class GetTodosClient(GetTodos.Call):
     transportation: Wirespec.Transportation
     async def get_todos(self) -> Response[Any]:
         request = Request()
-        rawRequest = GetTodos.toRawRequest(serialization=self.serialization, request=request)
+        rawRequest = GetTodos.toRawRequest(self.serialization, request)
         rawResponse = await self.transportation.transport(rawRequest)
-        return GetTodos.fromRawResponse(serialization=self.serialization, response=rawResponse)
+        return GetTodos.fromRawResponse(self.serialization, rawResponse)
 
 from __future__ import annotations
 import re

--- a/src/compiler/emitters/python/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/python/fixtures/sharedOutputTest.txt
@@ -26,6 +26,8 @@ class Wirespec:
         pass
     class Channel(ABC):
         pass
+    class GraphQL(ABC):
+        pass
     class Path(ABC):
         pass
     class Queries(ABC):
@@ -110,6 +112,24 @@ class Wirespec:
     class Transportation(ABC):
         @abstractmethod
         async def transport(self, request: Wirespec.RawRequest) -> Wirespec.RawResponse:
+            ...
+    @dataclass
+    class GraphQLErrorLocation:
+        line: int
+        column: int
+    @dataclass
+    class GraphQLError:
+        message: str
+        locations: Optional[list[Wirespec.GraphQLErrorLocation]]
+        path: Optional[list[Any]]
+        extensions: Optional[Any]
+    class Cancellable(ABC):
+        @abstractmethod
+        def cancel(self) -> None:
+            ...
+    class StreamTransportation(ABC):
+        @abstractmethod
+        def stream(self, request: Wirespec.RawRequest, onNext: Callable[[Wirespec.RawResponse], None]) -> Wirespec.Cancellable:
             ...
     class GeneratorField(ABC, Generic[T]):
         pass

--- a/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitter.kt
+++ b/src/compiler/emitters/python/src/commonMain/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitter.kt
@@ -13,6 +13,7 @@ import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Identifier
@@ -256,16 +257,18 @@ open class PythonIrEmitter(
         )
     }
 
-    override fun emitClient(endpoints: List<Endpoint>, logger: Logger): File {
-        val modelImports = endpoints.flatMap { it.importReferences() }.distinctBy { it.value }
+    override fun emitClient(endpoints: List<Endpoint>, graphqls: List<Graphql>, logger: Logger): File {
+        val modelImports = (endpoints.flatMap { it.importReferences() } + graphqls.flatMap { it.importReferences() })
+            .distinctBy { it.value }
             .map { import(".model.${it.value}", it.value) }
         val endpointImports = endpoints.map { import(".endpoint.${it.identifier.value}", "*") }
-        val clientImports =
-            endpoints.map { import(".client.${it.identifier.value}Client", "${it.identifier.value}Client") }
-        val allImports = modelImports + endpointImports + clientImports
+        val graphqlImports = graphqls.map { import(".graphql.${it.identifier.value}", "*") }
+        val clientImports = (endpoints.map { it.identifier.value } + graphqls.map { it.identifier.value })
+            .map { import(".client.${it}Client", "${it}Client") }
+        val allImports = modelImports + endpointImports + graphqlImports + clientImports
         val endpointNames = endpoints.map { it.identifier.value }
 
-        val file = super.emitClient(endpoints, logger)
+        val file = super.emitClient(endpoints, graphqls, logger)
             .sanitizeNames(sanitizationConfig)
             .addSelfReceiverToClientFields()
             .snakeCaseClientFunctions()

--- a/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitterTest.kt
+++ b/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitterTest.kt
@@ -3,11 +3,11 @@ package community.flock.wirespec.emitters.python
 import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
-import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
 import community.flock.wirespec.compiler.test.CompileFullEndpointTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest

--- a/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitterTest.kt
+++ b/src/compiler/emitters/python/src/commonTest/kotlin/community/flock/wirespec/emitters/python/PythonIrEmitterTest.kt
@@ -3,6 +3,7 @@ package community.flock.wirespec.emitters.python
 import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
@@ -31,6 +32,11 @@ class PythonIrEmitterTest {
         val python = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { PythonIrEmitter() } shouldBeRight python
+    }
+
+    @Test
+    fun compileGraphqlTest() {
+        CompileGraphqlTest.compiler { PythonIrEmitter() } shouldBeRight EmitterFixtures.compileGraphqlTest
     }
 
     @Test

--- a/src/compiler/emitters/rust/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileGraphqlTest.txt
@@ -1,0 +1,194 @@
+use super::super::wirespec::*;
+use regex;
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Pet {
+    pub id: String,
+    pub name: Option<String>,
+    pub tags: Vec<String>,
+}
+impl Pet {
+    pub fn validate(&self) -> Vec<String> {
+        return Vec::<String>::new();
+    }
+}
+
+use super::super::wirespec::*;
+use regex;
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PetInput {
+    pub name: String,
+}
+impl PetInput {
+    pub fn validate(&self) -> Vec<String> {
+        return Vec::<String>::new();
+    }
+}
+
+use super::super::wirespec::*;
+use regex;
+pub mod GetPet {
+    use super::*;
+    pub struct Input {
+        pub id: String,
+    }
+    pub struct Data {
+        pub pet: Option<Pet>,
+    }
+    pub struct Result {
+        pub data: Option<Data>,
+        pub errors: Option<Vec<Wirespec.GraphQLError>>,
+    }
+    pub struct RequestBody {
+        pub query: String,
+        pub variables: Input,
+    }
+    pub fn document() -> String {
+        return String::from("query GetPet($id: String!) { pet(id: $id) { id name tags } }");
+    }
+    pub fn to_raw_request(serialization: Wirespec.Serializer, input: Input) -> Wirespec.RawRequest {
+        return Wirespec.RawRequest { method: String::from("POST"), path: vec![String::from("graphql")], queries: std::collections::HashMap::new(), headers: std::collections::HashMap::new(), body: Some(serialization.serialize_body(&RequestBody { query: document(), variables: input }, std::any::TypeId::of::<RequestBody>())) };
+    }
+    pub fn from_raw_response(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> Result {
+        return response.body.as_ref().map(|it| serialization.deserialize_body(it, std::any::TypeId::of::<Result>())).expect("body is null");
+    }
+    pub trait Handler: Wirespec.Handler {
+        async fn get_pet(input: Input) -> Result;
+    }
+    pub trait Call: Wirespec.Call {
+        async fn get_pet(input: Input) -> Result;
+    }
+}
+
+use super::super::wirespec::*;
+use regex;
+pub mod AddPet {
+    use super::*;
+    pub struct Input {
+        pub input: PetInput,
+    }
+    pub struct Data {
+        pub add_pet: Pet,
+    }
+    pub struct Result {
+        pub data: Option<Data>,
+        pub errors: Option<Vec<Wirespec.GraphQLError>>,
+    }
+    pub struct RequestBody {
+        pub query: String,
+        pub variables: Input,
+    }
+    pub fn document() -> String {
+        return String::from("mutation AddPet($input: PetInput!) { addPet(input: $input) { id name tags } }");
+    }
+    pub fn to_raw_request(serialization: Wirespec.Serializer, input: Input) -> Wirespec.RawRequest {
+        return Wirespec.RawRequest { method: String::from("POST"), path: vec![String::from("graphql")], queries: std::collections::HashMap::new(), headers: std::collections::HashMap::new(), body: Some(serialization.serialize_body(&RequestBody { query: document(), variables: input }, std::any::TypeId::of::<RequestBody>())) };
+    }
+    pub fn from_raw_response(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> Result {
+        return response.body.as_ref().map(|it| serialization.deserialize_body(it, std::any::TypeId::of::<Result>())).expect("body is null");
+    }
+    pub trait Handler: Wirespec.Handler {
+        async fn add_pet(input: Input) -> Result;
+    }
+    pub trait Call: Wirespec.Call {
+        async fn add_pet(input: Input) -> Result;
+    }
+}
+
+use super::super::wirespec::*;
+use regex;
+pub mod OnPetAdded {
+    use super::*;
+    pub struct Input;
+    pub struct Data {
+        pub pet_added: Pet,
+    }
+    pub struct Result {
+        pub data: Option<Data>,
+        pub errors: Option<Vec<Wirespec.GraphQLError>>,
+    }
+    pub struct RequestBody {
+        pub query: String,
+        pub variables: Input,
+    }
+    pub fn document() -> String {
+        return String::from("subscription OnPetAdded { petAdded { id name tags } }");
+    }
+    pub fn to_raw_request(serialization: Wirespec.Serializer, input: Input) -> Wirespec.RawRequest {
+        return Wirespec.RawRequest { method: String::from("POST"), path: vec![String::from("graphql")], queries: std::collections::HashMap::new(), headers: std::collections::HashMap::new(), body: Some(serialization.serialize_body(&RequestBody { query: document(), variables: input }, std::any::TypeId::of::<RequestBody>())) };
+    }
+    pub fn from_raw_response(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse) -> Result {
+        return response.body.as_ref().map(|it| serialization.deserialize_body(it, std::any::TypeId::of::<Result>())).expect("body is null");
+    }
+    pub trait Handler: Wirespec.Handler {
+        fn on_pet_added(input: Input, on_next: Box<dyn Fn(Result) -> ()>) -> Wirespec.Cancellable;
+    }
+    pub trait Call: Wirespec.Call {
+        fn on_pet_added(input: Input, on_next: Box<dyn Fn(Result) -> ()>) -> Wirespec.Cancellable;
+    }
+}
+
+pub struct GetPetClient {
+    pub serialization: Wirespec.Serialization,
+    pub transportation: Wirespec.Transportation,
+}
+impl GetPetClient {
+    pub async fn get_pet(input: GetPet.Input) -> GetPet.Result {
+        let raw_request = get_pet.to_raw_request(serialization, input);
+        let raw_response = transportation.transport(raw_request);
+        return get_pet.from_raw_response(serialization, raw_response);
+    }
+}
+
+pub struct AddPetClient {
+    pub serialization: Wirespec.Serialization,
+    pub transportation: Wirespec.Transportation,
+}
+impl AddPetClient {
+    pub async fn add_pet(input: AddPet.Input) -> AddPet.Result {
+        let raw_request = add_pet.to_raw_request(serialization, input);
+        let raw_response = transportation.transport(raw_request);
+        return add_pet.from_raw_response(serialization, raw_response);
+    }
+}
+
+pub struct OnPetAddedClient {
+    pub serialization: Wirespec.Serialization,
+    pub transportation: Wirespec.StreamTransportation,
+}
+impl OnPetAddedClient {
+    pub fn on_pet_added(input: OnPetAdded.Input, on_next: Box<dyn Fn(OnPetAdded.Result) -> ()>) -> Wirespec.Cancellable {
+        let raw_request = on_pet_added.to_raw_request(serialization, input);
+        return transportation.stream(raw_request, Box::new(|raw| on_next(on_pet_added.from_raw_response(serialization, raw))));
+    }
+}
+
+use super::super::wirespec::*;
+use regex;
+use super::super::model::pet::Pet;
+pub struct PetGenerator;
+impl PetGenerator {
+    pub fn generate(generator: Wirespec.Generator, path: Vec<String>) -> Pet {
+        return Pet { id: generator.generate(vec![path.as_slice(), vec![String::from("id")].as_slice()].concat(), Wirespec.GeneratorFieldString { regex: None, annotations: Vec::<std::collections::HashMap<String, Box<dyn std::any::Any>>>::new() }), name: generator.generate(vec![path.as_slice(), vec![String::from("name")].as_slice()].concat(), Wirespec.GeneratorFieldNullable { generate: Box::new(|p0| generator.generate(p0, Wirespec.GeneratorFieldString { regex: None, annotations: Vec::<std::collections::HashMap<String, Box<dyn std::any::Any>>>::new() })) }), tags: generator.generate(vec![path.as_slice(), vec![String::from("tags")].as_slice()].concat(), Wirespec.GeneratorFieldArray { generate: Box::new(|p0| generator.generate(p0, Wirespec.GeneratorFieldString { regex: None, annotations: Vec::<std::collections::HashMap<String, Box<dyn std::any::Any>>>::new() })) }) };
+    }
+}
+
+use super::super::wirespec::*;
+use regex;
+use super::super::model::pet_input::PetInput;
+pub struct PetInputGenerator;
+impl PetInputGenerator {
+    pub fn generate(generator: Wirespec.Generator, path: Vec<String>) -> PetInput {
+        return PetInput { name: generator.generate(vec![path.as_slice(), vec![String::from("name")].as_slice()].concat(), Wirespec.GeneratorFieldString { regex: None, annotations: Vec::<std::collections::HashMap<String, Box<dyn std::any::Any>>>::new() }) };
+    }
+}
+
+#![allow(warnings)]
+pub mod model;
+pub mod endpoint;
+pub mod wirespec;
+
+use super::wirespec::*;
+pub struct Client<S: Serialization, T: Transportation> {
+    pub serialization: S,
+    pub transportation: T,
+}

--- a/src/compiler/emitters/rust/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/rust/fixtures/compileGraphqlTest.txt
@@ -32,7 +32,7 @@ pub mod GetPet {
         pub id: String,
     }
     pub struct Data {
-        pub pet: Option<Pet>,
+        pub get_pet: Option<Pet>,
     }
     pub struct Result {
         pub data: Option<Data>,
@@ -43,7 +43,7 @@ pub mod GetPet {
         pub variables: Input,
     }
     pub fn document() -> String {
-        return String::from("query GetPet($id: String!) { pet(id: $id) { id name tags } }");
+        return String::from("query GetPet($id: String!) { getPet(id: $id) { id name tags } }");
     }
     pub fn to_raw_request(serialization: Wirespec.Serializer, input: Input) -> Wirespec.RawRequest {
         return Wirespec.RawRequest { method: String::from("POST"), path: vec![String::from("graphql")], queries: std::collections::HashMap::new(), headers: std::collections::HashMap::new(), body: Some(serialization.serialize_body(&RequestBody { query: document(), variables: input }, std::any::TypeId::of::<RequestBody>())) };
@@ -100,7 +100,7 @@ pub mod OnPetAdded {
     use super::*;
     pub struct Input;
     pub struct Data {
-        pub pet_added: Pet,
+        pub on_pet_added: Pet,
     }
     pub struct Result {
         pub data: Option<Data>,
@@ -111,7 +111,7 @@ pub mod OnPetAdded {
         pub variables: Input,
     }
     pub fn document() -> String {
-        return String::from("subscription OnPetAdded { petAdded { id name tags } }");
+        return String::from("subscription OnPetAdded { onPetAdded { id name tags } }");
     }
     pub fn to_raw_request(serialization: Wirespec.Serializer, input: Input) -> Wirespec.RawRequest {
         return Wirespec.RawRequest { method: String::from("POST"), path: vec![String::from("graphql")], queries: std::collections::HashMap::new(), headers: std::collections::HashMap::new(), body: Some(serialization.serialize_body(&RequestBody { query: document(), variables: input }, std::any::TypeId::of::<RequestBody>())) };

--- a/src/compiler/emitters/rust/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/rust/fixtures/sharedOutputTest.txt
@@ -102,7 +102,7 @@ pub trait Cancellable {
     fn cancel(&self);
 }
 pub trait StreamTransportation {
-    fn stream(&self, request: RawRequest, on_next: Box<dyn Fn(RawResponse) -> ()>) -> Cancellable;
+    fn stream(&self, request: RawRequest, on_next: Box<dyn Fn(RawResponse)>) -> Box<dyn Cancellable>;
 }
 pub trait GeneratorField<T> {}
 pub struct GeneratorFieldString {

--- a/src/compiler/emitters/rust/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/rust/fixtures/sharedOutputTest.txt
@@ -14,6 +14,7 @@ pub trait Refined<T> {
 }
 pub trait Endpoint {}
 pub trait Channel {}
+pub trait GraphQL {}
 pub trait Path {}
 pub trait Queries {}
 pub trait Headers {}
@@ -85,6 +86,23 @@ pub struct RawResponse {
 }
 pub trait Transportation {
     async fn transport(&self, request: &RawRequest) -> RawResponse;
+}
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct GraphQLErrorLocation {
+    pub line: i32,
+    pub column: i32,
+}
+pub struct GraphQLError {
+    pub message: String,
+    pub locations: Option<Vec<GraphQLErrorLocation>>,
+    pub path: Option<Vec<Box<dyn std::any::Any>>>,
+    pub extensions: Option<Box<dyn std::any::Any>>,
+}
+pub trait Cancellable {
+    fn cancel(&self);
+}
+pub trait StreamTransportation {
+    fn stream(&self, request: RawRequest, on_next: Box<dyn Fn(RawResponse) -> ()>) -> Cancellable;
 }
 pub trait GeneratorField<T> {}
 pub struct GeneratorFieldString {

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
@@ -14,6 +14,7 @@ import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Identifier
@@ -475,7 +476,7 @@ open class RustIrEmitter(
         )
     }
 
-    override fun emitClient(endpoints: List<Endpoint>, logger: Logger): File {
+    override fun emitClient(endpoints: List<Endpoint>, graphqls: List<Graphql>, logger: Logger): File {
         logger.info("Emitting main Client for ${endpoints.size} endpoints")
 
         val modDeclarations = endpoints.joinToString("\n") { endpoint ->

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitter.kt
@@ -206,6 +206,8 @@ open class RustIrEmitter(
             "PathDeserializer" to RawElement("pub trait PathDeserializer {\n    fn deserialize_path<T: std::str::FromStr>(&self, raw: &str, r#type: TypeId) -> T where T::Err: std::fmt::Debug;\n}"),
             "ParamSerializer" to RawElement("pub trait ParamSerializer {\n    fn serialize_param<T: 'static>(&self, value: &T, r#type: TypeId) -> Vec<String>;\n}"),
             "ParamDeserializer" to RawElement("pub trait ParamDeserializer {\n    fn deserialize_param<T: 'static>(&self, values: &[String], r#type: TypeId) -> T;\n}"),
+            "Cancellable" to RawElement("pub trait Cancellable {\n    fn cancel(&self);\n}"),
+            "StreamTransportation" to RawElement("pub trait StreamTransportation {\n    fn stream(&self, request: RawRequest, on_next: Box<dyn Fn(RawResponse)>) -> Box<dyn Cancellable>;\n}"),
         )
 
         val transportationTrait = `interface`("Transportation") {

--- a/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustTransform.kt
+++ b/src/compiler/emitters/rust/src/commonMain/kotlin/community/flock/wirespec/emitters/rust/RustTransform.kt
@@ -313,6 +313,11 @@ object RustTransform {
             else -> "$value"
         }
         is RawExpression -> code
+        is FunctionCall -> {
+            val recv = receiver?.let { "${it.toRawCode()}." } ?: ""
+            val args = arguments.values.joinToString(", ") { it.toRawCode() }
+            "$recv${name.snakeCase().sanitizeKeywords()}($args)"
+        }
         else -> error("Unsupported expression type in toRawCode: ${this::class.simpleName}")
     }
 }

--- a/src/compiler/emitters/rust/src/commonTest/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitterTest.kt
+++ b/src/compiler/emitters/rust/src/commonTest/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitterTest.kt
@@ -3,11 +3,11 @@ package community.flock.wirespec.emitters.rust
 import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
-import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
 import community.flock.wirespec.compiler.test.CompileFullEndpointTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest

--- a/src/compiler/emitters/rust/src/commonTest/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitterTest.kt
+++ b/src/compiler/emitters/rust/src/commonTest/kotlin/community/flock/wirespec/emitters/rust/RustIrEmitterTest.kt
@@ -3,6 +3,7 @@ package community.flock.wirespec.emitters.rust
 import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
@@ -52,6 +53,11 @@ class RustIrEmitterTest {
         val rust = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { RustIrEmitter() } shouldBeRight rust
+    }
+
+    @Test
+    fun compileGraphqlTest() {
+        CompileGraphqlTest.compiler { RustIrEmitter() } shouldBeRight EmitterFixtures.compileGraphqlTest
     }
 
     @Test

--- a/src/compiler/emitters/scala/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileGraphqlTest.txt
@@ -1,0 +1,233 @@
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+case class Pet(
+  val id: String,
+  val name: Option[String],
+  val tags: List[String]
+) extends Wirespec.Shape {
+  override def validate(): List[String] =
+    List.empty[String]
+}
+
+package community.flock.wirespec.generated.model
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+case class PetInput(
+  val name: String
+) extends Wirespec.Shape {
+  override def validate(): List[String] =
+    List.empty[String]
+}
+
+package community.flock.wirespec.generated.graphql
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+object GetPet extends Wirespec.GraphQL {
+  case class Input(
+      val id: String
+    )
+  case class Data(
+      val pet: Option[Pet]
+    )
+  case class Result(
+      val data: Option[Data],
+      val errors: Option[List[Wirespec.GraphQLError]]
+    )
+  case class RequestBody(
+      val query: String,
+      val variables: Input
+    )
+  def document(): String =
+    "query GetPet($id: String!) { pet(id: $id) { id name tags } }"
+  def toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest =
+    new Wirespec.RawRequest(
+      method = "POST",
+      path = List("graphql"),
+      queries = Map.empty,
+      headers = Map.empty,
+      body = Some(serialization.serializeBody[RequestBody](RequestBody(
+        query = document(),
+        variables = input
+      ), scala.reflect.classTag[RequestBody]))
+    )
+  def fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Result =
+    (response.body.map(it => serialization.deserializeBody[Result](it, scala.reflect.classTag[Result])).getOrElse(throw new IllegalStateException("body is null")))
+  trait Handler extends Wirespec.Handler {
+      def getPet(input: Input): Result
+  }
+  trait Call extends Wirespec.Call {
+      def getPet(input: Input): Result
+  }
+}
+
+package community.flock.wirespec.generated.graphql
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+object AddPet extends Wirespec.GraphQL {
+  case class Input(
+      val input: PetInput
+    )
+  case class Data(
+      val addPet: Pet
+    )
+  case class Result(
+      val data: Option[Data],
+      val errors: Option[List[Wirespec.GraphQLError]]
+    )
+  case class RequestBody(
+      val query: String,
+      val variables: Input
+    )
+  def document(): String =
+    "mutation AddPet($input: PetInput!) { addPet(input: $input) { id name tags } }"
+  def toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest =
+    new Wirespec.RawRequest(
+      method = "POST",
+      path = List("graphql"),
+      queries = Map.empty,
+      headers = Map.empty,
+      body = Some(serialization.serializeBody[RequestBody](RequestBody(
+        query = document(),
+        variables = input
+      ), scala.reflect.classTag[RequestBody]))
+    )
+  def fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Result =
+    (response.body.map(it => serialization.deserializeBody[Result](it, scala.reflect.classTag[Result])).getOrElse(throw new IllegalStateException("body is null")))
+  trait Handler extends Wirespec.Handler {
+      def addPet(input: Input): Result
+  }
+  trait Call extends Wirespec.Call {
+      def addPet(input: Input): Result
+  }
+}
+
+package community.flock.wirespec.generated.graphql
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+object OnPetAdded extends Wirespec.GraphQL {
+  object Input
+  case class Data(
+      val petAdded: Pet
+    )
+  case class Result(
+      val data: Option[Data],
+      val errors: Option[List[Wirespec.GraphQLError]]
+    )
+  case class RequestBody(
+      val query: String,
+      val variables: Input.type
+    )
+  def document(): String =
+    "subscription OnPetAdded { petAdded { id name tags } }"
+  def toRawRequest(serialization: Wirespec.Serializer, input: Input.type): Wirespec.RawRequest =
+    new Wirespec.RawRequest(
+      method = "POST",
+      path = List("graphql"),
+      queries = Map.empty,
+      headers = Map.empty,
+      body = Some(serialization.serializeBody[RequestBody](RequestBody(
+        query = document(),
+        variables = input
+      ), scala.reflect.classTag[RequestBody]))
+    )
+  def fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Result =
+    (response.body.map(it => serialization.deserializeBody[Result](it, scala.reflect.classTag[Result])).getOrElse(throw new IllegalStateException("body is null")))
+  trait Handler extends Wirespec.Handler {
+      def onPetAdded(input: Input.type, onNext: (Result) => Unit): Wirespec.Cancellable
+  }
+  trait Call extends Wirespec.Call {
+      def onPetAdded(input: Input.type, onNext: (Result) => Unit): Wirespec.Cancellable
+  }
+}
+
+case class GetPetClient(
+  val serialization: Wirespec.Serialization,
+  val transportation: Wirespec.Transportation
+) extends GetPet.Call {
+  override def getPet(input: GetPet.Input): GetPet.Result = {
+    val rawRequest = GetPet.toRawRequest(serialization, input)
+    val rawResponse = transportation.transport(rawRequest)
+    GetPet.fromRawResponse(serialization, rawResponse)
+  }
+}
+
+case class AddPetClient(
+  val serialization: Wirespec.Serialization,
+  val transportation: Wirespec.Transportation
+) extends AddPet.Call {
+  override def addPet(input: AddPet.Input): AddPet.Result = {
+    val rawRequest = AddPet.toRawRequest(serialization, input)
+    val rawResponse = transportation.transport(rawRequest)
+    AddPet.fromRawResponse(serialization, rawResponse)
+  }
+}
+
+case class OnPetAddedClient(
+  val serialization: Wirespec.Serialization,
+  val transportation: Wirespec.StreamTransportation
+) extends OnPetAdded.Call {
+  override def onPetAdded(input: OnPetAdded.Input.type, onNext: (OnPetAdded.Result) => Unit): Wirespec.Cancellable = {
+    val rawRequest = OnPetAdded.toRawRequest(serialization, input)
+    transportation.stream(rawRequest, (raw) => onNext(OnPetAdded.fromRawResponse(serialization, raw)))
+  }
+}
+
+package community.flock.wirespec.generated.generator
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+import community.flock.wirespec.generated.model.Pet
+object PetGenerator {
+  def generate(generator: Wirespec.Generator, path: List[String]): Pet =
+    new Pet(
+      id = generator.generate(path ++ List("id"), new Wirespec.GeneratorFieldString(
+        regex = None,
+        annotations = List.empty[Map[String, Any]]
+      )),
+      name = generator.generate(path ++ List("name"), new Wirespec.GeneratorFieldNullable(generate = (p0) => generator.generate(p0, new Wirespec.GeneratorFieldString(
+        regex = None,
+        annotations = List.empty[Map[String, Any]]
+      )))),
+      tags = generator.generate(path ++ List("tags"), new Wirespec.GeneratorFieldArray(generate = (p0) => generator.generate(p0, new Wirespec.GeneratorFieldString(
+        regex = None,
+        annotations = List.empty[Map[String, Any]]
+      ))))
+    )
+}
+
+package community.flock.wirespec.generated.generator
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+import community.flock.wirespec.generated.model.PetInput
+object PetInputGenerator {
+  def generate(generator: Wirespec.Generator, path: List[String]): PetInput =
+    new PetInput(name = generator.generate(path ++ List("name"), new Wirespec.GeneratorFieldString(
+      regex = None,
+      annotations = List.empty[Map[String, Any]]
+    )))
+}
+
+package community.flock.wirespec.generated
+import community.flock.wirespec.scala.Wirespec
+import scala.reflect.ClassTag
+import community.flock.wirespec.generated.model.Pet
+import community.flock.wirespec.generated.model.PetInput
+import community.flock.wirespec.generated.graphql.GetPet
+import community.flock.wirespec.generated.graphql.AddPet
+import community.flock.wirespec.generated.client.GetPetClient
+import community.flock.wirespec.generated.client.AddPetClient
+case class Client(
+  val serialization: Wirespec.Serialization,
+  val transportation: Wirespec.Transportation
+) extends GetPet.Call[[A] =>> A] with AddPet.Call[[A] =>> A] {
+  override def getPet(input: GetPet.Input): GetPet.Result =
+    new GetPetClient(
+      serialization = serialization,
+      transportation = transportation
+    ).getPet(input)
+  override def addPet(input: AddPet.Input): AddPet.Result =
+    new AddPetClient(
+      serialization = serialization,
+      transportation = transportation
+    ).addPet(input)
+}

--- a/src/compiler/emitters/scala/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/scala/fixtures/compileGraphqlTest.txt
@@ -28,7 +28,7 @@ object GetPet extends Wirespec.GraphQL {
       val id: String
     )
   case class Data(
-      val pet: Option[Pet]
+      val getPet: Option[Pet]
     )
   case class Result(
       val data: Option[Data],
@@ -39,7 +39,7 @@ object GetPet extends Wirespec.GraphQL {
       val variables: Input
     )
   def document(): String =
-    "query GetPet($id: String!) { pet(id: $id) { id name tags } }"
+    "query GetPet($id: String!) { getPet(id: $id) { id name tags } }"
   def toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest =
     new Wirespec.RawRequest(
       method = "POST",
@@ -108,7 +108,7 @@ import scala.reflect.ClassTag
 object OnPetAdded extends Wirespec.GraphQL {
   object Input
   case class Data(
-      val petAdded: Pet
+      val onPetAdded: Pet
     )
   case class Result(
       val data: Option[Data],
@@ -119,7 +119,7 @@ object OnPetAdded extends Wirespec.GraphQL {
       val variables: Input.type
     )
   def document(): String =
-    "subscription OnPetAdded { petAdded { id name tags } }"
+    "subscription OnPetAdded { onPetAdded { id name tags } }"
   def toRawRequest(serialization: Wirespec.Serializer, input: Input.type): Wirespec.RawRequest =
     new Wirespec.RawRequest(
       method = "POST",

--- a/src/compiler/emitters/scala/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/scala/fixtures/sharedOutputTest.txt
@@ -13,6 +13,7 @@ object Wirespec {
   }
   trait Endpoint
   trait Channel
+  trait GraphQL
   trait Path
   trait Queries
   trait Headers
@@ -84,6 +85,22 @@ object Wirespec {
     )
   trait Transportation {
       def transport(request: RawRequest): RawResponse
+  }
+  case class GraphQLErrorLocation(
+      val line: Int,
+      val column: Int
+    )
+  case class GraphQLError(
+      val message: String,
+      val locations: Option[List[GraphQLErrorLocation]],
+      val path: Option[List[Any]],
+      val extensions: Option[Any]
+    )
+  trait Cancellable {
+      def cancel(): Unit
+  }
+  trait StreamTransportation {
+      def stream(request: RawRequest, onNext: (RawResponse) => Unit): Cancellable
   }
   sealed trait GeneratorField[T]
   case class GeneratorFieldString(

--- a/src/compiler/emitters/scala/src/commonMain/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitter.kt
+++ b/src/compiler/emitters/scala/src/commonMain/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitter.kt
@@ -15,6 +15,7 @@ import community.flock.wirespec.compiler.core.emit.plus
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Identifier
@@ -272,15 +273,18 @@ open class ScalaIrEmitter(
         )
     }
 
-    override fun emitClient(endpoints: List<Endpoint>, logger: Logger): File {
-        val imports = endpoints.flatMap { it.importReferences() }.distinctBy { it.value }
+    override fun emitClient(endpoints: List<Endpoint>, graphqls: List<Graphql>, logger: Logger): File {
+        val imports = (endpoints.flatMap { it.importReferences() } + graphqls.flatMap { it.importReferences() })
+            .distinctBy { it.value }
             .map { import("${packageName.value}.model", it.value) }
         val endpointImports = endpoints
             .map { import("${packageName.value}.endpoint", it.identifier.value) }
-        val clientImports = endpoints
-            .map { import("${packageName.value}.client", "${it.identifier.value}Client") }
-        val allImports = imports + endpointImports + clientImports
-        val file = super.emitClient(endpoints, logger).sanitizeNames(sanitizationConfig).addIdentityTypeToCall()
+        val graphqlImports = graphqls
+            .map { import("${packageName.value}.graphql", it.identifier.value) }
+        val clientImports = (endpoints.map { it.identifier.value } + graphqls.map { it.identifier.value })
+            .map { import("${packageName.value}.client", "${it}Client") }
+        val allImports = imports + endpointImports + graphqlImports + clientImports
+        val file = super.emitClient(endpoints, graphqls, logger).sanitizeNames(sanitizationConfig).addIdentityTypeToCall()
         return File(
             name = Name.of(packageName.toDir() + file.name.pascalCase()),
             elements = buildList {

--- a/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
+++ b/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
@@ -10,6 +10,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
@@ -119,6 +120,11 @@ class ScalaIrEmitterTest {
         val scala = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { ScalaIrEmitter() } shouldBeRight scala
+    }
+
+    @Test
+    fun compileGraphqlTest() {
+        CompileGraphqlTest.compiler { ScalaIrEmitter() } shouldBeRight EmitterFixtures.compileGraphqlTest
     }
 
     @Test

--- a/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
+++ b/src/compiler/emitters/scala/src/commonTest/kotlin/community/flock/wirespec/emitters/scala/ScalaIrEmitterTest.kt
@@ -10,11 +10,11 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
-import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
 import community.flock.wirespec.compiler.test.CompileFullEndpointTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest

--- a/src/compiler/emitters/typescript/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/compileGraphqlTest.txt
@@ -22,7 +22,7 @@ export namespace GetPet {
     "id": string,
   }
   export type Data = {
-    "pet": Pet | undefined,
+    "getPet": Pet | undefined,
   }
   export type Result = {
     "data": Data | undefined,
@@ -33,7 +33,7 @@ export namespace GetPet {
     "variables": Input,
   }
   export function document(): string {
-    return 'query GetPet($id: String!) { pet(id: $id) { id name tags } }';
+    return 'query GetPet($id: String!) { getPet(id: $id) { id name tags } }';
   }
   export function toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest {
     return { method: 'POST', path: ['graphql'], queries: {}, headers: {}, body: serialization.serializeBody({ query: document(), variables: input }, "RequestBody") };
@@ -86,7 +86,7 @@ import {Wirespec} from '../Wirespec'
 export namespace OnPetAdded {
   export type Input = {}
   export type Data = {
-    "petAdded": Pet,
+    "onPetAdded": Pet,
   }
   export type Result = {
     "data": Data | undefined,
@@ -97,7 +97,7 @@ export namespace OnPetAdded {
     "variables": Input,
   }
   export function document(): string {
-    return 'subscription OnPetAdded { petAdded { id name tags } }';
+    return 'subscription OnPetAdded { onPetAdded { id name tags } }';
   }
   export function toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest {
     return { method: 'POST', path: ['graphql'], queries: {}, headers: {}, body: serialization.serializeBody({ query: document(), variables: input }, "RequestBody") };

--- a/src/compiler/emitters/typescript/fixtures/compileGraphqlTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/compileGraphqlTest.txt
@@ -1,0 +1,169 @@
+import {Wirespec} from '../Wirespec'
+export type Pet = {
+  "id": string,
+  "name": string | undefined,
+  "tags": string[],
+}
+export function validatePet(obj: Pet): string[] {
+  return [] as string[];
+}
+
+import {Wirespec} from '../Wirespec'
+export type PetInput = {
+  "name": string,
+}
+export function validatePetInput(obj: PetInput): string[] {
+  return [] as string[];
+}
+
+import {Wirespec} from '../Wirespec'
+export namespace GetPet {
+  export type Input = {
+    "id": string,
+  }
+  export type Data = {
+    "pet": Pet | undefined,
+  }
+  export type Result = {
+    "data": Data | undefined,
+    "errors": Wirespec.GraphQLError[] | undefined,
+  }
+  export type RequestBody = {
+    "query": string,
+    "variables": Input,
+  }
+  export function document(): string {
+    return 'query GetPet($id: String!) { pet(id: $id) { id name tags } }';
+  }
+  export function toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest {
+    return { method: 'POST', path: ['graphql'], queries: {}, headers: {}, body: serialization.serializeBody({ query: document(), variables: input }, "RequestBody") };
+  }
+  export function fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Result {
+    return response.body != null ? serialization.deserializeBody(response.body, "Result") : (() => { throw new Error('body is null') })();
+  }
+  export interface Handler extends Wirespec.Handler {
+    getPet(input: Input): Promise<Result>;
+  }
+  export interface Call extends Wirespec.Call {
+    getPet(input: Input): Promise<Result>;
+  }
+}
+
+import {Wirespec} from '../Wirespec'
+export namespace AddPet {
+  export type Input = {
+    "input": PetInput,
+  }
+  export type Data = {
+    "addPet": Pet,
+  }
+  export type Result = {
+    "data": Data | undefined,
+    "errors": Wirespec.GraphQLError[] | undefined,
+  }
+  export type RequestBody = {
+    "query": string,
+    "variables": Input,
+  }
+  export function document(): string {
+    return 'mutation AddPet($input: PetInput!) { addPet(input: $input) { id name tags } }';
+  }
+  export function toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest {
+    return { method: 'POST', path: ['graphql'], queries: {}, headers: {}, body: serialization.serializeBody({ query: document(), variables: input }, "RequestBody") };
+  }
+  export function fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Result {
+    return response.body != null ? serialization.deserializeBody(response.body, "Result") : (() => { throw new Error('body is null') })();
+  }
+  export interface Handler extends Wirespec.Handler {
+    addPet(input: Input): Promise<Result>;
+  }
+  export interface Call extends Wirespec.Call {
+    addPet(input: Input): Promise<Result>;
+  }
+}
+
+import {Wirespec} from '../Wirespec'
+export namespace OnPetAdded {
+  export type Input = {}
+  export type Data = {
+    "petAdded": Pet,
+  }
+  export type Result = {
+    "data": Data | undefined,
+    "errors": Wirespec.GraphQLError[] | undefined,
+  }
+  export type RequestBody = {
+    "query": string,
+    "variables": Input,
+  }
+  export function document(): string {
+    return 'subscription OnPetAdded { petAdded { id name tags } }';
+  }
+  export function toRawRequest(serialization: Wirespec.Serializer, input: Input): Wirespec.RawRequest {
+    return { method: 'POST', path: ['graphql'], queries: {}, headers: {}, body: serialization.serializeBody({ query: document(), variables: input }, "RequestBody") };
+  }
+  export function fromRawResponse(serialization: Wirespec.Deserializer, response: Wirespec.RawResponse): Result {
+    return response.body != null ? serialization.deserializeBody(response.body, "Result") : (() => { throw new Error('body is null') })();
+  }
+  export interface Handler extends Wirespec.Handler {
+    onPetAdded(input: Input, onNext: (p0: Result) => void): Wirespec.Cancellable;
+  }
+  export interface Call extends Wirespec.Call {
+    onPetAdded(input: Input, onNext: (p0: Result) => void): Wirespec.Cancellable;
+  }
+}
+
+export type GetPetClient = {
+  "serialization": Wirespec.Serialization,
+  "transportation": Wirespec.Transportation,
+}
+export async function getPet(input: GetPet.Input): GetPet.Result {
+  const rawRequest = GetPet.toRawRequest(serialization, input);
+  const rawResponse = transportation.transport(rawRequest);
+  return GetPet.fromRawResponse(serialization, rawResponse);
+}
+
+export type AddPetClient = {
+  "serialization": Wirespec.Serialization,
+  "transportation": Wirespec.Transportation,
+}
+export async function addPet(input: AddPet.Input): AddPet.Result {
+  const rawRequest = AddPet.toRawRequest(serialization, input);
+  const rawResponse = transportation.transport(rawRequest);
+  return AddPet.fromRawResponse(serialization, rawResponse);
+}
+
+export type OnPetAddedClient = {
+  "serialization": Wirespec.Serialization,
+  "transportation": Wirespec.StreamTransportation,
+}
+export function onPetAdded(input: OnPetAdded.Input, onNext: (p0: OnPetAdded.Result) => void): Wirespec.Cancellable {
+  const rawRequest = OnPetAdded.toRawRequest(serialization, input);
+  return transportation.stream(rawRequest, (raw: Wirespec.RawResponse) => onNext(OnPetAdded.fromRawResponse(serialization, raw)));
+}
+
+import {Wirespec} from '../Wirespec'
+import {Pet} from '../model/Pet'
+export namespace PetGenerator {
+  export function generate(generator: Wirespec.Generator, path: string[]): Pet {
+    return { id: generator.generate([...path, ...['id']], { kind: 'string', regex: undefined, annotations: [] as Record<string, any>[] }), name: generator.generate([...path, ...['name']], { kind: 'nullable', generate: (p0: string[]) => generator.generate(p0, { kind: 'string', regex: undefined, annotations: [] as Record<string, any>[] }) }), tags: generator.generate([...path, ...['tags']], { kind: 'array', generate: (p0: string[]) => generator.generate(p0, { kind: 'string', regex: undefined, annotations: [] as Record<string, any>[] }) }) };
+  }
+}
+
+import {Wirespec} from '../Wirespec'
+import {PetInput} from '../model/PetInput'
+export namespace PetInputGenerator {
+  export function generate(generator: Wirespec.Generator, path: string[]): PetInput {
+    return { name: generator.generate([...path, ...['name']], { kind: 'string', regex: undefined, annotations: [] as Record<string, any>[] }) };
+  }
+}
+
+import {Wirespec} from './Wirespec'
+export const client = (serialization: Wirespec.Serialization, transportation: Wirespec.Transportation) => ({
+})
+
+export {Pet} from './Pet'
+export {PetInput} from './PetInput'
+export {GetPet} from './GetPet'
+export {AddPet} from './AddPet'
+export {OnPetAdded} from './OnPetAdded'

--- a/src/compiler/emitters/typescript/fixtures/sharedOutputTest.txt
+++ b/src/compiler/emitters/typescript/fixtures/sharedOutputTest.txt
@@ -13,6 +13,7 @@ export namespace Wirespec {
   }
   export interface Endpoint {}
   export interface Channel {}
+  export interface GraphQL {}
   export interface Path {}
   export interface Queries {}
   export interface Headers {}
@@ -69,6 +70,22 @@ export namespace Wirespec {
   }
   export interface Transportation {
     transport(request: RawRequest): Promise<RawResponse>;
+  }
+  export type GraphQLErrorLocation = {
+    "line": number,
+    "column": number,
+  }
+  export type GraphQLError = {
+    "message": string,
+    "locations": GraphQLErrorLocation[] | undefined,
+    "path": any[] | undefined,
+    "extensions": any | undefined,
+  }
+  export interface Cancellable {
+    cancel(): void;
+  }
+  export interface StreamTransportation {
+    stream(request: RawRequest, onNext: (p0: RawResponse) => void): Cancellable;
   }
   export interface GeneratorField<T extends any | undefined> {}
   export type GeneratorFieldString = {

--- a/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitter.kt
+++ b/src/compiler/emitters/typescript/src/commonMain/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitter.kt
@@ -13,6 +13,7 @@ import community.flock.wirespec.compiler.core.parse.ast.AST
 import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Identifier
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
@@ -356,7 +357,7 @@ open class TypeScriptIrEmitter : IrEmitter {
         )
     }
 
-    override fun emitClient(endpoints: List<Endpoint>, logger: Logger): File {
+    override fun emitClient(endpoints: List<Endpoint>, graphqls: List<Graphql>, logger: Logger): File {
         logger.info("Emitting main Client for ${endpoints.size} endpoints")
 
         val clientImports = endpoints.map {

--- a/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitterTest.kt
+++ b/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitterTest.kt
@@ -2,6 +2,7 @@ package community.flock.wirespec.emitters.typescript
 
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
@@ -30,6 +31,11 @@ class TypeScriptIrEmitterTest {
         val typescript = EmitterFixtures.compileChannelTest
 
         CompileChannelTest.compiler { TypeScriptIrEmitter() } shouldBeRight typescript
+    }
+
+    @Test
+    fun compileGraphqlTest() {
+        CompileGraphqlTest.compiler { TypeScriptIrEmitter() } shouldBeRight EmitterFixtures.compileGraphqlTest
     }
 
     @Test

--- a/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitterTest.kt
+++ b/src/compiler/emitters/typescript/src/commonTest/kotlin/community/flock/wirespec/emitters/typescript/TypeScriptIrEmitterTest.kt
@@ -2,11 +2,11 @@ package community.flock.wirespec.emitters.typescript
 
 import community.flock.wirespec.compiler.test.CompileAnyTest
 import community.flock.wirespec.compiler.test.CompileChannelTest
-import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFieldNameSanitizationTest
 import community.flock.wirespec.compiler.test.CompileFullEndpointTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest

--- a/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitter.kt
+++ b/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitter.kt
@@ -14,6 +14,7 @@ interface WirespecEmitters:
     WirespecTypeDefinitionEmitter,
     WirespecEndpointDefinitionEmitter,
     WirespecChannelDefinitionEmitter,
+    WirespecGraphqlDefinitionEmitter,
     WirespecEnumDefinitionEmitter,
     WirespecUnionDefinitionEmitter,
     WirespecRefinedTypeDefinitionEmitter

--- a/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecGraphqlDefinitionEmitter.kt
+++ b/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecGraphqlDefinitionEmitter.kt
@@ -1,0 +1,14 @@
+package community.flock.wirespec.emitters.wirespec
+
+import community.flock.wirespec.compiler.core.emit.GraphqlDefinitionEmitter
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
+
+interface WirespecGraphqlDefinitionEmitter :
+    GraphqlDefinitionEmitter,
+    WirespecTypeDefinitionEmitter {
+    override fun emit(graphql: Graphql): String = graphql.inputs
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(", ", "(", ")") { it.emit() }
+        .orEmpty()
+        .let { inputs -> "graphql ${emit(graphql.identifier)} ${graphql.kind.name} ${emit(graphql.operation)}$inputs -> ${graphql.output.emit()}" }
+}

--- a/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecGraphqlDefinitionEmitter.kt
+++ b/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecGraphqlDefinitionEmitter.kt
@@ -7,8 +7,6 @@ interface WirespecGraphqlDefinitionEmitter :
     GraphqlDefinitionEmitter,
     WirespecTypeDefinitionEmitter {
     override fun emit(graphql: Graphql): String = graphql.inputs
-        .takeIf { it.isNotEmpty() }
-        ?.joinToString(", ", "(", ")") { it.emit() }
-        .orEmpty()
-        .let { inputs -> "graphql ${emit(graphql.identifier)} ${graphql.kind.name} ${emit(graphql.operation)}$inputs -> ${graphql.output.emit()}" }
+        .joinToString(", ", "{", "}") { it.emit() }
+        .let { inputs -> "graphql ${emit(graphql.identifier)} ${graphql.kind.name} $inputs -> ${graphql.output.emit()}" }
 }

--- a/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecTypeDefinitionEmitter.kt
+++ b/src/compiler/emitters/wirespec/src/commonMain/kotlin/community/flock/wirespec/emitters/wirespec/WirespecTypeDefinitionEmitter.kt
@@ -17,7 +17,11 @@ interface WirespecTypeDefinitionEmitter : TypeDefinitionEmitter, WirespecIdentif
 
     override fun Type.Shape.emit() = value.joinToString(",\n") { "$Spacer${it.emit()}" }
 
-    override fun Field.emit() = "${emit(identifier)}: ${reference.emit()}"
+    override fun Field.emit(): String = "${emit(identifier)}${parameters.emitParameters()}: ${reference.emit()}"
+
+    private fun List<Field>.emitParameters() = takeIf { it.isNotEmpty() }
+        ?.joinToString(", ", "(", ")") { it.emit() }
+        ?: ""
 
     override fun Reference.emit(): String = when (this) {
         is Reference.Dict -> "{ ${reference.emit()} }"

--- a/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
+++ b/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
@@ -81,9 +81,9 @@ class WirespecEmitterTest {
             |  name: String
             |}
             |
-            |graphql GetPet Query pet(id: String) -> Pet?
-            |graphql AddPet Mutation addPet(input: PetInput) -> Pet
-            |graphql OnPetAdded Subscription petAdded -> Pet
+            |graphql GetPet Query {id: String} -> Pet?
+            |graphql AddPet Mutation {input: PetInput} -> Pet
+            |graphql OnPetAdded Subscription {} -> Pet
         """.trimMargin()
 
         CompileGraphqlTest.compiler { WirespecEmitter() } shouldBeRight wirespec

--- a/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
+++ b/src/compiler/emitters/wirespec/src/commonTest/kotlin/community/flock/wirespec/emitters/wirespec/WirespecEmitterTest.kt
@@ -9,6 +9,7 @@ import community.flock.wirespec.compiler.test.CompileChannelTest
 import community.flock.wirespec.compiler.test.CompileComplexModelTest
 import community.flock.wirespec.compiler.test.CompileEnumTest
 import community.flock.wirespec.compiler.test.CompileFullEndpointTest
+import community.flock.wirespec.compiler.test.CompileGraphqlTest
 import community.flock.wirespec.compiler.test.CompileMinimalEndpointTest
 import community.flock.wirespec.compiler.test.CompileNestedTypeTest
 import community.flock.wirespec.compiler.test.CompileRefinedTest
@@ -65,6 +66,34 @@ class WirespecEmitterTest {
         """.trimMargin()
 
         CompileChannelTest.compiler { WirespecEmitter() } shouldBeRight wirespec
+    }
+
+    @Test
+    fun compileGraphqlTest() {
+        val wirespec = """
+            |type Pet {
+            |  id: String,
+            |  name: String?,
+            |  tags: String[]
+            |}
+            |
+            |type PetInput {
+            |  name: String
+            |}
+            |
+            |graphql GetPet Query pet(id: String) -> Pet?
+            |graphql AddPet Mutation addPet(input: PetInput) -> Pet
+            |graphql OnPetAdded Subscription petAdded -> Pet
+        """.trimMargin()
+
+        CompileGraphqlTest.compiler { WirespecEmitter() } shouldBeRight wirespec
+    }
+
+    @Test
+    fun graphqlRoundTripTest() {
+        val emitted = CompileGraphqlTest.compiler { WirespecEmitter() }.shouldBeRight()
+        val recompiled = compile(emitted)
+        recompiled { WirespecEmitter() } shouldBeRight emitted
     }
 
     @Test

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -1,6 +1,7 @@
 package community.flock.wirespec.ir.converter
 
 import community.flock.wirespec.compiler.core.emit.PackageName
+import community.flock.wirespec.compiler.core.emit.flattenListDict
 import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
 import community.flock.wirespec.compiler.core.parse.ast.Identifier
@@ -16,8 +17,11 @@ import community.flock.wirespec.ir.core.Expression
 import community.flock.wirespec.ir.core.FieldCall
 import community.flock.wirespec.ir.core.File
 import community.flock.wirespec.ir.core.FlatMapIndexed
+import community.flock.wirespec.ir.core.FunctionBuilder
 import community.flock.wirespec.ir.core.FunctionCall
 import community.flock.wirespec.ir.core.IfExpression
+import community.flock.wirespec.ir.core.InterfaceBuilder
+import community.flock.wirespec.ir.core.Lambda
 import community.flock.wirespec.ir.core.ListConcat
 import community.flock.wirespec.ir.core.Literal
 import community.flock.wirespec.ir.core.LiteralList
@@ -29,6 +33,7 @@ import community.flock.wirespec.ir.core.NullCheck
 import community.flock.wirespec.ir.core.NullableEmpty
 import community.flock.wirespec.ir.core.NullableMap
 import community.flock.wirespec.ir.core.NullableOf
+import community.flock.wirespec.ir.core.Parameter
 import community.flock.wirespec.ir.core.Precision
 import community.flock.wirespec.ir.core.ReturnStatement
 import community.flock.wirespec.ir.core.StringTemplate
@@ -43,6 +48,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition as Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint as EndpointWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Enum as EnumWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Field as FieldWirespec
+import community.flock.wirespec.compiler.core.parse.ast.Graphql as GraphqlWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Reference as ReferenceWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Refined as RefinedWirespec
 import community.flock.wirespec.compiler.core.parse.ast.Type as TypeWirespec
@@ -56,6 +62,7 @@ fun DefinitionWirespec.convert(): File = when (this) {
     is RefinedWirespec -> convert()
     is ChannelWirespec -> convert()
     is EndpointWirespec -> convert()
+    is GraphqlWirespec -> convert()
 }
 
 fun PackageName.convert(): File = file("Wirespec") {
@@ -82,6 +89,7 @@ fun PackageName.convert(): File = file("Wirespec") {
         }
         `interface`("Endpoint")
         `interface`("Channel")
+        `interface`("GraphQL")
         `interface`("Path")
         `interface`("Queries")
         `interface`("Headers")
@@ -204,6 +212,28 @@ fun PackageName.convert(): File = file("Wirespec") {
             asyncFunction("transport") {
                 returnType(type("RawResponse"))
                 arg("request", type("RawRequest"))
+            }
+        }
+        struct(Name("Graph", "QL", "Error", "Location")) {
+            field("line", integer)
+            field("column", integer)
+        }
+        struct(Name("Graph", "QL", "Error")) {
+            field("message", string)
+            field("locations", list(type("GraphQLErrorLocation")).nullable())
+            field("path", list(Type.Any).nullable())
+            field("extensions", Type.Nullable(Type.Any))
+        }
+        `interface`("Cancellable") {
+            function("cancel") {
+                returnType(unit)
+            }
+        }
+        `interface`(Name("Stream", "Transportation")) {
+            function("stream") {
+                returnType(type("Cancellable"))
+                arg("request", type("RawRequest"))
+                arg(Name("on", "Next"), Type.Function(listOf(type("RawResponse")), unit))
             }
         }
         `interface`("GeneratorField", isSealed = true) {
@@ -599,6 +629,98 @@ fun ChannelWirespec.convert() = file(identifier.toName()) {
             function(identifier.toName()) {
                 arg("handler", Type.Function(listOf(reference.convert()), unit))
                 returnType(unit)
+            }
+        }
+    }
+}
+
+fun GraphqlWirespec.convert(module: Module? = null): File {
+    val graphql = this
+    val name = identifier.toName()
+    val document = buildDocument(module)
+    val allInputs = inputs + document.liftedInputs
+    val outputType = output.convert()
+
+    return file(name) {
+        namespace(name, type("Wirespec.GraphQL")) {
+            struct("Input") {
+                allInputs.forEach { field(it.identifier.toName(), it.reference.convert()) }
+            }
+            struct("Data") {
+                field(graphql.operation.toName(), outputType)
+            }
+            struct("Result") {
+                field("data", type("Data").nullable())
+                field("errors", list(type("Wirespec.GraphQLError")).nullable())
+            }
+            struct("RequestBody") {
+                field("query", string)
+                field("variables", type("Input"))
+            }
+            function(Name.of("document"), isStatic = true) {
+                returnType(string)
+                returns(Literal(document.text, Type.String))
+            }
+            function(Name("to", "Raw", "Request"), isStatic = true) {
+                returnType(type("Wirespec.RawRequest"))
+                arg("serialization", type("Wirespec.Serializer"))
+                arg("input", type("Input"))
+                returns(
+                    construct(type("Wirespec.RawRequest")) {
+                        arg("method", Literal("POST", Type.String))
+                        arg("path", LiteralList(listOf(Literal("graphql", Type.String)), Type.String))
+                        arg("queries", LiteralMap(emptyMap(), Type.String, Type.Custom("List<String>")))
+                        arg("headers", LiteralMap(emptyMap(), Type.String, Type.Custom("List<String>")))
+                        arg(
+                            "body",
+                            NullableOf(
+                                FunctionCall(
+                                    receiver = VariableReference(Name.of("serialization")),
+                                    name = Name("serialize", "Body"),
+                                    typeArguments = listOf(Type.Custom("RequestBody")),
+                                    arguments = mapOf(
+                                        Name.of("value") to ConstructorStatement(
+                                            type = Type.Custom("RequestBody"),
+                                            namedArguments = mapOf(
+                                                Name.of("query") to FunctionCall(name = Name.of("document"), arguments = emptyMap()),
+                                                Name.of("variables") to VariableReference(Name.of("input")),
+                                            ),
+                                        ),
+                                        Name.of("type") to TypeDescriptor(Type.Custom("RequestBody")),
+                                    ),
+                                ),
+                            ),
+                        )
+                    },
+                )
+            }
+            function(Name("from", "Raw", "Response"), isStatic = true) {
+                returnType(type("Result"))
+                arg("serialization", type("Wirespec.Deserializer"))
+                arg("response", type("Wirespec.RawResponse"))
+                returns(
+                    NullableMap(
+                        expression = FieldCall(VariableReference(Name.of("response")), Name.of("body")),
+                        body = FunctionCall(
+                            receiver = VariableReference(Name.of("serialization")),
+                            name = Name("deserialize", "Body"),
+                            typeArguments = listOf(Type.Custom("Result")),
+                            arguments = mapOf(
+                                Name.of("value") to VariableReference(Name.of("it")),
+                                Name.of("type") to TypeDescriptor(Type.Custom("Result")),
+                            ),
+                        ),
+                        alternative = ErrorStatement(Literal("body is null", Type.String)),
+                    ),
+                )
+            }
+            `interface`("Handler") {
+                extends(type("Wirespec.Handler"))
+                graphqlHandlerFunction(graphql, name)
+            }
+            `interface`("Call") {
+                extends(type("Wirespec.Call"))
+                graphqlHandlerFunction(graphql, name)
             }
         }
     }
@@ -1235,7 +1357,7 @@ fun EndpointWirespec.convertEndpointClient(): File {
     }
 }
 
-fun List<EndpointWirespec>.convertClient(): File {
+fun List<EndpointWirespec>.convertClient(graphqls: List<GraphqlWirespec> = emptyList()): File {
     val endpoints = this
     return file(Name.of("Client")) {
         struct(Name.of("Client")) {
@@ -1271,9 +1393,226 @@ fun List<EndpointWirespec>.convertClient(): File {
                     )
                 }
             }
+
+            graphqls.forEach { graphql ->
+                implements(Type.Custom("${graphql.identifier.toName().value()}.Call"))
+            }
+
+            graphqls.forEach { graphql ->
+                val graphqlName = graphql.identifier.toName()
+                val graphqlNameStr = graphqlName.value()
+
+                asyncFunction(graphqlName, isOverride = true) {
+                    arg("input", Type.Custom("$graphqlNameStr.Input"))
+                    returnType(Type.Custom("$graphqlNameStr.Result"))
+
+                    returns(
+                        FunctionCall(
+                            name = Name(listOf(graphqlName.camelCase())),
+                            receiver = ConstructorStatement(
+                                type = Type.Custom("${graphqlNameStr}Client"),
+                                namedArguments = mapOf(
+                                    Name.of("serialization") to FieldCall(field = Name.of("serialization")),
+                                    Name.of("transportation") to FieldCall(field = Name.of("transportation")),
+                                ),
+                            ),
+                            arguments = mapOf(Name.of("input") to VariableReference(Name.of("input"))),
+                        ),
+                    )
+                }
+            }
         }
     }
 }
+
+private data class GraphqlDocument(val text: String, val liftedInputs: List<FieldWirespec>)
+
+private fun GraphqlWirespec.buildDocument(module: Module?): GraphqlDocument {
+    val lifted = mutableListOf<FieldWirespec>()
+    val selection = output.selection(module, emptySet(), emptyList(), lifted)
+    val allInputs = inputs + lifted
+    val variableDefinitions = allInputs
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(", ", "(", ")") { "$${it.identifier.value}: ${it.reference.toGraphqlType()}" }
+        .orEmpty()
+    val operationArguments = inputs
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(", ", "(", ")") { "${it.identifier.value}: $${it.identifier.value}" }
+        .orEmpty()
+    val text = "${kind.name.lowercase()} ${identifier.toName().value()}$variableDefinitions" +
+        " { ${operation.value}$operationArguments${selection?.let { " $it" }.orEmpty()} }"
+    return GraphqlDocument(text, lifted)
+}
+
+private fun ReferenceWirespec.selection(
+    module: Module?,
+    visited: Set<String>,
+    path: List<String>,
+    lifted: MutableList<FieldWirespec>,
+): String? = when (val root = flattenListDict()) {
+    is ReferenceWirespec.Custom -> when (val definition = module?.statements?.find { it.identifier.value == root.value }) {
+        is TypeWirespec ->
+            if (root.value in visited) {
+                "{ __typename }"
+            } else {
+                definition.shape.value
+                    .joinToString(" ") { it.selection(module, visited + root.value, path, lifted) }
+                    .let { "{ $it }" }
+            }
+
+        is UnionWirespec ->
+            definition.entries
+                .joinToString(" ") { entry ->
+                    "... on ${entry.value}${entry.selection(module, visited + root.value, path, lifted)?.let { " $it" }.orEmpty()}"
+                }
+                .let { "{ __typename $it }" }
+
+        else -> null
+    }
+
+    else -> null
+}
+
+private fun FieldWirespec.selection(
+    module: Module?,
+    visited: Set<String>,
+    path: List<String>,
+    lifted: MutableList<FieldWirespec>,
+): String {
+    val fieldPath = path + identifier.value
+    val arguments = parameters
+        .filter { !it.reference.isNullable }
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(", ", "(", ")") { parameter ->
+            val variableName = (fieldPath + parameter.identifier.value).toDromedaryPath()
+            lifted += FieldWirespec(
+                annotations = emptyList(),
+                identifier = FieldIdentifier(variableName),
+                reference = parameter.reference,
+            )
+            "${parameter.identifier.value}: $$variableName"
+        }
+        .orEmpty()
+    return "${identifier.value}$arguments${reference.selection(module, visited, fieldPath, lifted)?.let { " $it" }.orEmpty()}"
+}
+
+private fun List<String>.toDromedaryPath(): String = mapIndexed { index, part ->
+    if (index == 0) part else part.replaceFirstChar(Char::uppercaseChar)
+}.joinToString("")
+
+private fun ReferenceWirespec.toGraphqlType(): String = when (this) {
+    is ReferenceWirespec.Custom -> value
+    is ReferenceWirespec.Iterable -> "[${reference.toGraphqlType()}]"
+    is ReferenceWirespec.Primitive -> when (type) {
+        is ReferenceWirespec.Primitive.Type.String -> "String"
+        is ReferenceWirespec.Primitive.Type.Integer -> "Int"
+        is ReferenceWirespec.Primitive.Type.Number -> "Float"
+        is ReferenceWirespec.Primitive.Type.Boolean -> "Boolean"
+        is ReferenceWirespec.Primitive.Type.Bytes -> "String"
+    }
+
+    is ReferenceWirespec.Any, is ReferenceWirespec.Unit, is ReferenceWirespec.Dict ->
+        error("Reference '$this' cannot be used as a GraphQL variable type")
+}.let { if (isNullable) it else "$it!" }
+
+private fun InterfaceBuilder.graphqlHandlerFunction(graphql: GraphqlWirespec, name: Name) = when (graphql.kind) {
+    GraphqlWirespec.Kind.Subscription -> function(name) {
+        arg("input", Type.Custom("Input"))
+        arg(Name("on", "Next"), Type.Function(listOf(Type.Custom("Result")), Type.Unit))
+        returnType(Type.Custom("Wirespec.Cancellable"))
+    }
+
+    GraphqlWirespec.Kind.Query, GraphqlWirespec.Kind.Mutation -> asyncFunction(name) {
+        arg("input", Type.Custom("Input"))
+        returnType(Type.Custom("Result"))
+    }
+}
+
+fun GraphqlWirespec.convertGraphqlClient(): File {
+    val graphql = this
+    val name = identifier.toName()
+    val nameStr = name.value()
+
+    return file(Name.of("${nameStr}Client")) {
+        struct(Name.of("${nameStr}Client")) {
+            field("serialization", Type.Custom("Wirespec.Serialization"))
+            when (graphql.kind) {
+                GraphqlWirespec.Kind.Subscription -> field("transportation", Type.Custom("Wirespec.StreamTransportation"))
+                else -> field("transportation", Type.Custom("Wirespec.Transportation"))
+            }
+            implements(Type.Custom("$nameStr.Call"))
+
+            when (graphql.kind) {
+                GraphqlWirespec.Kind.Subscription -> function(name, isOverride = true) {
+                    arg("input", Type.Custom("$nameStr.Input"))
+                    arg(Name("on", "Next"), Type.Function(listOf(Type.Custom("$nameStr.Result")), Type.Unit))
+                    returnType(Type.Custom("Wirespec.Cancellable"))
+                    assignRawRequest(nameStr)
+                    returns(
+                        FunctionCall(
+                            receiver = FieldCall(field = Name.of("transportation")),
+                            name = Name.of("stream"),
+                            arguments = mapOf(
+                                Name.of("request") to VariableReference(Name.of("rawRequest")),
+                                Name("on", "Next") to Lambda(
+                                    parameters = listOf(Parameter(Name.of("raw"), Type.Custom("Wirespec.RawResponse"))),
+                                    body = FunctionCall(
+                                        name = Name(listOf("onNext")),
+                                        arguments = mapOf(
+                                            Name.of("value") to FunctionCall(
+                                                name = Name(listOf("$nameStr.fromRawResponse")),
+                                                arguments = mapOf(
+                                                    Name.of("serialization") to FieldCall(field = Name.of("serialization")),
+                                                    Name.of("response") to VariableReference(Name.of("raw")),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    )
+                }
+
+                GraphqlWirespec.Kind.Query, GraphqlWirespec.Kind.Mutation -> asyncFunction(name, isOverride = true) {
+                    arg("input", Type.Custom("$nameStr.Input"))
+                    returnType(Type.Custom("$nameStr.Result"))
+                    assignRawRequest(nameStr)
+                    assign(
+                        "rawResponse",
+                        FunctionCall(
+                            receiver = FieldCall(field = Name.of("transportation")),
+                            name = Name.of("transport"),
+                            arguments = mapOf(
+                                Name.of("request") to VariableReference(Name.of("rawRequest")),
+                            ),
+                        ),
+                    )
+                    returns(
+                        FunctionCall(
+                            name = Name(listOf("$nameStr.fromRawResponse")),
+                            arguments = mapOf(
+                                Name.of("serialization") to FieldCall(field = Name.of("serialization")),
+                                Name.of("response") to VariableReference(Name.of("rawResponse")),
+                            ),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun FunctionBuilder.assignRawRequest(nameStr: String) = assign(
+    "rawRequest",
+    FunctionCall(
+        name = Name(listOf("$nameStr.toRawRequest")),
+        arguments = mapOf(
+            Name.of("serialization") to FieldCall(field = Name.of("serialization")),
+            Name.of("input") to VariableReference(Name.of("input")),
+        ),
+    ),
+)
 
 fun EndpointWirespec.requestParameters(): List<Pair<Name, Type>> = buildList {
     path.filterIsInstance<EndpointWirespec.Segment.Param>()

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/converter/IrConverter.kt
@@ -647,7 +647,7 @@ fun GraphqlWirespec.convert(module: Module? = null): File {
                 allInputs.forEach { field(it.identifier.toName(), it.reference.convert()) }
             }
             struct("Data") {
-                field(graphql.operation.toName(), outputType)
+                field(graphql.operation, outputType)
             }
             struct("Result") {
                 field("data", type("Data").nullable())
@@ -1440,7 +1440,7 @@ private fun GraphqlWirespec.buildDocument(module: Module?): GraphqlDocument {
         ?.joinToString(", ", "(", ")") { "${it.identifier.value}: $${it.identifier.value}" }
         .orEmpty()
     val text = "${kind.name.lowercase()} ${identifier.toName().value()}$variableDefinitions" +
-        " { ${operation.value}$operationArguments${selection?.let { " $it" }.orEmpty()} }"
+        " { $operation$operationArguments${selection?.let { " $it" }.orEmpty()} }"
     return GraphqlDocument(text, lifted)
 }
 

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/emit/IrEmitter.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/emit/IrEmitter.kt
@@ -9,14 +9,17 @@ import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Model
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Refined
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
 import community.flock.wirespec.compiler.utils.Logger
+import community.flock.wirespec.ir.converter.convert
 import community.flock.wirespec.ir.converter.convertClient
 import community.flock.wirespec.ir.converter.convertEndpointClient
+import community.flock.wirespec.ir.converter.convertGraphqlClient
 import community.flock.wirespec.ir.core.File
 import community.flock.wirespec.ir.core.IR
 import community.flock.wirespec.ir.extension.IrExtension
@@ -36,7 +39,12 @@ interface IrEmitter : Emitter {
         }
         val sharedFile = emitShared()
         val allEndpoints = ast.modules.toList().flatMap { it.statements.filterIsInstance<Endpoint>() }
-        val mainClientFile = allEndpoints.takeIf { it.isNotEmpty() }?.let { emitClient(it, logger) }
+        val allGraphqls = ast.modules.toList()
+            .flatMap { it.statements.filterIsInstance<Graphql>() }
+            .filter { it.kind != Graphql.Kind.Subscription }
+        val mainClientFile = (allEndpoints + allGraphqls)
+            .takeIf { it.isNotEmpty() }
+            ?.let { emitClient(allEndpoints, allGraphqls, logger) }
 
         val allFiles: IR = moduleFiles + listOfNotNull(sharedFile) + listOfNotNull(mainClientFile)
         val transformedFiles = extensions
@@ -56,6 +64,9 @@ interface IrEmitter : Emitter {
         val clientFiles = module.statements.toList().filterIsInstance<Endpoint>().map { endpoint ->
             logger.info("Emitting Client for endpoint ${endpoint.identifier.value}")
             emitEndpointClient(endpoint)
+        } + module.statements.toList().filterIsInstance<Graphql>().map { graphql ->
+            logger.info("Emitting Client for graphql ${graphql.identifier.value}")
+            emitGraphqlClient(graphql)
         }
         val generatorFiles = module.statements.toList()
             .filterIsInstance<Model>()
@@ -77,6 +88,7 @@ interface IrEmitter : Emitter {
             is Refined -> emit(definition)
             is Union -> emit(definition)
             is Channel -> emit(definition)
+            is Graphql -> emit(definition, module)
         }
     }
 
@@ -84,9 +96,11 @@ interface IrEmitter : Emitter {
 
     fun emitEndpointClient(endpoint: Endpoint): File = endpoint.convertEndpointClient()
 
-    fun emitClient(endpoints: List<Endpoint>, logger: Logger): File {
-        logger.info("Emitting main Client for ${endpoints.size} endpoints")
-        return endpoints.convertClient()
+    fun emitGraphqlClient(graphql: Graphql): File = graphql.convertGraphqlClient()
+
+    fun emitClient(endpoints: List<Endpoint>, graphqls: List<Graphql>, logger: Logger): File {
+        logger.info("Emitting main Client for ${endpoints.size} endpoints and ${graphqls.size} graphql operations")
+        return endpoints.convertClient(graphqls)
     }
 
     fun emitShared(): File?
@@ -97,6 +111,7 @@ interface IrEmitter : Emitter {
     fun emit(endpoint: Endpoint): File
     fun emit(union: Union): File
     fun emit(channel: Channel): File
+    fun emit(graphql: Graphql, module: Module): File = graphql.convert(module)
 
     fun transformTestFile(file: File): File = file
 }

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/generator/PythonGenerator.kt
@@ -350,7 +350,7 @@ object PythonGenerator :
             if (recv != null) {
                 "$awaitPrefix${recv.emit()}.${name.value()}(${arguments.values.joinToString(", ") { it.emit() }})\n".indentCode(indent)
             } else {
-                "$awaitPrefix${name.value()}(${arguments.map { "${it.key.value()}=${it.value.emit()}" }.joinToString(", ")})\n".indentCode(indent)
+                "$awaitPrefix${name.value()}(${arguments.values.joinToString(", ") { it.emit() }})\n".indentCode(indent)
             }
         }
         is ArrayIndexCall -> if (caseSensitive) {
@@ -413,7 +413,7 @@ object PythonGenerator :
             if (recv != null) {
                 "$awaitPrefix${recv.emit()}.${name.value()}(${arguments.values.joinToString(", ") { it.emit() }})"
             } else {
-                "$awaitPrefix${name.value()}(${arguments.map { "${it.key.value()}=${it.value.emit()}" }.joinToString(", ")})"
+                "$awaitPrefix${name.value()}(${arguments.values.joinToString(", ") { it.emit() }})"
             }
         }
         is ArrayIndexCall -> if (caseSensitive) {

--- a/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/transformer/SharedTransforms.kt
+++ b/src/compiler/ir/src/commonMain/kotlin/community/flock/wirespec/ir/transformer/SharedTransforms.kt
@@ -4,6 +4,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Refined
 import community.flock.wirespec.compiler.core.parse.ast.Type
 import community.flock.wirespec.compiler.core.parse.ast.Union
@@ -96,4 +97,5 @@ fun Definition.sortKey(): Int = when (this) {
     is Union -> 4
     is Endpoint -> 5
     is Channel -> 6
+    is Graphql -> 7
 }

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/GraphqlIrConverterTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/GraphqlIrConverterTest.kt
@@ -51,11 +51,11 @@ class GraphqlIrConverterTest {
                 id: String,
                 name: String?
             }
-            graphql GetPet Query pet(id: String) -> Pet?
+            graphql GetPet Query {id: String} -> Pet?
             """.trimIndent(),
         )
 
-        assertEquals("query GetPet(\$id: String!) { pet(id: \$id) { id name } }", module.document("GetPet"))
+        assertEquals("query GetPet(\$id: String!) { getPet(id: \$id) { id name } }", module.document("GetPet"))
     }
 
     @Test
@@ -66,11 +66,11 @@ class GraphqlIrConverterTest {
                 id: String,
                 friend: Pet?
             }
-            graphql GetPet Query pet -> Pet
+            graphql GetPet Query {} -> Pet
             """.trimIndent(),
         )
 
-        assertEquals("query GetPet { pet { id friend { __typename } } }", module.document("GetPet"))
+        assertEquals("query GetPet { getPet { id friend { __typename } } }", module.document("GetPet"))
     }
 
     @Test
@@ -84,7 +84,7 @@ class GraphqlIrConverterTest {
                 name: String
             }
             type Result = Pet | Owner
-            graphql Search Query search(text: String) -> Result[]
+            graphql Search Query {text: String} -> Result[]
             """.trimIndent(),
         )
 
@@ -104,12 +104,12 @@ class GraphqlIrConverterTest {
             type User {
                 posts(first: Integer32, after: String?): Post[]
             }
-            graphql GetUser Query user(id: String) -> User?
+            graphql GetUser Query {id: String} -> User?
             """.trimIndent(),
         )
 
         assertEquals(
-            "query GetUser(\$id: String!, \$postsFirst: Int!) { user(id: \$id) { posts(first: \$postsFirst) { id } } }",
+            "query GetUser(\$id: String!, \$postsFirst: Int!) { getUser(id: \$id) { posts(first: \$postsFirst) { id } } }",
             module.document("GetUser"),
         )
         assertEquals(listOf("id", "postsFirst"), module.inputFields("GetUser"))
@@ -124,10 +124,10 @@ class GraphqlIrConverterTest {
                 id: String,
                 status: Status
             }
-            graphql GetTicket Query ticket -> Ticket
+            graphql GetTicket Query {} -> Ticket
             """.trimIndent(),
         )
 
-        assertEquals("query GetTicket { ticket { id status } }", module.document("GetTicket"))
+        assertEquals("query GetTicket { getTicket { id status } }", module.document("GetTicket"))
     }
 }

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/GraphqlIrConverterTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/converter/GraphqlIrConverterTest.kt
@@ -1,0 +1,133 @@
+package community.flock.wirespec.ir.converter
+
+import arrow.core.getOrElse
+import arrow.core.nonEmptyListOf
+import community.flock.wirespec.compiler.core.FileUri
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.core.ParseContext
+import community.flock.wirespec.compiler.core.WirespecSpec
+import community.flock.wirespec.compiler.core.parse
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
+import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.utils.NoLogger
+import community.flock.wirespec.ir.core.Field
+import community.flock.wirespec.ir.core.Function
+import community.flock.wirespec.ir.core.Literal
+import community.flock.wirespec.ir.core.Name
+import community.flock.wirespec.ir.core.Namespace
+import community.flock.wirespec.ir.core.ReturnStatement
+import community.flock.wirespec.ir.core.Struct
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class GraphqlIrConverterTest {
+
+    private fun parseModule(source: String): Module = object : ParseContext, NoLogger {
+        override val spec = WirespecSpec
+    }.parse(nonEmptyListOf(ModuleContent(FileUri("test.ws"), source)))
+        .map { it.modules.first() }
+        .getOrElse { fail("Parse failed: $it") }
+
+    private fun Module.document(name: String): String {
+        val graphql = statements.filterIsInstance<Graphql>().first { it.identifier.value == name }
+        val namespace = graphql.convert(this).elements.filterIsInstance<Namespace>().first()
+        val function = namespace.elements.filterIsInstance<Function>().first { it.name == Name.of("document") }
+        return function.body.filterIsInstance<ReturnStatement>().first().expression.let { (it as Literal).value as String }
+    }
+
+    private fun Module.inputFields(name: String): List<String> {
+        val graphql = statements.filterIsInstance<Graphql>().first { it.identifier.value == name }
+        val namespace = graphql.convert(this).elements.filterIsInstance<Namespace>().first()
+        return namespace.elements.filterIsInstance<Struct>().first { it.name == Name.of("Input") }
+            .fields.filterIsInstance<Field>().map { it.name.camelCase() }
+    }
+
+    @Test
+    fun documentWithVariablesAndSelection() {
+        val module = parseModule(
+            """
+            type Pet {
+                id: String,
+                name: String?
+            }
+            graphql GetPet Query pet(id: String) -> Pet?
+            """.trimIndent(),
+        )
+
+        assertEquals("query GetPet(\$id: String!) { pet(id: \$id) { id name } }", module.document("GetPet"))
+    }
+
+    @Test
+    fun selectionCutsCyclesWithTypename() {
+        val module = parseModule(
+            """
+            type Pet {
+                id: String,
+                friend: Pet?
+            }
+            graphql GetPet Query pet -> Pet
+            """.trimIndent(),
+        )
+
+        assertEquals("query GetPet { pet { id friend { __typename } } }", module.document("GetPet"))
+    }
+
+    @Test
+    fun selectionExpandsUnionsWithInlineFragments() {
+        val module = parseModule(
+            """
+            type Pet {
+                id: String
+            }
+            type Owner {
+                name: String
+            }
+            type Result = Pet | Owner
+            graphql Search Query search(text: String) -> Result[]
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            "query Search(\$text: String!) { search(text: \$text) { __typename ... on Pet { id } ... on Owner { name } } }",
+            module.document("Search"),
+        )
+    }
+
+    @Test
+    fun nestedNonNullableParametersAreLiftedIntoInput() {
+        val module = parseModule(
+            """
+            type Post {
+                id: String
+            }
+            type User {
+                posts(first: Integer32, after: String?): Post[]
+            }
+            graphql GetUser Query user(id: String) -> User?
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            "query GetUser(\$id: String!, \$postsFirst: Int!) { user(id: \$id) { posts(first: \$postsFirst) { id } } }",
+            module.document("GetUser"),
+        )
+        assertEquals(listOf("id", "postsFirst"), module.inputFields("GetUser"))
+    }
+
+    @Test
+    fun enumAndScalarLeavesGetNoSelection() {
+        val module = parseModule(
+            """
+            enum Status { OPEN, CLOSED }
+            type Ticket {
+                id: String,
+                status: Status
+            }
+            graphql GetTicket Query ticket -> Ticket
+            """.trimIndent(),
+        )
+
+        assertEquals("query GetTicket { ticket { id status } }", module.document("GetTicket"))
+    }
+}

--- a/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/generator/DslTest.kt
+++ b/src/compiler/ir/src/commonTest/kotlin/community/flock/wirespec/ir/generator/DslTest.kt
@@ -275,7 +275,7 @@ class DslTest {
         assertTrue(javaCode.contains("return new User(1);"))
 
         // Python
-        assertTrue(pythonCode.contains("return myFunc(a=1)"))
+        assertTrue(pythonCode.contains("return myFunc(1)"))
         assertTrue(pythonCode.contains("return User(id=1)"))
 
         // TypeScript
@@ -460,7 +460,7 @@ class DslTest {
 
         // Python
         assertTrue(pythonCode.contains("x = 1"))
-        assertTrue(pythonCode.contains("y = myFunc(a=1)"))
+        assertTrue(pythonCode.contains("y = myFunc(1)"))
 
         // TypeScript
         assertTrue(tsCode.contains("const x = 1;"))

--- a/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
+++ b/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
@@ -13,6 +13,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Field
 import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Module
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Reference.Primitive.Type.Constraint
@@ -38,6 +39,7 @@ fun WsDefinition.consume(): Definition = when (this) {
     is WsType -> consume()
     is WsUnion -> consume()
     is WsChannel -> consume()
+    is WsGraphql -> consume()
 }
 
 fun WsEndpoint.consume(): Endpoint = Endpoint(
@@ -110,10 +112,27 @@ private fun WsChannel.consume() = Channel(
     reference = reference.consume(),
 )
 
-private fun WsField.consume() = Field(
+private fun WsGraphql.consume() = Graphql(
+    comment = comment?.let { Comment(it) },
+    annotations = emptyList(),
+    identifier = DefinitionIdentifier(identifier),
+    kind = kind.consume(),
+    operation = FieldIdentifier(operation),
+    inputs = inputs.map { it.consume() },
+    output = output.consume(),
+)
+
+private fun WsGraphqlKind.consume() = when (this) {
+    WsGraphqlKind.Query -> Graphql.Kind.Query
+    WsGraphqlKind.Mutation -> Graphql.Kind.Mutation
+    WsGraphqlKind.Subscription -> Graphql.Kind.Subscription
+}
+
+private fun WsField.consume(): Field = Field(
     identifier = identifier.consume(),
     annotations = emptyList(),
     reference = reference.consume(),
+    parameters = parameters.map { it.consume() },
 )
 
 private fun WsRequest.consume() = Endpoint.Request(
@@ -223,6 +242,21 @@ fun Definition.produce(): WsDefinition = when (this) {
         comment = comment?.value,
         reference = reference.produce(),
     )
+
+    is Graphql -> WsGraphql(
+        identifier = identifier.value,
+        comment = comment?.value,
+        kind = kind.produce(),
+        operation = operation.value,
+        inputs = inputs.produce(),
+        output = output.produce(),
+    )
+}
+
+private fun Graphql.Kind.produce() = when (this) {
+    Graphql.Kind.Query -> WsGraphqlKind.Query
+    Graphql.Kind.Mutation -> WsGraphqlKind.Mutation
+    Graphql.Kind.Subscription -> WsGraphqlKind.Subscription
 }
 
 private fun Type.Shape.produce() = WsShape(
@@ -236,9 +270,10 @@ private fun List<Endpoint.Segment>.produce(): Array<WsSegment> = map {
     }
 }.toTypedArray()
 
-private fun Field.produce() = WsField(
+private fun Field.produce(): WsField = WsField(
     identifier = identifier.produce(),
     reference = reference.produce(),
+    parameters = parameters.map { it.produce() }.toTypedArray(),
 )
 
 private fun List<Field>.produce() = map { it.produce() }.toTypedArray()
@@ -365,6 +400,19 @@ data class WsChannel(
 ) : WsDefinition
 
 @JsExport
+data class WsGraphql(
+    override val identifier: String,
+    override val comment: String?,
+    val kind: WsGraphqlKind,
+    val operation: String,
+    val inputs: Array<WsField>,
+    val output: WsReference,
+) : WsDefinition
+
+@JsExport
+enum class WsGraphqlKind { Query, Mutation, Subscription }
+
+@JsExport
 data class WsRefined(
     override val identifier: String,
     override val comment: String?,
@@ -390,7 +438,11 @@ data class WsParam(
 data class Shape(val value: Array<WsField>)
 
 @JsExport
-data class WsField(val identifier: WsFieldIdentifier, val reference: WsReference)
+data class WsField(
+    val identifier: WsFieldIdentifier,
+    val reference: WsReference,
+    val parameters: Array<WsField> = emptyArray(),
+)
 
 @JsExport
 sealed interface WsIdentifier

--- a/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
+++ b/src/compiler/lib/src/jsMain/kotlin/community/flock/wirespec/compiler/lib/Ast.kt
@@ -117,7 +117,6 @@ private fun WsGraphql.consume() = Graphql(
     annotations = emptyList(),
     identifier = DefinitionIdentifier(identifier),
     kind = kind.consume(),
-    operation = FieldIdentifier(operation),
     inputs = inputs.map { it.consume() },
     output = output.consume(),
 )
@@ -247,7 +246,6 @@ fun Definition.produce(): WsDefinition = when (this) {
         identifier = identifier.value,
         comment = comment?.value,
         kind = kind.produce(),
-        operation = operation.value,
         inputs = inputs.produce(),
         output = output.produce(),
     )
@@ -404,7 +402,6 @@ data class WsGraphql(
     override val identifier: String,
     override val comment: String?,
     val kind: WsGraphqlKind,
-    val operation: String,
     val inputs: Array<WsField>,
     val output: WsReference,
 ) : WsDefinition

--- a/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileGraphqlTest.kt
+++ b/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileGraphqlTest.kt
@@ -15,11 +15,11 @@ object CompileGraphqlTest : Fixture {
         |  name: String
         |}
         |
-        |graphql GetPet Query pet(id: String) -> Pet?
+        |graphql GetPet Query {id: String} -> Pet?
         |
-        |graphql AddPet Mutation addPet(input: PetInput) -> Pet
+        |graphql AddPet Mutation {input: PetInput} -> Pet
         |
-        |graphql OnPetAdded Subscription petAdded -> Pet
+        |graphql OnPetAdded Subscription {} -> Pet
         """.trimMargin()
 
     override val compiler = source.let(::compile)

--- a/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileGraphqlTest.kt
+++ b/src/compiler/test/src/commonMain/kotlin/community/flock/wirespec/compiler/test/CompileGraphqlTest.kt
@@ -1,0 +1,26 @@
+package community.flock.wirespec.compiler.test
+
+object CompileGraphqlTest : Fixture {
+
+    override val source =
+        // language=ws
+        """
+        |type Pet {
+        |  id: String,
+        |  name: String?,
+        |  tags: String[]
+        |}
+        |
+        |type PetInput {
+        |  name: String
+        |}
+        |
+        |graphql GetPet Query pet(id: String) -> Pet?
+        |
+        |graphql AddPet Mutation addPet(input: PetInput) -> Pet
+        |
+        |graphql OnPetAdded Subscription petAdded -> Pet
+        """.trimMargin()
+
+    override val compiler = source.let(::compile)
+}

--- a/src/compiler/test/src/jvmMain/kotlin/community/flock/wirespec/compiler/test/EmitterFixtureUpdater.kt
+++ b/src/compiler/test/src/jvmMain/kotlin/community/flock/wirespec/compiler/test/EmitterFixtureUpdater.kt
@@ -73,6 +73,7 @@ private fun IrEmitter.sharedOutputAsString(): String = emitShared()
 private fun compileFixtures(emitterFactory: () -> Emitter): Map<String, () -> String> = linkedMapOf(
     "compileFullEndpointTest" to { compile(CompileFullEndpointTest, emitterFactory) },
     "compileChannelTest" to { compile(CompileChannelTest, emitterFactory) },
+    "compileGraphqlTest" to { compile(CompileGraphqlTest, emitterFactory) },
     "compileEnumTest" to { compile(CompileEnumTest, emitterFactory) },
     "compileMinimalEndpointTest" to { compile(CompileMinimalEndpointTest, emitterFactory) },
     "compileRefinedTest" to { compile(CompileRefinedTest, emitterFactory) },

--- a/src/converter/graphql/build.gradle.kts
+++ b/src/converter/graphql/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    id("module.publication")
+    id("module.spotless")
+    alias(libs.plugins.kotlin.multiplatform)
+}
+
+group = "${libs.versions.group.id.get()}.converter"
+version = System.getenv(libs.versions.from.env.get()) ?: libs.versions.default.get()
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+val enableNative = (findProperty("wirespec.enableNative") as String?).toBoolean()
+
+kotlin {
+    if (enableNative) {
+        macosX64()
+        macosArm64()
+        linuxX64()
+        mingwX64()
+    }
+    js(IR) {
+        nodejs()
+    }
+    jvm {
+        java {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
+            }
+        }
+    }
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":src:converter:common"))
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation(project(":src:compiler:test"))
+                implementation(libs.kotlin.test)
+                implementation(libs.bundles.kotest)
+            }
+        }
+    }
+}

--- a/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLConverter.kt
+++ b/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLConverter.kt
@@ -1,0 +1,164 @@
+package community.flock.wirespec.converter.graphql
+
+import community.flock.wirespec.compiler.core.parse.ast.Annotation
+import community.flock.wirespec.compiler.core.parse.ast.Comment
+import community.flock.wirespec.compiler.core.parse.ast.Definition
+import community.flock.wirespec.compiler.core.parse.ast.DefinitionIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.FieldIdentifier
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Type
+import community.flock.wirespec.compiler.core.parse.ast.Union
+import community.flock.wirespec.converter.graphql.GraphQLModel.Directive
+import community.flock.wirespec.converter.graphql.GraphQLModel.Document
+import community.flock.wirespec.converter.graphql.GraphQLModel.EnumTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.FieldDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.InputObjectTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.InputValueDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.InterfaceTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.ObjectTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.ScalarTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.SchemaDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.TypeRef
+import community.flock.wirespec.converter.graphql.GraphQLModel.UnionTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.Value
+
+object GraphQLConverter {
+
+    /** Marker annotations used to keep the SDL round trip lossless. */
+    const val INPUT_MARKER = "input"
+    const val INTERFACE_MARKER = "interface"
+    const val ID_MARKER = "id"
+
+    fun convert(document: Document, strict: Boolean): List<Definition> {
+        val schema = document.definitions.filterIsInstance<SchemaDefinition>().firstOrNull()
+        val rootTypes = mapOf(
+            (schema?.query ?: "Query") to Graphql.Kind.Query,
+            (schema?.mutation ?: "Mutation") to Graphql.Kind.Mutation,
+            (schema?.subscription ?: "Subscription") to Graphql.Kind.Subscription,
+        )
+
+        return document.definitions.flatMap { definition ->
+            when (definition) {
+                is SchemaDefinition -> emptyList()
+                is ObjectTypeDefinition ->
+                    rootTypes[definition.name]
+                        ?.let { kind -> definition.fields.map { it.toGraphql(kind) } }
+                        ?: listOf(definition.toType())
+
+                is InterfaceTypeDefinition -> listOf(definition.toType())
+                is InputObjectTypeDefinition -> listOf(definition.toType())
+                is EnumTypeDefinition -> listOf(definition.toEnum())
+                is UnionTypeDefinition -> listOf(definition.toUnion())
+                is ScalarTypeDefinition -> listOf(definition.toRefined())
+            }
+        }
+    }
+
+    private fun FieldDefinition.toGraphql(kind: Graphql.Kind) = Graphql(
+        comment = description?.let { Comment(it) },
+        annotations = directives.toAnnotations(),
+        identifier = DefinitionIdentifier(name.replaceFirstChar(Char::uppercaseChar) + kind.name),
+        kind = kind,
+        operation = FieldIdentifier(name),
+        inputs = arguments.map { it.toField() },
+        output = type.toReference(),
+    )
+
+    private fun ObjectTypeDefinition.toType() = Type(
+        comment = description?.let { Comment(it) },
+        annotations = directives.toAnnotations(),
+        identifier = DefinitionIdentifier(name),
+        shape = Type.Shape(fields.map { it.toField() }),
+        extends = interfaces.map { Reference.Custom(it, isNullable = false) },
+    )
+
+    private fun InterfaceTypeDefinition.toType() = Type(
+        comment = description?.let { Comment(it) },
+        annotations = listOf(Annotation(INTERFACE_MARKER, emptyList())) + directives.toAnnotations(),
+        identifier = DefinitionIdentifier(name),
+        shape = Type.Shape(fields.map { it.toField() }),
+        extends = interfaces.map { Reference.Custom(it, isNullable = false) },
+    )
+
+    private fun InputObjectTypeDefinition.toType() = Type(
+        comment = description?.let { Comment(it) },
+        annotations = listOf(Annotation(INPUT_MARKER, emptyList())) + directives.toAnnotations(),
+        identifier = DefinitionIdentifier(name),
+        shape = Type.Shape(fields.map { it.toField() }),
+        extends = emptyList(),
+    )
+
+    private fun EnumTypeDefinition.toEnum() = Enum(
+        comment = description?.let { Comment(it) },
+        annotations = directives.toAnnotations(),
+        identifier = DefinitionIdentifier(name),
+        entries = values.toSet(),
+    )
+
+    private fun UnionTypeDefinition.toUnion() = Union(
+        comment = description?.let { Comment(it) },
+        annotations = directives.toAnnotations(),
+        identifier = DefinitionIdentifier(name),
+        entries = members.map { Reference.Custom(it, isNullable = false) }.toSet(),
+    )
+
+    private fun ScalarTypeDefinition.toRefined() = Refined(
+        comment = description?.let { Comment(it) },
+        annotations = directives.toAnnotations(),
+        identifier = DefinitionIdentifier(name),
+        reference = Reference.Primitive(type = Reference.Primitive.Type.String(null), isNullable = false),
+    )
+
+    private fun FieldDefinition.toField() = Field(
+        annotations = type.idAnnotations() + directives.toAnnotations(),
+        identifier = FieldIdentifier(name),
+        reference = type.toReference(),
+        parameters = arguments.map { it.toField() },
+    )
+
+    private fun InputValueDefinition.toField() = Field(
+        annotations = type.idAnnotations() + directives.toAnnotations(),
+        identifier = FieldIdentifier(name),
+        reference = type.toReference(),
+    )
+
+    private fun TypeRef.idAnnotations(): List<Annotation> = when (baseName()) {
+        "ID" -> listOf(Annotation(ID_MARKER, emptyList()))
+        else -> emptyList()
+    }
+
+    private fun TypeRef.baseName(): String? = when (this) {
+        is TypeRef.Named -> name
+        is TypeRef.ListOf -> inner.baseName()
+    }
+
+    // GraphQL is nullable-by-default; Wirespec is non-null by default. Pure inversion per wrapper.
+    private fun TypeRef.toReference(): Reference = when (this) {
+        is TypeRef.Named -> when (name) {
+            "Int" -> Reference.Primitive(Reference.Primitive.Type.Integer(Reference.Primitive.Type.Precision.P32, null), !nonNull)
+            "Float" -> Reference.Primitive(Reference.Primitive.Type.Number(Reference.Primitive.Type.Precision.P64, null), !nonNull)
+            "String", "ID" -> Reference.Primitive(Reference.Primitive.Type.String(null), !nonNull)
+            "Boolean" -> Reference.Primitive(Reference.Primitive.Type.Boolean, !nonNull)
+            else -> Reference.Custom(name, !nonNull)
+        }
+
+        is TypeRef.ListOf -> Reference.Iterable(inner.toReference(), !nonNull)
+    }
+
+    private fun List<Directive>.toAnnotations(): List<Annotation> = map { directive ->
+        Annotation(
+            name = directive.name,
+            parameters = directive.arguments.map { Annotation.Parameter(it.name, it.value.toAnnotationValue()) },
+        )
+    }
+
+    private fun Value.toAnnotationValue(): Annotation.Value = when (this) {
+        is Value.Single -> Annotation.Value.Single(value)
+        is Value.ListOf -> Annotation.Value.Array(values.map { Annotation.Value.Single(it.value) })
+        is Value.ObjectOf -> Annotation.Value.Dict(fields.map { Annotation.Parameter(it.name, it.value.toAnnotationValue()) })
+    }
+}

--- a/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLConverter.kt
+++ b/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLConverter.kt
@@ -58,12 +58,12 @@ object GraphQLConverter {
         }
     }
 
+    // PascalCase(field) + kind: the language derives the field name back by stripping the kind suffix.
     private fun FieldDefinition.toGraphql(kind: Graphql.Kind) = Graphql(
         comment = description?.let { Comment(it) },
         annotations = directives.toAnnotations(),
         identifier = DefinitionIdentifier(name.replaceFirstChar(Char::uppercaseChar) + kind.name),
         kind = kind,
-        operation = FieldIdentifier(name),
         inputs = arguments.map { it.toField() },
         output = type.toReference(),
     )

--- a/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLEmitter.kt
+++ b/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLEmitter.kt
@@ -1,0 +1,146 @@
+package community.flock.wirespec.converter.graphql
+
+import arrow.core.NonEmptyList
+import community.flock.wirespec.compiler.core.emit.Emitted
+import community.flock.wirespec.compiler.core.emit.Emitter
+import community.flock.wirespec.compiler.core.emit.FileExtension
+import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.compiler.core.parse.ast.Annotation
+import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
+import community.flock.wirespec.compiler.core.parse.ast.HasComment
+import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Type
+import community.flock.wirespec.compiler.core.parse.ast.Union
+import community.flock.wirespec.compiler.utils.Logger
+import community.flock.wirespec.converter.graphql.GraphQLConverter.ID_MARKER
+import community.flock.wirespec.converter.graphql.GraphQLConverter.INPUT_MARKER
+import community.flock.wirespec.converter.graphql.GraphQLConverter.INTERFACE_MARKER
+
+object GraphQLEmitter : Emitter {
+
+    override val extension = FileExtension.GraphQL
+
+    private const val INDENT = "  "
+    private const val JSON_SCALAR = "JSON"
+    private val markerAnnotations = setOf(INPUT_MARKER, INTERFACE_MARKER, ID_MARKER)
+
+    override fun emit(ast: AST, logger: Logger): NonEmptyList<Emitted> = ast.modules
+        .map {
+            logger.info("Emitting GraphQL SDL from ${it.fileUri.value}")
+            Emitted("schema.graphqls", emit(it))
+        }
+
+    fun emit(module: Module): String {
+        val jsonScalarNeeded = ScalarTracker()
+        val models = module.statements.toList().mapNotNull { definition ->
+            when (definition) {
+                is Type -> definition.render(jsonScalarNeeded)
+                is Enum -> definition.render()
+                is Union -> definition.render()
+                is Refined -> definition.render()
+                else -> null
+            }
+        }
+        val operations = module.statements.toList()
+            .filterIsInstance<Graphql>()
+            .groupBy { it.kind }
+            .toList()
+            .sortedBy { (kind, _) -> kind.ordinal }
+            .map { (kind, definitions) -> definitions.renderRootType(kind, jsonScalarNeeded) }
+
+        return (listOfNotNull("scalar $JSON_SCALAR".takeIf { jsonScalarNeeded.needed }) + models + operations)
+            .joinToString("\n\n")
+            .plus("\n")
+    }
+
+    private class ScalarTracker(var needed: Boolean = false)
+
+    private fun List<Graphql>.renderRootType(kind: Graphql.Kind, tracker: ScalarTracker): String = joinToString("\n") { graphql ->
+        val description = graphql.renderDescription()
+        val arguments = graphql.inputs.renderArguments(tracker)
+        val directives = graphql.annotations.renderDirectives()
+        "$description$INDENT${graphql.operation.value}$arguments: ${graphql.output.render(tracker, graphql.annotations)}$directives"
+    }.let { "type ${kind.name} {\n$it\n}" }
+
+    private fun Type.render(tracker: ScalarTracker): String {
+        val keyword = when {
+            annotations.any { it.name == INPUT_MARKER } -> "input"
+            annotations.any { it.name == INTERFACE_MARKER } -> "interface"
+            else -> "type"
+        }
+        val implements = extends
+            .takeIf { it.isNotEmpty() && keyword != "input" }
+            ?.joinToString(" & ", " implements ") { it.value }
+            .orEmpty()
+        val directives = annotations.renderDirectives()
+        val fields = shape.value.joinToString("\n") { it.render(tracker) }
+        return "${renderDescription()}$keyword ${identifier.value}$implements$directives {\n$fields\n}"
+    }
+
+    private fun Field.render(tracker: ScalarTracker): String {
+        val arguments = parameters.renderArguments(tracker)
+        val directives = annotations.renderDirectives()
+        return "$INDENT${identifier.value}$arguments: ${reference.render(tracker, annotations)}$directives"
+    }
+
+    private fun List<Field>.renderArguments(tracker: ScalarTracker): String = takeIf { it.isNotEmpty() }
+        ?.joinToString(", ", "(", ")") { "${it.identifier.value}: ${it.reference.render(tracker, it.annotations)}" }
+        .orEmpty()
+
+    private fun Enum.render(): String = "${renderDescription()}enum ${identifier.value}${annotations.renderDirectives()} {\n" +
+        entries.joinToString("\n") { "$INDENT$it" } +
+        "\n}"
+
+    private fun Union.render(): String = "${renderDescription()}union ${identifier.value}${annotations.renderDirectives()} = ${entries.joinToString(" | ") { it.value }}"
+
+    private fun Refined.render(): String = "${renderDescription()}scalar ${identifier.value}${annotations.renderDirectives()}"
+
+    private fun HasComment.renderDescription(): String = comment?.value
+        ?.let {
+            if ("\n" in it || "\"" in it) "\"\"\"\n$it\n\"\"\"\n" else "\"$it\"\n"
+        }
+        .orEmpty()
+
+    // Wirespec is non-null by default; GraphQL is nullable by default. Pure inversion per wrapper.
+    private fun Reference.render(tracker: ScalarTracker, annotations: List<Annotation> = emptyList()): String = when (this) {
+        is Reference.Custom -> value
+        is Reference.Iterable -> "[${reference.render(tracker)}]"
+        is Reference.Primitive -> when (type) {
+            is Reference.Primitive.Type.String ->
+                if (annotations.any { it.name == ID_MARKER }) "ID" else "String"
+
+            is Reference.Primitive.Type.Integer -> "Int"
+            is Reference.Primitive.Type.Number -> "Float"
+            is Reference.Primitive.Type.Boolean -> "Boolean"
+            is Reference.Primitive.Type.Bytes -> JSON_SCALAR.also { tracker.needed = true }
+        }
+
+        is Reference.Any, is Reference.Dict -> JSON_SCALAR.also { tracker.needed = true }
+        is Reference.Unit -> error("Unit cannot be represented in GraphQL")
+    }.let { if (isNullable) it else "$it!" }
+
+    private fun List<Annotation>.renderDirectives(): String = filterNot { it.name in markerAnnotations }
+        .joinToString("") { annotation ->
+            val arguments = annotation.parameters
+                .takeIf { it.isNotEmpty() }
+                ?.joinToString(", ", "(", ")") { "${it.name}: ${it.value.render()}" }
+                .orEmpty()
+            " @${annotation.name}$arguments"
+        }
+
+    private fun Annotation.Value.render(): String = when (this) {
+        is Annotation.Value.Single -> value.renderSingle()
+        is Annotation.Value.Array -> value.joinToString(", ", "[", "]") { it.value.renderSingle() }
+        is Annotation.Value.Dict -> value.joinToString(", ", "{", "}") { "${it.name}: ${it.value.render()}" }
+    }
+
+    private fun String.renderSingle(): String = when {
+        this in setOf("true", "false", "null") -> this
+        toLongOrNull() != null || toDoubleOrNull() != null -> this
+        else -> "\"${replace("\\", "\\\\").replace("\"", "\\\"")}\""
+    }
+}

--- a/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLEmitter.kt
+++ b/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLEmitter.kt
@@ -63,7 +63,7 @@ object GraphQLEmitter : Emitter {
         val description = graphql.renderDescription()
         val arguments = graphql.inputs.renderArguments(tracker)
         val directives = graphql.annotations.renderDirectives()
-        "$description$INDENT${graphql.operation.value}$arguments: ${graphql.output.render(tracker, graphql.annotations)}$directives"
+        "$description$INDENT${graphql.operation}$arguments: ${graphql.output.render(tracker, graphql.annotations)}$directives"
     }.let { "type ${kind.name} {\n$it\n}" }
 
     private fun Type.render(tracker: ScalarTracker): String {

--- a/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLModel.kt
+++ b/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLModel.kt
@@ -1,0 +1,95 @@
+package community.flock.wirespec.converter.graphql
+
+object GraphQLModel {
+
+    data class Document(val definitions: List<TypeSystemDefinition>)
+
+    sealed interface TypeSystemDefinition
+
+    data class SchemaDefinition(
+        val query: String?,
+        val mutation: String?,
+        val subscription: String?,
+    ) : TypeSystemDefinition
+
+    sealed interface TypeDefinition : TypeSystemDefinition {
+        val name: String
+        val description: String?
+        val directives: List<Directive>
+    }
+
+    data class ObjectTypeDefinition(
+        override val name: String,
+        override val description: String?,
+        override val directives: List<Directive>,
+        val interfaces: List<String>,
+        val fields: List<FieldDefinition>,
+    ) : TypeDefinition
+
+    data class InterfaceTypeDefinition(
+        override val name: String,
+        override val description: String?,
+        override val directives: List<Directive>,
+        val interfaces: List<String>,
+        val fields: List<FieldDefinition>,
+    ) : TypeDefinition
+
+    data class InputObjectTypeDefinition(
+        override val name: String,
+        override val description: String?,
+        override val directives: List<Directive>,
+        val fields: List<InputValueDefinition>,
+    ) : TypeDefinition
+
+    data class EnumTypeDefinition(
+        override val name: String,
+        override val description: String?,
+        override val directives: List<Directive>,
+        val values: List<String>,
+    ) : TypeDefinition
+
+    data class UnionTypeDefinition(
+        override val name: String,
+        override val description: String?,
+        override val directives: List<Directive>,
+        val members: List<String>,
+    ) : TypeDefinition
+
+    data class ScalarTypeDefinition(
+        override val name: String,
+        override val description: String?,
+        override val directives: List<Directive>,
+    ) : TypeDefinition
+
+    data class FieldDefinition(
+        val name: String,
+        val description: String?,
+        val arguments: List<InputValueDefinition>,
+        val type: TypeRef,
+        val directives: List<Directive>,
+    )
+
+    data class InputValueDefinition(
+        val name: String,
+        val description: String?,
+        val type: TypeRef,
+        val directives: List<Directive>,
+    )
+
+    sealed interface TypeRef {
+        val nonNull: Boolean
+
+        data class Named(val name: String, override val nonNull: Boolean) : TypeRef
+        data class ListOf(val inner: TypeRef, override val nonNull: Boolean) : TypeRef
+    }
+
+    data class Directive(val name: String, val arguments: List<Argument>)
+
+    data class Argument(val name: String, val value: Value)
+
+    sealed interface Value {
+        data class Single(val value: String) : Value
+        data class ListOf(val values: List<Single>) : Value
+        data class ObjectOf(val fields: List<Argument>) : Value
+    }
+}

--- a/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLParser.kt
+++ b/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLParser.kt
@@ -1,0 +1,376 @@
+package community.flock.wirespec.converter.graphql
+
+import arrow.core.nonEmptyListOf
+import arrow.core.toNonEmptyListOrNull
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.core.parse.ast.AST
+import community.flock.wirespec.compiler.core.parse.ast.Module
+import community.flock.wirespec.converter.common.Parser
+import community.flock.wirespec.converter.graphql.GraphQLModel.Argument
+import community.flock.wirespec.converter.graphql.GraphQLModel.Directive
+import community.flock.wirespec.converter.graphql.GraphQLModel.Document
+import community.flock.wirespec.converter.graphql.GraphQLModel.EnumTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.FieldDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.InputObjectTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.InputValueDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.InterfaceTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.ObjectTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.ScalarTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.SchemaDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.TypeRef
+import community.flock.wirespec.converter.graphql.GraphQLModel.TypeSystemDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.UnionTypeDefinition
+import community.flock.wirespec.converter.graphql.GraphQLModel.Value
+
+object GraphQLParser : Parser {
+
+    override fun parse(moduleContent: ModuleContent, strict: Boolean): AST {
+        val document = parseDocument(moduleContent.content, strict)
+        val definitions = GraphQLConverter.convert(document, strict)
+        return AST(
+            nonEmptyListOf(
+                Module(
+                    moduleContent.fileUri,
+                    definitions.toNonEmptyListOrNull()
+                        ?: error("Cannot yield empty AST from GraphQL schema ${moduleContent.fileUri.value}"),
+                ),
+            ),
+        )
+    }
+
+    fun parseDocument(source: String, strict: Boolean = false): Document {
+        val tokens = GraphQLTokenizer(source).tokenize()
+        return DocumentParser(tokens, strict).parseDocument()
+    }
+
+    private class DocumentParser(private val tokens: List<GraphQLToken>, private val strict: Boolean) {
+        private var pos = 0
+
+        fun parseDocument(): Document {
+            val definitions = mutableListOf<TypeSystemDefinition>()
+            while (pos < tokens.size) {
+                parseTypeSystemDefinition()?.let(definitions::add)
+            }
+            return Document(definitions)
+        }
+
+        private fun parseTypeSystemDefinition(): TypeSystemDefinition? {
+            val description = consumeDescription()
+            return when (val keyword = peekName()) {
+                "schema" -> parseSchema()
+                "type" -> parseObjectLike(description, isInterface = false)
+                "interface" -> parseObjectLike(description, isInterface = true)
+                "input" -> parseInput(description)
+                "enum" -> parseEnum(description)
+                "union" -> parseUnion(description)
+                "scalar" -> parseScalar(description)
+                "directive" -> {
+                    skipDirectiveDefinition()
+                    null
+                }
+
+                "extend" ->
+                    if (strict) {
+                        error("'extend' definitions are not supported")
+                    } else {
+                        skipExtension()
+                        null
+                    }
+
+                "query", "mutation", "subscription", "fragment" ->
+                    error("Expected a type system definition but found executable definition '$keyword'")
+
+                else -> error("Unexpected token: ${peekToken()}")
+            }
+        }
+
+        private fun parseSchema(): SchemaDefinition {
+            advance()
+            parseDirectives()
+            expectPunctuator("{")
+            var query: String? = null
+            var mutation: String? = null
+            var subscription: String? = null
+            while (!peekPunctuator("}")) {
+                val operation = expectName()
+                expectPunctuator(":")
+                val typeName = expectName()
+                when (operation) {
+                    "query" -> query = typeName
+                    "mutation" -> mutation = typeName
+                    "subscription" -> subscription = typeName
+                    else -> error("Unexpected operation type '$operation' in schema definition")
+                }
+            }
+            expectPunctuator("}")
+            return SchemaDefinition(query, mutation, subscription)
+        }
+
+        private fun parseObjectLike(description: String?, isInterface: Boolean): TypeSystemDefinition {
+            advance()
+            val name = expectName()
+            val interfaces = parseImplements()
+            val directives = parseDirectives()
+            val fields = parseFieldDefinitions()
+            return if (isInterface) {
+                InterfaceTypeDefinition(name, description, directives, interfaces, fields)
+            } else {
+                ObjectTypeDefinition(name, description, directives, interfaces, fields)
+            }
+        }
+
+        private fun parseInput(description: String?): InputObjectTypeDefinition {
+            advance()
+            val name = expectName()
+            val directives = parseDirectives()
+            expectPunctuator("{")
+            val fields = mutableListOf<InputValueDefinition>()
+            while (!peekPunctuator("}")) {
+                fields.add(parseInputValue())
+            }
+            expectPunctuator("}")
+            return InputObjectTypeDefinition(name, description, directives, fields)
+        }
+
+        private fun parseEnum(description: String?): EnumTypeDefinition {
+            advance()
+            val name = expectName()
+            val directives = parseDirectives()
+            expectPunctuator("{")
+            val values = mutableListOf<String>()
+            while (!peekPunctuator("}")) {
+                consumeDescription()
+                values.add(expectName())
+                parseDirectives()
+            }
+            expectPunctuator("}")
+            return EnumTypeDefinition(name, description, directives, values)
+        }
+
+        private fun parseUnion(description: String?): UnionTypeDefinition {
+            advance()
+            val name = expectName()
+            val directives = parseDirectives()
+            expectPunctuator("=")
+            val members = mutableListOf(expectName())
+            while (peekPunctuator("|")) {
+                advance()
+                members.add(expectName())
+            }
+            return UnionTypeDefinition(name, description, directives, members)
+        }
+
+        private fun parseScalar(description: String?): ScalarTypeDefinition {
+            advance()
+            val name = expectName()
+            val directives = parseDirectives()
+            return ScalarTypeDefinition(name, description, directives)
+        }
+
+        private fun parseImplements(): List<String> {
+            if (peekName() != "implements") return emptyList()
+            advance()
+            if (peekPunctuator("&")) advance()
+            val interfaces = mutableListOf(expectName())
+            while (peekPunctuator("&")) {
+                advance()
+                interfaces.add(expectName())
+            }
+            return interfaces
+        }
+
+        private fun parseFieldDefinitions(): List<FieldDefinition> {
+            expectPunctuator("{")
+            val fields = mutableListOf<FieldDefinition>()
+            while (!peekPunctuator("}")) {
+                val description = consumeDescription()
+                val name = expectName()
+                val arguments = parseArgumentDefinitions()
+                expectPunctuator(":")
+                val type = parseTypeRef()
+                val directives = parseDirectives()
+                fields.add(FieldDefinition(name, description, arguments, type, directives))
+            }
+            expectPunctuator("}")
+            return fields
+        }
+
+        private fun parseArgumentDefinitions(): List<InputValueDefinition> {
+            if (!peekPunctuator("(")) return emptyList()
+            advance()
+            val arguments = mutableListOf<InputValueDefinition>()
+            while (!peekPunctuator(")")) {
+                arguments.add(parseInputValue())
+            }
+            expectPunctuator(")")
+            return arguments
+        }
+
+        private fun parseInputValue(): InputValueDefinition {
+            val description = consumeDescription()
+            val name = expectName()
+            expectPunctuator(":")
+            val type = parseTypeRef()
+            if (peekPunctuator("=")) {
+                advance()
+                parseValue() // default values are parsed and discarded
+            }
+            val directives = parseDirectives()
+            return InputValueDefinition(name, description, type, directives)
+        }
+
+        private fun parseTypeRef(): TypeRef {
+            val inner = if (peekPunctuator("[")) {
+                advance()
+                val element = parseTypeRef()
+                expectPunctuator("]")
+                TypeRef.ListOf(element, nonNull = false)
+            } else {
+                TypeRef.Named(expectName(), nonNull = false)
+            }
+            return if (peekPunctuator("!")) {
+                advance()
+                when (inner) {
+                    is TypeRef.Named -> inner.copy(nonNull = true)
+                    is TypeRef.ListOf -> inner.copy(nonNull = true)
+                }
+            } else {
+                inner
+            }
+        }
+
+        private fun parseDirectives(): List<Directive> {
+            val directives = mutableListOf<Directive>()
+            while (peekPunctuator("@")) {
+                advance()
+                val name = expectName()
+                val arguments = if (peekPunctuator("(")) {
+                    advance()
+                    mutableListOf<Argument>().apply {
+                        while (!peekPunctuator(")")) {
+                            val argName = expectName()
+                            expectPunctuator(":")
+                            add(Argument(argName, parseValue()))
+                        }
+                    }.also { expectPunctuator(")") }
+                } else {
+                    emptyList()
+                }
+                directives.add(Directive(name, arguments))
+            }
+            return directives
+        }
+
+        private fun parseValue(): Value = when (val token = peekToken()) {
+            is GraphQLToken.StringValue -> Value.Single(token.value).also { advance() }
+            is GraphQLToken.IntValue -> Value.Single(token.value).also { advance() }
+            is GraphQLToken.FloatValue -> Value.Single(token.value).also { advance() }
+            is GraphQLToken.Name -> Value.Single(token.value).also { advance() }
+            is GraphQLToken.Punctuator -> when (token.value) {
+                "[" -> {
+                    advance()
+                    val values = mutableListOf<Value.Single>()
+                    while (!peekPunctuator("]")) {
+                        values.add(parseValue() as? Value.Single ?: error("Nested lists in directive arguments are not supported"))
+                    }
+                    expectPunctuator("]")
+                    Value.ListOf(values)
+                }
+
+                "{" -> {
+                    advance()
+                    val fields = mutableListOf<Argument>()
+                    while (!peekPunctuator("}")) {
+                        val name = expectName()
+                        expectPunctuator(":")
+                        fields.add(Argument(name, parseValue()))
+                    }
+                    expectPunctuator("}")
+                    Value.ObjectOf(fields)
+                }
+
+                "$" -> error("Variables are not allowed in a type system document")
+                else -> error("Unexpected token in value position: $token")
+            }
+
+            null -> error("Unexpected end of input in value position")
+        }
+
+        private fun skipDirectiveDefinition() {
+            advance()
+            expectPunctuator("@")
+            expectName()
+            if (peekPunctuator("(")) {
+                advance()
+                var depth = 1
+                while (depth > 0 && pos < tokens.size) {
+                    when {
+                        peekPunctuator("(") -> depth++
+                        peekPunctuator(")") -> depth--
+                    }
+                    advance()
+                }
+            }
+            if (peekName() == "repeatable") advance()
+            if (peekName() == "on") {
+                advance()
+                if (peekPunctuator("|")) advance()
+                expectName()
+                while (peekPunctuator("|")) {
+                    advance()
+                    expectName()
+                }
+            }
+        }
+
+        private fun skipExtension() {
+            advance() // extend
+            advance() // the definition keyword
+            expectName()
+            if (peekName() == "implements") parseImplements()
+            parseDirectives()
+            if (peekPunctuator("=")) {
+                advance()
+                expectName()
+                while (peekPunctuator("|")) {
+                    advance()
+                    expectName()
+                }
+                return
+            }
+            if (peekPunctuator("{")) {
+                var depth = 0
+                do {
+                    when {
+                        peekPunctuator("{") -> depth++
+                        peekPunctuator("}") -> depth--
+                    }
+                    advance()
+                } while (depth > 0 && pos < tokens.size)
+            }
+        }
+
+        private fun consumeDescription(): String? = (peekToken() as? GraphQLToken.StringValue)
+            ?.also { advance() }
+            ?.value
+
+        private fun peekToken(): GraphQLToken? = tokens.getOrNull(pos)
+
+        private fun peekName(): String? = (peekToken() as? GraphQLToken.Name)?.value
+
+        private fun peekPunctuator(value: String): Boolean = (peekToken() as? GraphQLToken.Punctuator)?.value == value
+
+        private fun advance() {
+            pos++
+        }
+
+        private fun expectName(): String = (peekToken() as? GraphQLToken.Name)?.value
+            ?.also { advance() }
+            ?: error("Expected a name but found ${peekToken()}")
+
+        private fun expectPunctuator(value: String) {
+            require(peekPunctuator(value)) { "Expected '$value' but found ${peekToken()}" }
+            advance()
+        }
+    }
+}

--- a/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLTokenizer.kt
+++ b/src/converter/graphql/src/commonMain/kotlin/community/flock/wirespec/converter/graphql/GraphQLTokenizer.kt
@@ -1,0 +1,146 @@
+package community.flock.wirespec.converter.graphql
+
+internal sealed interface GraphQLToken {
+    data class Name(val value: String) : GraphQLToken
+    data class StringValue(val value: String, val block: Boolean) : GraphQLToken
+    data class IntValue(val value: String) : GraphQLToken
+    data class FloatValue(val value: String) : GraphQLToken
+    data class Punctuator(val value: String) : GraphQLToken
+}
+
+internal class GraphQLTokenizer(private val source: String) {
+    private var pos = 0
+    private var line = 1
+    private var column = 1
+
+    fun tokenize(): List<GraphQLToken> {
+        val tokens = mutableListOf<GraphQLToken>()
+        while (pos < source.length) {
+            val c = source[pos]
+            when {
+                // Commas are insignificant, like whitespace, per the GraphQL spec.
+                c.isWhitespace() || c == ',' -> advance()
+                c == '#' -> skipLineComment()
+                c == '"' && peek(1) == '"' && peek(2) == '"' -> tokens.add(readBlockString())
+                c == '"' -> tokens.add(readString())
+                c.isLetter() || c == '_' -> tokens.add(readName())
+                c.isDigit() || (c == '-' && peek(1)?.isDigit() == true) -> tokens.add(readNumber())
+                c == '.' && peek(1) == '.' && peek(2) == '.' -> {
+                    tokens.add(GraphQLToken.Punctuator("..."))
+                    repeat(3) { advance() }
+                }
+
+                c in PUNCTUATOR_CHARS -> {
+                    tokens.add(GraphQLToken.Punctuator("$c"))
+                    advance()
+                }
+
+                else -> error("Unexpected character '$c' at line $line column $column")
+            }
+        }
+        return tokens
+    }
+
+    private fun peek(offset: Int): Char? = source.getOrNull(pos + offset)
+
+    private fun advance() {
+        if (source[pos] == '\n') {
+            line++
+            column = 1
+        } else {
+            column++
+        }
+        pos++
+    }
+
+    private fun skipLineComment() {
+        while (pos < source.length && source[pos] != '\n') advance()
+    }
+
+    private fun readName(): GraphQLToken.Name {
+        val start = pos
+        while (pos < source.length && (source[pos].isLetterOrDigit() || source[pos] == '_')) advance()
+        return GraphQLToken.Name(source.substring(start, pos))
+    }
+
+    private fun readNumber(): GraphQLToken {
+        val start = pos
+        if (source[pos] == '-') advance()
+        while (pos < source.length && source[pos].isDigit()) advance()
+        var isFloat = false
+        if (pos < source.length && source[pos] == '.') {
+            isFloat = true
+            advance()
+            while (pos < source.length && source[pos].isDigit()) advance()
+        }
+        if (pos < source.length && (source[pos] == 'e' || source[pos] == 'E')) {
+            isFloat = true
+            advance()
+            if (pos < source.length && (source[pos] == '+' || source[pos] == '-')) advance()
+            while (pos < source.length && source[pos].isDigit()) advance()
+        }
+        val text = source.substring(start, pos)
+        return if (isFloat) GraphQLToken.FloatValue(text) else GraphQLToken.IntValue(text)
+    }
+
+    private fun readString(): GraphQLToken.StringValue {
+        advance()
+        val builder = StringBuilder()
+        while (pos < source.length && source[pos] != '"') {
+            if (source[pos] == '\\' && pos + 1 < source.length) {
+                advance()
+                builder.append(
+                    when (val esc = source[pos]) {
+                        'n' -> '\n'
+                        't' -> '\t'
+                        'r' -> '\r'
+                        'b' -> '\b'
+                        '"' -> '"'
+                        '\\' -> '\\'
+                        '/' -> '/'
+                        else -> esc
+                    },
+                )
+                advance()
+            } else {
+                builder.append(source[pos])
+                advance()
+            }
+        }
+        if (pos < source.length) advance()
+        return GraphQLToken.StringValue(builder.toString(), block = false)
+    }
+
+    private fun readBlockString(): GraphQLToken.StringValue {
+        repeat(3) { advance() }
+        val start = pos
+        var end = pos
+        while (pos < source.length) {
+            if (source[pos] == '"' && peek(1) == '"' && peek(2) == '"') {
+                end = pos
+                repeat(3) { advance() }
+                break
+            }
+            end = pos + 1
+            advance()
+        }
+        val raw = source.substring(start, end)
+        return GraphQLToken.StringValue(raw.trimBlockString(), block = true)
+    }
+
+    // Common-indent stripping per the GraphQL spec's block string semantics.
+    private fun String.trimBlockString(): String {
+        val lines = lines()
+        val commonIndent = lines.drop(1)
+            .filter { it.isNotBlank() }
+            .minOfOrNull { it.takeWhile(Char::isWhitespace).length }
+            ?: 0
+        return (listOf(lines.first()) + lines.drop(1).map { it.drop(commonIndent) })
+            .joinToString("\n")
+            .trim('\n', ' ')
+    }
+
+    companion object {
+        private val PUNCTUATOR_CHARS = setOf('!', '$', '&', '(', ')', ':', '=', '@', '[', ']', '{', '}', '|')
+    }
+}

--- a/src/converter/graphql/src/commonTest/kotlin/community/flock/wirespec/converter/graphql/GraphQLEmitterTest.kt
+++ b/src/converter/graphql/src/commonTest/kotlin/community/flock/wirespec/converter/graphql/GraphQLEmitterTest.kt
@@ -1,0 +1,85 @@
+package community.flock.wirespec.converter.graphql
+
+import community.flock.wirespec.compiler.core.FileUri
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.utils.NoLogger
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class GraphQLEmitterTest : NoLogger {
+
+    private fun roundTrip(sdl: String): String = GraphQLParser
+        .parse(ModuleContent(FileUri("schema.graphqls"), sdl), strict = false)
+        .let { GraphQLEmitter.emit(it, logger) }
+        .head.result
+
+    @Test
+    fun emitCanonicalSchema() {
+        val sdl =
+            // language=graphql
+            """
+            |scalar DateTime
+            |
+            |"A pet in the store"
+            |type Pet implements Node {
+            |  id: ID!
+            |  name: String
+            |  status: Status
+            |  createdAt: DateTime
+            |  tags: [String!]!
+            |  posts(first: Int, offset: Int): [Post]
+            |}
+            |
+            |interface Node {
+            |  id: ID!
+            |}
+            |
+            |type Post {
+            |  id: ID!
+            |  body: String @deprecated(reason: "use content")
+            |}
+            |
+            |enum Status {
+            |  AVAILABLE
+            |  SOLD
+            |}
+            |
+            |union SearchResult = Pet | Post
+            |
+            |input PetInput {
+            |  name: String!
+            |}
+            |
+            |type Query {
+            |  pet(id: ID!): Pet
+            |  search(text: String!): [SearchResult!]
+            |}
+            |
+            |type Mutation {
+            |  addPet(input: PetInput!): Pet!
+            |}
+            |
+            |type Subscription {
+            |  petAdded: Pet!
+            |}
+            """.trimMargin()
+
+        roundTrip(sdl) shouldBe sdl + "\n"
+    }
+
+    @Test
+    fun emittedSchemaIsStableUnderReparse() {
+        val sdl =
+            // language=graphql
+            """
+            type Query { pet(id: ID!): Pet }
+            type Pet { id: ID!, name: String, friend: Pet }
+            input PetInput { name: String! }
+            enum Status { A B }
+            """.trimIndent()
+
+        val once = roundTrip(sdl)
+        val twice = roundTrip(once)
+        twice shouldBe once
+    }
+}

--- a/src/converter/graphql/src/commonTest/kotlin/community/flock/wirespec/converter/graphql/GraphQLParserTest.kt
+++ b/src/converter/graphql/src/commonTest/kotlin/community/flock/wirespec/converter/graphql/GraphQLParserTest.kt
@@ -1,0 +1,231 @@
+package community.flock.wirespec.converter.graphql
+
+import community.flock.wirespec.compiler.core.FileUri
+import community.flock.wirespec.compiler.core.ModuleContent
+import community.flock.wirespec.compiler.core.parse.ast.Enum
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
+import community.flock.wirespec.compiler.core.parse.ast.Reference
+import community.flock.wirespec.compiler.core.parse.ast.Refined
+import community.flock.wirespec.compiler.core.parse.ast.Type
+import community.flock.wirespec.compiler.core.parse.ast.Union
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+
+class GraphQLParserTest {
+
+    private fun parse(sdl: String) = GraphQLParser
+        .parse(ModuleContent(FileUri("schema.graphqls"), sdl), strict = false)
+        .modules.head.statements.toList()
+
+    @Test
+    fun parseObjectType() {
+        val statements = parse(
+            // language=graphql
+            """
+            "A pet in the store"
+            type Pet @deprecated(reason: "old") {
+              id: ID!
+              name: String
+              tags: [String!]!
+              friends: [Pet]
+            }
+            """.trimIndent(),
+        )
+
+        statements.shouldHaveSize(1).first().shouldBeInstanceOf<Type>().run {
+            comment?.value shouldBe "A pet in the store"
+            identifier.value shouldBe "Pet"
+            annotations.shouldHaveSize(1).first().run {
+                name shouldBe "deprecated"
+                parameters.shouldHaveSize(1).first().name shouldBe "reason"
+            }
+            shape.value.shouldHaveSize(4).run {
+                get(0).run {
+                    identifier.value shouldBe "id"
+                    annotations.map { it.name } shouldContainExactly listOf("id")
+                    reference.shouldBeInstanceOf<Reference.Primitive>().run {
+                        type.shouldBeInstanceOf<Reference.Primitive.Type.String>()
+                        isNullable shouldBe false
+                    }
+                }
+                get(1).reference.isNullable shouldBe true
+                get(2).reference.shouldBeInstanceOf<Reference.Iterable>().run {
+                    isNullable shouldBe false
+                    reference.shouldBeInstanceOf<Reference.Primitive>().isNullable shouldBe false
+                }
+                get(3).reference.shouldBeInstanceOf<Reference.Iterable>().run {
+                    isNullable shouldBe true
+                    reference.shouldBeInstanceOf<Reference.Custom>().run {
+                        value shouldBe "Pet"
+                        isNullable shouldBe true
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun parseInputInterfaceEnumUnionScalar() {
+        val statements = parse(
+            // language=graphql
+            """
+            scalar DateTime
+
+            enum Status { AVAILABLE SOLD }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Pet implements Node {
+              id: ID!
+              status: Status
+              createdAt: DateTime
+            }
+
+            union SearchResult = Pet | Owner
+
+            type Owner {
+              name: String!
+            }
+
+            input PetInput {
+              name: String!
+            }
+            """.trimIndent(),
+        )
+
+        statements.shouldHaveSize(7)
+        statements[0].shouldBeInstanceOf<Refined>().identifier.value shouldBe "DateTime"
+        statements[1].shouldBeInstanceOf<Enum>().entries shouldBe setOf("AVAILABLE", "SOLD")
+        statements[2].shouldBeInstanceOf<Type>().run {
+            annotations.map { it.name } shouldContainExactly listOf(GraphQLConverter.INTERFACE_MARKER)
+        }
+        statements[3].shouldBeInstanceOf<Type>().run {
+            extends.map { it.value } shouldContainExactly listOf("Node")
+            shape.value[2].reference.shouldBeInstanceOf<Reference.Custom>().value shouldBe "DateTime"
+        }
+        statements[4].shouldBeInstanceOf<Union>().entries.map { it.value } shouldContainExactly listOf("Pet", "Owner")
+        statements[5].shouldBeInstanceOf<Type>().identifier.value shouldBe "Owner"
+        statements[6].shouldBeInstanceOf<Type>().run {
+            annotations.map { it.name } shouldContainExactly listOf(GraphQLConverter.INPUT_MARKER)
+        }
+    }
+
+    @Test
+    fun parseOperations() {
+        val statements = parse(
+            // language=graphql
+            """
+            type Query {
+              pet(id: ID!): Pet
+              pets: [Pet!]!
+            }
+
+            type Mutation {
+              addPet(input: PetInput!): Pet!
+            }
+
+            type Subscription {
+              petAdded: Pet!
+            }
+
+            type Pet { id: ID! }
+            input PetInput { name: String! }
+            """.trimIndent(),
+        )
+
+        val graphqls = statements.filterIsInstance<Graphql>()
+        graphqls.shouldHaveSize(4)
+        graphqls[0].run {
+            identifier.value shouldBe "PetQuery"
+            kind shouldBe Graphql.Kind.Query
+            operation.value shouldBe "pet"
+            inputs.shouldHaveSize(1).first().run {
+                identifier.value shouldBe "id"
+                reference.isNullable shouldBe false
+            }
+            output.shouldBeInstanceOf<Reference.Custom>().run {
+                value shouldBe "Pet"
+                isNullable shouldBe true
+            }
+        }
+        graphqls[1].identifier.value shouldBe "PetsQuery"
+        graphqls[2].run {
+            identifier.value shouldBe "AddPetMutation"
+            kind shouldBe Graphql.Kind.Mutation
+        }
+        graphqls[3].run {
+            identifier.value shouldBe "PetAddedSubscription"
+            kind shouldBe Graphql.Kind.Subscription
+        }
+        statements.filterIsInstance<Type>().shouldHaveSize(2)
+    }
+
+    @Test
+    fun parseSchemaBlockWithCustomRootNames() {
+        val statements = parse(
+            // language=graphql
+            """
+            schema {
+              query: MyQuery
+            }
+
+            type MyQuery {
+              pet: Pet
+            }
+
+            type Pet { id: ID! }
+            """.trimIndent(),
+        )
+
+        statements.filterIsInstance<Graphql>().shouldHaveSize(1).first().kind shouldBe Graphql.Kind.Query
+        statements.filterIsInstance<Type>().shouldHaveSize(1)
+    }
+
+    @Test
+    fun parseNestedFieldArguments() {
+        val statements = parse(
+            // language=graphql
+            """
+            type User {
+              posts(first: Int, after: String): [Post!]!
+            }
+
+            type Post { id: ID! }
+            """.trimIndent(),
+        )
+
+        statements.first().shouldBeInstanceOf<Type>().shape.value.first().run {
+            identifier.value shouldBe "posts"
+            parameters.shouldHaveSize(2)
+            parameters[0].identifier.value shouldBe "first"
+            parameters[0].reference.shouldBeInstanceOf<Reference.Primitive>().run {
+                type.shouldBeInstanceOf<Reference.Primitive.Type.Integer>().precision shouldBe Reference.Primitive.Type.Precision.P32
+                isNullable shouldBe true
+            }
+        }
+    }
+
+    @Test
+    fun parseDescriptionsAndComments() {
+        val statements = parse(
+            // language=graphql
+            """
+            # a line comment
+            \"\"\"
+            Block description
+            over two lines
+            \"\"\"
+            type Pet {
+              id: ID!
+            }
+            """.trimIndent().replace("\\\"", "\""),
+        )
+
+        statements.first().shouldBeInstanceOf<Type>().comment?.value shouldBe "Block description\nover two lines"
+    }
+}

--- a/src/converter/graphql/src/commonTest/kotlin/community/flock/wirespec/converter/graphql/GraphQLParserTest.kt
+++ b/src/converter/graphql/src/commonTest/kotlin/community/flock/wirespec/converter/graphql/GraphQLParserTest.kt
@@ -143,7 +143,7 @@ class GraphQLParserTest {
         graphqls[0].run {
             identifier.value shouldBe "PetQuery"
             kind shouldBe Graphql.Kind.Query
-            operation.value shouldBe "pet"
+            operation shouldBe "pet"
             inputs.shouldHaveSize(1).first().run {
                 identifier.value shouldBe "id"
                 reference.isNullable shouldBe false

--- a/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3Emitter.kt
+++ b/src/converter/openapi/src/commonMain/kotlin/community/flock/wirespec/openapi/v3/OpenAPIV3Emitter.kt
@@ -37,6 +37,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Channel
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
 import community.flock.wirespec.compiler.core.parse.ast.Statements
@@ -86,7 +87,7 @@ object OpenAPIV3Emitter : Emitter {
     )
 
     private fun Statements.emitComponents(logger: Logger) = this
-        .filter { it !is Endpoint && it !is Channel }
+        .filter { it !is Endpoint && it !is Channel && it !is Graphql }
         .associate { definition ->
             definition.identifier.value to when (definition) {
                 is Enum -> definition.emit()
@@ -95,6 +96,7 @@ object OpenAPIV3Emitter : Emitter {
                 is Union -> definition.emit()
                 is Endpoint -> error("Cannot emit endpoint")
                 is Channel -> error("Cannot emit channel")
+                is Graphql -> error("Cannot emit graphql")
             }
                 .also { logger.info("Emitting ${definition::class.simpleName} ${definition.identifier.value}") }
         }

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
@@ -6,7 +6,6 @@ import community.flock.wirespec.compiler.core.tokenize.Annotation
 import community.flock.wirespec.compiler.core.tokenize.Arrow
 import community.flock.wirespec.compiler.core.tokenize.Brackets
 import community.flock.wirespec.compiler.core.tokenize.ChannelDefinition
-import community.flock.wirespec.compiler.core.tokenize.GraphqlDefinition
 import community.flock.wirespec.compiler.core.tokenize.Character
 import community.flock.wirespec.compiler.core.tokenize.Colon
 import community.flock.wirespec.compiler.core.tokenize.Comma
@@ -16,6 +15,7 @@ import community.flock.wirespec.compiler.core.tokenize.EndpointDefinition
 import community.flock.wirespec.compiler.core.tokenize.EnumTypeDefinition
 import community.flock.wirespec.compiler.core.tokenize.Equals
 import community.flock.wirespec.compiler.core.tokenize.ForwardSlash
+import community.flock.wirespec.compiler.core.tokenize.GraphqlDefinition
 import community.flock.wirespec.compiler.core.tokenize.Hash
 import community.flock.wirespec.compiler.core.tokenize.Integer
 import community.flock.wirespec.compiler.core.tokenize.LeftBracket

--- a/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
+++ b/src/ide/intellij-plugin/src/main/kotlin/community/flock/wirespec/ide/intellij/Lexer.kt
@@ -6,6 +6,7 @@ import community.flock.wirespec.compiler.core.tokenize.Annotation
 import community.flock.wirespec.compiler.core.tokenize.Arrow
 import community.flock.wirespec.compiler.core.tokenize.Brackets
 import community.flock.wirespec.compiler.core.tokenize.ChannelDefinition
+import community.flock.wirespec.compiler.core.tokenize.GraphqlDefinition
 import community.flock.wirespec.compiler.core.tokenize.Character
 import community.flock.wirespec.compiler.core.tokenize.Colon
 import community.flock.wirespec.compiler.core.tokenize.Comma
@@ -113,6 +114,7 @@ class Lexer : IntellijLexer() {
             EnumTypeDefinition::class to Types.ENUM_DEF,
             EndpointDefinition::class to Types.ENDPOINT_DEF,
             ChannelDefinition::class to Types.CHANNEL_DEF,
+            GraphqlDefinition::class to Types.CHANNEL_DEF,
             WsString::class to Types.WS_STRING,
             WsInteger::class to Types.WS_INTEGER,
             WsNumber::class to Types.WS_NUMBER,

--- a/src/integration/jackson/src/jvmCodegen/resources/wirespec/todos.ws
+++ b/src/integration/jackson/src/jvmCodegen/resources/wirespec/todos.ws
@@ -22,3 +22,9 @@ enum TodoCategory {
     WORK,
     LIFE
 }
+
+graphql GetTodo Query todo(id: String) -> Todo?
+
+graphql AddTodo Mutation addTodo(input: TodoInput) -> Todo
+
+graphql OnTodoAdded Subscription todoAdded -> Todo

--- a/src/integration/jackson/src/jvmCodegen/resources/wirespec/todos.ws
+++ b/src/integration/jackson/src/jvmCodegen/resources/wirespec/todos.ws
@@ -23,8 +23,8 @@ enum TodoCategory {
     LIFE
 }
 
-graphql GetTodo Query todo(id: String) -> Todo?
+graphql GetTodo Query {id: String} -> Todo?
 
-graphql AddTodo Mutation addTodo(input: TodoInput) -> Todo
+graphql AddTodo Mutation {input: TodoInput} -> Todo
 
-graphql OnTodoAdded Subscription todoAdded -> Todo
+graphql OnTodoAdded Subscription {} -> Todo

--- a/src/plugin/arguments/build.gradle.kts
+++ b/src/plugin/arguments/build.gradle.kts
@@ -47,6 +47,7 @@ kotlin {
                 api(project(":src:compiler:emitters:scala"))
                 api(project(":src:compiler:emitters:wirespec"))
                 implementation(project(":src:converter:avro"))
+                implementation(project(":src:converter:graphql"))
                 implementation(project(":src:converter:openapi"))
                 implementation(libs.kotlinx.io.core)
             }

--- a/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Format.kt
+++ b/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Format.kt
@@ -4,6 +4,7 @@ enum class Format {
     OpenAPIV2,
     OpenAPIV3,
     Avro,
+    GraphQL,
     ;
 
     companion object {

--- a/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Language.kt
+++ b/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Language.kt
@@ -3,6 +3,7 @@ package community.flock.wirespec.plugin
 import community.flock.wirespec.compiler.core.emit.EmitShared
 import community.flock.wirespec.compiler.core.emit.PackageName
 import community.flock.wirespec.converter.avro.AvroJsonEmitter
+import community.flock.wirespec.converter.graphql.GraphQLEmitter
 import community.flock.wirespec.emitters.java.JavaIrEmitter
 import community.flock.wirespec.emitters.kotlin.KotlinIrEmitter
 import community.flock.wirespec.emitters.python.PythonIrEmitter
@@ -24,6 +25,7 @@ enum class Language {
     OpenAPIV2,
     OpenAPIV3,
     Avro,
+    GraphQL,
     ;
 
     companion object {
@@ -43,4 +45,5 @@ fun Language.toEmitter(packageName: PackageName, emitShared: EmitShared) = when 
     Language.OpenAPIV2 -> OpenAPIV2Emitter
     Language.OpenAPIV3 -> OpenAPIV3Emitter
     Language.Avro -> AvroJsonEmitter
+    Language.GraphQL -> GraphQLEmitter
 }

--- a/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Wirespec.kt
+++ b/src/plugin/arguments/src/commonMain/kotlin/community/flock/wirespec/plugin/Wirespec.kt
@@ -13,6 +13,7 @@ import community.flock.wirespec.compiler.core.parse.ParseOptions
 import community.flock.wirespec.compiler.core.validate.Validator
 import community.flock.wirespec.converter.avro.AvroJsonParser
 import community.flock.wirespec.converter.common.Parser
+import community.flock.wirespec.converter.graphql.GraphQLParser
 import community.flock.wirespec.openapi.v2.OpenAPIV2Parser
 import community.flock.wirespec.openapi.v3.OpenAPIV3Parser
 
@@ -36,6 +37,7 @@ fun convert(arguments: ConverterArguments) {
         Format.OpenAPIV2 -> OpenAPIV2Parser
         Format.OpenAPIV3 -> OpenAPIV3Parser
         Format.Avro -> AvroJsonParser
+        Format.GraphQL -> GraphQLParser
     }
     val options = ParseOptions(
         strict = arguments.strict,

--- a/src/plugin/arguments/src/commonTest/kotlin/community/flock/wirespec/plugin/FormatTest.kt
+++ b/src/plugin/arguments/src/commonTest/kotlin/community/flock/wirespec/plugin/FormatTest.kt
@@ -6,6 +6,6 @@ import kotlin.test.Test
 class FormatTest {
     @Test
     fun testFormat() {
-        Format.toString() shouldBe "OpenAPIV2, OpenAPIV3, Avro"
+        Format.toString() shouldBe "OpenAPIV2, OpenAPIV3, Avro, GraphQL"
     }
 }

--- a/src/plugin/arguments/src/commonTest/kotlin/community/flock/wirespec/plugin/LanguageTest.kt
+++ b/src/plugin/arguments/src/commonTest/kotlin/community/flock/wirespec/plugin/LanguageTest.kt
@@ -6,6 +6,6 @@ import kotlin.test.Test
 class LanguageTest {
     @Test
     fun testLanguages() {
-        Language.toString() shouldBe "Java, Kotlin, TypeScript, Python, Rust, Scala, Wirespec, OpenAPIV2, OpenAPIV3, Avro"
+        Language.toString() shouldBe "Java, Kotlin, TypeScript, Python, Rust, Scala, Wirespec, OpenAPIV2, OpenAPIV3, Avro, GraphQL"
     }
 }

--- a/src/plugin/cli/src/commonMain/kotlin/community/flock/wirespec/plugin/cli/CommandLineArgumentsParser.kt
+++ b/src/plugin/cli/src/commonMain/kotlin/community/flock/wirespec/plugin/cli/CommandLineArgumentsParser.kt
@@ -154,6 +154,7 @@ private class Convert(
             is DirectoryPath -> throw ConvertNeedsAFile()
             is FilePath -> when (inputPath.extension) {
                 FileExtension.JSON -> Source<JSON>(inputPath.name, inputPath.read())
+                FileExtension.GraphQL -> Source<JSON>(inputPath.name, inputPath.read())
                 else -> throw JSONFileError()
             }
                 .also { logger.info("Found 1 file to process: $inputPath") }

--- a/src/plugin/gradle/build.gradle.kts
+++ b/src/plugin/gradle/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     implementation(project(":src:compiler:core"))
     implementation(project(":src:converter:avro"))
+    implementation(project(":src:converter:graphql"))
     implementation(project(":src:converter:openapi"))
     implementation(project(":src:plugin:arguments"))
 }

--- a/src/plugin/gradle/src/main/kotlin/ConvertWirespecTask.kt
+++ b/src/plugin/gradle/src/main/kotlin/ConvertWirespecTask.kt
@@ -49,6 +49,7 @@ abstract class ConvertWirespecTask : BaseWirespecTask() {
             is FilePath -> when (inputPath.extension) {
                 FileExtension.JSON -> Source<JSON>(inputPath.name, preProcessorFunction(inputPath.read()))
                 FileExtension.AvroJson -> Source<JSON>(inputPath.name, preProcessorFunction(inputPath.read()))
+                FileExtension.GraphQL -> Source<JSON>(inputPath.name, preProcessorFunction(inputPath.read()))
                 else -> throw JSONFileError()
             }
                 .also { logger.info("Found 1 file to process: $inputPath") }

--- a/src/plugin/maven/build.gradle.kts
+++ b/src/plugin/maven/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     implementation(project(":src:compiler:core"))
     implementation(project(":src:converter:avro"))
+    implementation(project(":src:converter:graphql"))
     implementation(project(":src:converter:openapi"))
     implementation(project(":src:plugin:arguments"))
     implementation(libs.kotlin.reflect)

--- a/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/ConvertMojo.kt
+++ b/src/plugin/maven/src/main/kotlin/community/flock/wirespec/plugin/maven/mojo/ConvertMojo.kt
@@ -92,6 +92,7 @@ class ConvertMojo : BaseMojo() {
             is FilePath -> when (inputPath.extension) {
                 FileExtension.JSON -> Source<JSON>(inputPath.name, inputPath.read())
                 FileExtension.AvroJson -> Source<JSON>(inputPath.name, inputPath.read())
+                FileExtension.GraphQL -> Source<JSON>(inputPath.name, inputPath.read())
                 else -> throw JSONFileError()
             }
                 .also { logger.info("Found 1 file to process: $inputPath") }

--- a/src/plugin/npm/build.gradle.kts
+++ b/src/plugin/npm/build.gradle.kts
@@ -75,6 +75,7 @@ kotlin {
                 implementation(project(":src:plugin:cli"))
                 implementation(project(":src:converter:openapi"))
                 implementation(project(":src:converter:avro"))
+                implementation(project(":src:converter:graphql"))
                 implementation(project(":src:tools:generator"))
                 implementation(libs.kotlinx.openapi.bindings)
                 implementation(libs.kotlinx.serialization)

--- a/src/plugin/npm/src/jsMain/kotlin/community/flock/wirespec/plugin/npm/Main.kt
+++ b/src/plugin/npm/src/jsMain/kotlin/community/flock/wirespec/plugin/npm/Main.kt
@@ -23,6 +23,8 @@ import community.flock.wirespec.compiler.utils.NoLogger
 import community.flock.wirespec.compiler.utils.noLogger
 import community.flock.wirespec.converter.avro.AvroJsonEmitter
 import community.flock.wirespec.converter.avro.AvroJsonParser
+import community.flock.wirespec.converter.graphql.GraphQLEmitter
+import community.flock.wirespec.converter.graphql.GraphQLParser
 import community.flock.wirespec.emitters.java.JavaIrEmitter
 import community.flock.wirespec.emitters.kotlin.KotlinIrEmitter
 import community.flock.wirespec.emitters.python.PythonIrEmitter
@@ -60,6 +62,7 @@ enum class Emitters {
     OPENAPI_V2,
     OPENAPI_V3,
     AVRO,
+    GRAPHQL,
 }
 
 @JsExport
@@ -67,6 +70,7 @@ enum class Converters {
     OPENAPI_V2,
     OPENAPI_V3,
     AVRO,
+    GRAPHQL,
 }
 
 @JsExport
@@ -89,6 +93,7 @@ fun convert(source: String, converters: Converters, strict: Boolean = false) = w
     Converters.OPENAPI_V2 -> OpenAPIV2Parser.parse(ModuleContent(FileUri(""), source), strict).produce()
     Converters.OPENAPI_V3 -> OpenAPIV3Parser.parse(ModuleContent(FileUri(""), source), strict).produce()
     Converters.AVRO -> AvroJsonParser.parse(ModuleContent(FileUri(""), source), strict).produce()
+    Converters.GRAPHQL -> GraphQLParser.parse(ModuleContent(FileUri(""), source), strict).produce()
 }
 
 @JsExport
@@ -123,6 +128,7 @@ fun emit(wsAst: WsAST, emitter: Emitters, packageName: String, emitShared: Boole
                 .map { ast -> AvroJsonEmitter.emit(ast) }
                 .map { Json.encodeToString(it) }
                 .map { Emitted("avro.json", it) }
+        Emitters.GRAPHQL -> GraphQLEmitter.emit(ast, noLogger)
     }
         .map { it.produce() }
         .toTypedArray()

--- a/src/site/docs/docs/language/graphql.mdx
+++ b/src/site/docs/docs/language/graphql.mdx
@@ -1,0 +1,68 @@
+---
+id: graphql
+title: GraphQL
+slug: /language/graphql
+sidebar_position: 3
+---
+
+Wirespec supports GraphQL operations as a first-class language construct. Each `graphql` definition describes exactly
+one root operation — queries and mutations are never bundled — with an identifier, an operation kind (`Query`,
+`Mutation` or `Subscription`), the root field name on the server's schema, optional arguments, and a return
+[type](types).
+
+```wirespec
+type Pet {
+  id: String,
+  name: String?
+}
+
+type PetInput {
+  name: String
+}
+
+graphql GetPet Query pet(id: String) -> Pet?
+graphql AddPet Mutation addPet(input: PetInput) -> Pet
+graphql OnPetAdded Subscription petAdded -> Pet
+```
+
+The identifier (`GetPet`) names both the generated code and the GraphQL operation; the field name (`pet`) must match
+the root field on the server's schema.
+
+## Generated code
+
+For every operation Wirespec generates a typed `Input`, the `Data`/`Result` response envelope (preserving GraphQL's
+partial-error semantics with `errors: [GraphQLError]`), the complete GraphQL document — including variable definitions
+and a selection set derived from the return type — and a client that sends `{query, variables}` over `POST /graphql`
+using the standard Wirespec transport.
+
+Subscriptions use a callback-based contract (`Wirespec.StreamTransportation`), so the wire protocol (for example
+graphql-ws over WebSocket, or SSE) is supplied by your transport implementation.
+
+## Parameterized fields
+
+Fields on ordinary types can carry GraphQL field arguments:
+
+```wirespec
+type User {
+  posts(first: Integer32?, after: String?): Post[]
+}
+```
+
+Non-nullable parameters of selected fields are lifted into the operation's `Input` as variables; nullable parameters
+are omitted from the generated document, letting the server apply its defaults.
+
+## Converting GraphQL schemas
+
+A GraphQL SDL schema (`.graphqls`) can be converted to Wirespec — `type`, `input`, `interface`, `enum`, `union` and
+`scalar` map onto Wirespec models, and every root field becomes one `graphql` definition. The reverse direction emits
+an SDL schema from Wirespec definitions:
+
+```shell
+wirespec convert -i schema.graphqls -f GraphQL -l Kotlin
+wirespec compile -i api.ws -l GraphQL
+```
+
+## Recursive types
+
+Selection sets are generated at compile time by flattening the return type. Recursive references are cut with
+`__typename`; use nullable back-references in recursive types so the cut branch can deserialize.

--- a/src/site/docs/docs/language/graphql.mdx
+++ b/src/site/docs/docs/language/graphql.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 Wirespec supports GraphQL operations as a first-class language construct. Each `graphql` definition describes exactly
 one root operation — queries and mutations are never bundled — with an identifier, an operation kind (`Query`,
-`Mutation` or `Subscription`), the root field name on the server's schema, optional arguments, and a return
+`Mutation` or `Subscription`), a brace-delimited argument shape (`{}` when there are none), and a return
 [type](types).
 
 ```wirespec
@@ -20,13 +20,14 @@ type PetInput {
   name: String
 }
 
-graphql GetPet Query pet(id: String) -> Pet?
-graphql AddPet Mutation addPet(input: PetInput) -> Pet
-graphql OnPetAdded Subscription petAdded -> Pet
+graphql GetPet Query {id: String} -> Pet?
+graphql AddPet Mutation {input: PetInput} -> Pet
+graphql OnPetAdded Subscription {} -> Pet
 ```
 
-The identifier (`GetPet`) names both the generated code and the GraphQL operation; the field name (`pet`) must match
-the root field on the server's schema.
+The identifier names the generated code and the GraphQL operation. The root field sent to the server is derived from
+the identifier — a trailing kind suffix is dropped, then the first letter is lowercased — so `GetPet` calls `getPet`,
+and a definition named `PetQuery` calls `pet`. Name your definition so the derived field matches the server's schema.
 
 ## Generated code
 

--- a/src/tools/generator/src/commonMain/kotlin/community/flock/wirespec/generator/Generator.kt
+++ b/src/tools/generator/src/commonMain/kotlin/community/flock/wirespec/generator/Generator.kt
@@ -7,6 +7,7 @@ import community.flock.wirespec.compiler.core.parse.ast.Definition
 import community.flock.wirespec.compiler.core.parse.ast.Endpoint
 import community.flock.wirespec.compiler.core.parse.ast.Enum
 import community.flock.wirespec.compiler.core.parse.ast.Field
+import community.flock.wirespec.compiler.core.parse.ast.Graphql
 import community.flock.wirespec.compiler.core.parse.ast.Reference
 import community.flock.wirespec.compiler.core.parse.ast.Refined
 import community.flock.wirespec.compiler.core.parse.ast.Type
@@ -102,4 +103,5 @@ private fun AST.generateObject(def: Definition, random: Random) = when (def) {
     is Union -> generateUnion(def, random)
     is Endpoint -> throw NotImplementedError("Endpoint cannot be generated")
     is Channel -> throw NotImplementedError("Channel cannot be generated")
+    is Graphql -> throw NotImplementedError("Graphql cannot be generated")
 }

--- a/types/wirespec/graphql.ws
+++ b/types/wirespec/graphql.ws
@@ -1,0 +1,5 @@
+graphql GetTodo Query todo(id: String) -> TodoResult?
+
+graphql AddTodo Mutation addTodo(input: TodoInput) -> TodoResult
+
+graphql OnTodoAdded Subscription todoAdded -> TodoResult

--- a/types/wirespec/graphql.ws
+++ b/types/wirespec/graphql.ws
@@ -1,5 +1,5 @@
-graphql GetTodo Query todo(id: String) -> TodoResult?
+graphql GetTodo Query {id: String} -> TodoResult?
 
-graphql AddTodo Mutation addTodo(input: TodoInput) -> TodoResult
+graphql AddTodo Mutation {input: TodoInput} -> TodoResult
 
-graphql OnTodoAdded Subscription todoAdded -> TodoResult
+graphql OnTodoAdded Subscription {} -> TodoResult


### PR DESCRIPTION
## Description

Adds GraphQL support to Wirespec in both directions, plus a first-class `graphql` keyword in the language (one definition per operation — queries and mutations are never bundled):

```wirespec
type Pet { id: String, name: String? }
type PetInput { name: String }

graphql GetPet Query {id: String} -> Pet?
graphql AddPet Mutation {input: PetInput} -> Pet
graphql OnPetAdded Subscription {} -> Pet
```

Inputs are a brace-delimited shape (`{}` when there are none). The GraphQL root field sent to the server is derived from the identifier — a trailing kind suffix is dropped, then the first letter is lowercased — so `GetPet` calls `getPet`, and a converter-synthesized `PetQuery` calls `pet`.

**Language (`src/compiler/core`)**
- New `Graphql` definition (identifier, kind `Query|Mutation|Subscription`, brace-shape arguments, output reference), tokenizer/parser/validator support, and `.ws` emitter round trip.
- `Field` gains `parameters` so ordinary types can carry GraphQL field arguments: `type User { posts(first: Integer32?): Post[] }`.

**Codegen (`src/compiler/ir`, all six languages)**
- Per operation: typed `Input`, `Data`/`Result` envelope (preserving partial-error semantics with a spec-complete `GraphQLError` incl. `locations`/`path`/`extensions`), `RequestBody`, and a compile-time synthesized GraphQL document — variable definitions from the typed arguments and a transitively flattened selection set (recursive references cut with `__typename`; non-nullable nested field parameters lifted into `Input` as path-named variables).
- `toRawRequest`/`fromRawResponse` over `POST /graphql` reusing the existing `BodySerializer`/`BodyDeserializer` contract; per-operation clients plus main `Client` delegation, exactly like endpoints.
- Subscriptions use a new callback-based `Wirespec.StreamTransportation`/`Cancellable` runtime contract (dependency-free in all six languages); the wire protocol (graphql-ws, SSE) is supplied by the transport implementation.
- Generated Kotlin and Java are compile-verified via the jackson integration test sources (`todos.ws` now includes graphql operations).

**Converter (`src/converter/graphql`)**
- Hand-rolled, dependency-free SDL tokenizer/parser (modeled on the Avro IDL converter): full type-system SDL — `type`, `input`, `interface`/`implements`, `enum`, `union`, `scalar`, descriptions, directives (mapped to annotations, `@deprecated` round-trips), `schema` block, block strings.
- Nullability is a pure recursive inversion (`[Pet!]!` ⇄ `Pet[]`); `Int`⇄`Integer32`, `Float`⇄`Number`, `ID`→`String` + `@id` marker; each root field becomes one `graphql` definition (`pet` → `PetQuery`, which derives back to field `pet`).
- SDL emitter for the reverse direction with a stable round trip (`parse → emit → parse` is a fixed point).
- Registered as `Format.GraphQL` (convert) and `Language.GraphQL` (emit) across the CLI, Maven, Gradle and npm plugins; new `FileExtension.GraphQL("graphqls")`.

Deferred (documented): the client-side query language (fragments, aliases, caller-chosen selection sets), `extend`, `directive` definitions, argument default values, introspection.

Note: `graphql` becomes a reserved word; a field literally named `graphql` needs backticks. IntelliJ/VSCode get keyword highlighting only (full PSI support deferred).

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist
- [x] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [x] I have written tests for my changes
- [x] I have updated the documentation if necessary
- [x] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes
- `IrEmitter.emitClient` gained a `graphqls: List<Graphql>` parameter (compiler API, not generated code).
- Python generated code now calls receiverless static functions positionally instead of with keyword arguments (equivalent semantics; required so user-supplied subscription callbacks can be invoked).
- `graphql` is now a reserved keyword in `.ws` files; escape with backticks if used as a field name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AV5q4Vja5Z8GEDis8qpzSd