### PR TITLE
ci(npm): publish @flock/wirespec via npm trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -534,9 +534,16 @@ jobs:
     needs:
       - version
 
+    # Publishes via npm trusted publishing (OIDC): the job exchanges a GitHub
+    # id-token for a short-lived registry token, so no long-lived NPM_TOKEN
+    # secret is needed. The trusted publisher for @flock/wirespec on npmjs.com
+    # must point at this repository and workflow file (build.yml).
+    permissions:
+      contents: read
+      id-token: write
+
     env:
       VERSION: ${{needs.version.outputs.version}}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -549,8 +556,13 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
+      - name: Update npm
+        # Trusted publishing requires npm >= 11.5.1.
+        run: |
+          npm install -g npm@latest
+          npm --version
       - name: Build NPM distribution
         # JS-only build: only the tasks needed to produce
         # src/plugin/npm/build/dist/js/productionLibrary. Skips JVM/native

--- a/src/plugin/npm/build.gradle.kts
+++ b/src/plugin/npm/build.gradle.kts
@@ -54,7 +54,7 @@ kotlin {
             )
             customField("peerDependencies", mapOf("msw" to "^2.0.0"))
             customField("peerDependenciesMeta", mapOf("msw" to mapOf("optional" to true)))
-            customField("repository", mapOf("type" to "git", "url" to "https://github.com/flock-community/wirespec"))
+            customField("repository", mapOf("type" to "git", "url" to "git+https://github.com/flock-community/wirespec.git"))
             customField("license", "Apache-2.0")
         }
     }


### PR DESCRIPTION
## Description

The `release-lib-npm` job has failed on every stable release since v0.20.0 ([v0.20.1 run](https://github.com/flock-community/wirespec/actions/runs/33746751676/job/100625144805), [v0.20.0 run](https://github.com/flock-community/wirespec/actions/runs/33368274546)) with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@flock%2fwirespec - Not found
```

The Gradle build, the tarball and `package.json` are all fine, and the job is byte-identical to the one that published `0.19.7` in July and `0.20.0-RC.16` on Aug 12. npm answers a `PUT` with 404 when the auth token is no longer valid, and the `NPM_TOKEN` secret has expired under npm's current token lifetime limits (granular tokens are capped at 90 days, classic tokens were revoked). Every other release job (Maven Central, VS Code, IntelliJ, CLI assets, docs, playground) succeeded.

This PR switches the job to [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC), so no long-lived secret is needed anymore:

- grant the job `id-token: write` (and `contents: read` for checkout)
- drop `NODE_AUTH_TOKEN`
- use Node 24 and upgrade npm on the runner, since trusted publishing needs npm >= 11.5.1
- set `repository.url` in the generated `package.json` to the `git+https://...git` form, so npm no longer auto-corrects it at publish time (provenance, which trusted publishing enables, checks it against the source repository)

### One-time setup required on npmjs.com

Trusted publishing must be configured for the package before this works. A maintainer of `@flock/wirespec` needs to:

1. Open https://www.npmjs.com/package/@flock/wirespec/access
2. Under **Trusted Publisher**, add a GitHub Actions publisher with:
   - Organization or user: `flock-community`
   - Repository: `wirespec`
   - Workflow filename: `build.yml`
   - Environment name: leave empty

After that, the next release (or a `workflow_dispatch` RC publish) will authenticate via OIDC. The `NPM_TOKEN` secret can then be deleted.

### Getting 0.20.1 out

Re-running the failed job on the existing tag would use the old workflow file, so to publish `0.20.1` to npm either cut a new release from master once this is merged, or rotate `NPM_TOKEN` on npmjs.com and re-run the failed job from the [v0.20.1 run](https://github.com/flock-community/wirespec/actions/runs/33746751676) as a stopgap.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Build/CI pipeline changes
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guidelines](https://github.com/flock-community/wirespec/blob/master/CONTRIBUTING.md)
- [ ] I have written tests for my changes
- [ ] I have updated the documentation if necessary
- [ ] I have written code in a functional style (using [Arrow](https://arrow-kt.io/) where appropriate)

## Breaking Changes

None for consumers. The release pipeline now requires the trusted publisher to be configured on npmjs.com (see above) instead of an `NPM_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNQAMXiV9N5VtURa8SDNwF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNQAMXiV9N5VtURa8SDNwF)_